### PR TITLE
Datasource mutation observer: terminal NOT_EXECUTED outcome, deterministic connection-abort injection, and driver-neutral bounded streams

### DIFF
--- a/design/datasource-mutation-observer.md
+++ b/design/datasource-mutation-observer.md
@@ -197,7 +197,7 @@ the driver `commit` call.  No error text is examined.
 | rollback returned 0 | `SQL_MUTATION_OUTCOME_ROLLBACK` | `True` |
 | rollback raised | `SQL_MUTATION_OUTCOME_ROLLBACK_ERROR` | `True` |
 | connection lost or aborted with no commit in flight | `SQL_MUTATION_OUTCOME_LOST_CONNECTION` | `True` |
-| admission rejected the operation | `SQL_MUTATION_OUTCOME_NOT_EXECUTED` | `True` |
+| admission rejected the operation or the stream | `SQL_MUTATION_OUTCOME_NOT_EXECUTED` | `True` |
 
 A commit that raises is **always** ambiguous.  It is never reported as a rollback, because the core
 cannot know whether the server applied it.  This is the single most important rule in this design: a
@@ -224,10 +224,35 @@ notification.
 - Returning `NOTHING`, or a hash with `admit` `True`, admits the operation.
 - Returning `{"admit": False, "err": ..., "desc": ...}` rejects it.  The core raises the given
   exception — defaulting to `SQL-MUTATION-REJECTED` — does not execute the operation, and does not
-  change transaction state.  An `OUTCOME_NOT_EXECUTED` event is not emitted, because the consumer
-  itself produced the rejection.
+  change transaction state.
 - An exception thrown by the observer propagates and the operation is not executed.  Admission is
   fail-closed by design: a consumer that cannot decide must not have its silence read as consent.
+
+### Terminal events for a rejected operation
+
+Every rejected admission point is followed by exactly one terminal event carrying
+`OUTCOME_NOT_EXECUTED` and `replay_safe` `True`.  This holds for both kinds of rejection — an
+explicit `admit` `False` decision and a fail-closed observer exception — because a consumer tracking
+reservations by `op_id` must always see the operation's lifetime close.  Without it, a rejection
+outside a transaction produces no terminal event at all: no rollback follows, so no `OUTCOME` event
+is ever emitted, and the reservation has no boundary at which to be released.
+
+| rejected at | terminal event | emitted by |
+|---|---|---|
+| `PRE_EXEC` | `POST_EXEC` with `OUTCOME_NOT_EXECUTED` | the core; pairs the admission event |
+| `STREAM_BEGIN` | `STREAM_END` with `OUTCOME_NOT_EXECUTED` | the core; the producer never started the stream, so it reports no end boundary of its own |
+| `STREAM_PROGRESS` | `STREAM_END` with `OUTCOME_NOT_EXECUTED` | the producer, which is required to report the end boundary of a stream it started |
+
+The terminal event is a notification: its return value is ignored, and it cannot re-enter the
+callback that produced the rejection, because the re-entrancy depth is released before it is
+delivered.  The rejection exception is reported on it through `ex` without being consumed.
+
+For a stream stopped at `STREAM_PROGRESS` the core records the rejection and maps the producer's
+`reportMutationStreamEnd(consumed, False)` to `OUTCOME_NOT_EXECUTED` instead of `OUTCOME_ERROR`.  The
+distinction matters to a consumer: `OUTCOME_ERROR` on a stream means the database failed while the
+payload was being sent, whereas `OUTCOME_NOT_EXECUTED` means the consumer itself stopped it.  In both
+cases the bytes already sent are discarded by the surrounding rollback; `replay_safe` `True` states
+only that no commit was attempted, not that nothing was sent.
 
 ### Notification events
 

--- a/design/datasource-mutation-observer.md
+++ b/design/datasource-mutation-observer.md
@@ -422,6 +422,38 @@ Test matrix:
 - concurrent pools and tenants, with no cross-talk between two pools in one process;
 - PostgreSQL equivalents where `QORE_DB_CONNSTR_PGSQL` is set, guarded by `%try-module pgsql`.
 
+### Deterministic faults on a real driver
+
+`dbitest` cannot cover an end-to-end test against a real database server, because it is not
+installed and is not a real driver.  For that case a debug build registers one builtin:
+
+```qore
+dbg_ds_arm_connection_abort(AbstractDatasource ds, string op_id, int when);
+```
+
+It arms a one-shot connection abort for an exact declared `op_id`, at either
+`SQL_MUTATION_FAULT_AFTER_EXEC` (after the statement has been executed and before any commit, giving
+`LOST_CONNECTION` with `replay_safe` `True`) or `SQL_MUTATION_FAULT_ON_COMMIT` (with the
+`commit_in_progress` flag set, giving `COMMIT_AMBIGUOUS`).  An arming that does not match the
+current operation's `op_id` is left untouched, and a match consumes it.
+
+Three properties make this a real outcome rather than a simulated one:
+
+- the abort runs the ordinary `Datasource::connectionAborted()` path, so the connection is really
+  closed and the server really discards the in-flight transaction;
+- the resulting outcome is produced by the existing classification code, with no special casing for
+  the fault;
+- because the abort is applied at the core boundary rather than inside a driver, it behaves
+  identically on every DBI driver.
+
+The arming lives on the `SqlMutationContext`, which a `DatasourcePool` shares with every connection
+it pools, so a test can arm the pool without knowing which connection its thread will be allocated.
+
+Everything here is compiled only when `DEBUG` is defined: a release build registers no function and
+carries no fault state, so there is no way to reach any of it in production.  Tests call the builtin
+by name through `call_function()` and skip when it is absent, so a release-build test run skips
+rather than failing to parse.
+
 ## Performance
 
 `bench/cases/bench_datasource_mutation_observer.qr` measures the monitored and unmonitored statement

--- a/examples/test/qlib/SqlUtil/BulkSqlUtilStream.qtest
+++ b/examples/test/qlib/SqlUtil/BulkSqlUtilStream.qtest
@@ -1,0 +1,334 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+
+%prepend-module-path "${SCRIPT_DIR}/../../../../qlib"
+%requires QUnit
+%requires SqlUtil
+%requires BulkSqlUtil
+
+%try-module pgsql
+%define NoPgsql
+%endtry
+
+%exec-class BulkSqlUtilStreamTest
+
+#! collects bounded stream events for assertions
+class StreamCollector {
+    public {
+        list<hash<SqlMutationEventInfo>> events();
+        #! stop the stream once this many bytes have been consumed; 0 = never
+        int abort_after = 0;
+        #! refuse the stream at its begin boundary
+        bool reject_begin = False;
+    }
+
+    *hash<SqlMutationDecisionInfo> event(hash<SqlMutationEventInfo> ev) {
+        events += ev;
+        if (reject_begin && ev.event == SQL_MUTATION_EVENT_STREAM_BEGIN) {
+            return <SqlMutationDecisionInfo>{
+                "admit": False,
+                "err": "STREAM-REFUSED",
+                "desc": "the bulk operation was refused before it started",
+            };
+        }
+        if (abort_after && ev.event == SQL_MUTATION_EVENT_STREAM_PROGRESS
+            && ev.consumed_bytes > abort_after) {
+            return <SqlMutationDecisionInfo>{
+                "admit": False,
+                "err": "STREAM-OVER-BUDGET",
+                "desc": sprintf("the bulk operation consumed %d bytes", ev.consumed_bytes),
+            };
+        }
+        return NOTHING;
+    }
+
+    reset() {
+        events = ();
+        abort_after = 0;
+        reject_begin = False;
+    }
+
+    #! returns only the bounded stream events
+    list<hash<SqlMutationEventInfo>> streamEvents() {
+        return map $1, events, $1.event >= SQL_MUTATION_EVENT_STREAM_BEGIN
+            && $1.event <= SQL_MUTATION_EVENT_STREAM_END;
+    }
+
+    list<int> streamCodes() {
+        return map $1.event, streamEvents();
+    }
+}
+
+#! verifies that a bulk operation reports itself as a bounded stream
+/** The reporting is driver-neutral: it is implemented in BulkSqlUtil over the existing block flush
+    path, so it does not depend on a native bulk-load mechanism such as PostgreSQL \c COPY, and it
+    behaves identically on drivers with and without \c DBI_CAP_HAS_ARRAY_BIND.
+*/
+public class BulkSqlUtilStreamTest inherits QUnit::Test {
+    public {
+        const MyOpts = Opts + {
+            "connstr": "c,conn=s",
+        };
+
+        const OptionColumn = 22;
+
+        const OpInfo = <SqlMutationInfo>{
+            "op_id": "bulk-op-1",
+            "path_id": "bulk_stream_test.insert",
+            "op_code": 7,
+            "effect": SQL_MUTATION_EFFECT_MAY_GROW,
+            "max_growth_bytes": 1048576,
+        };
+
+        const TableName = "qore_bulk_stream_test";
+
+        #! rows per queued batch; the block size is smaller so that several blocks are flushed
+        const RowCount = 20;
+        const BlockSize = 5;
+    }
+
+    private {
+        StreamCollector obs();
+        *string connstr;
+    }
+
+    constructor() : Test("BulkSqlUtilStreamTest", "1.0", \ARGV, MyOpts) {
+        connstr = m_options.connstr ?? ENV.QORE_DB_CONNSTR_PGSQL ?? ENV.QORE_DB_CONNSTR;
+
+        addTestCase("bounded stream reporting", \boundedStreamTest());
+        addTestCase("stream overrun stops before commit", \streamOverrunTest());
+        addTestCase("stream refused before it starts", \streamRejectedTest());
+        addTestCase("discard ends the stream", \discardTest());
+        addTestCase("no observer means no events", \noObserverTest());
+        addTestCase("stream_bounds disabled", \streamBoundsDisabledTest());
+
+        set_return_value(main());
+    }
+
+    private usageIntern() {
+        TestReporter::usageIntern(OptionColumn);
+        printOption("-c,--conn=ARG", "set the DB connection string", OptionColumn);
+    }
+
+    private Datasource getDs() {
+%ifdef NoPgsql
+        testSkip("pgsql module not available");
+%endif
+        if (!connstr.val()) {
+            testSkip("no DB connection; set QORE_DB_CONNSTR_PGSQL");
+        }
+        Datasource ds;
+        try {
+            ds = new Datasource(connstr);
+            ds.setAutoCommit(False);
+            ds.open();
+        } catch (hash<ExceptionInfo> ex) {
+            testSkip("no DB connection: " + ex.err + ": " + ex.desc);
+        }
+        return ds;
+    }
+
+    #! creates the test table with no observer attached
+    private Datasource setupTable() {
+        Datasource ds = getDs();
+        ds.execRaw(sprintf("drop table if exists %s", TableName));
+        ds.execRaw(sprintf("create table %s (id integer, val varchar(64))", TableName));
+        ds.commit();
+        obs.reset();
+        ds.setMutationObserver(\obs.event(), SQL_MUTATION_MASK_ALL);
+        return ds;
+    }
+
+    private dropTable(Datasource ds) {
+        ds.clearMutationObserver();
+        try {
+            ds.rollback();
+            ds.execRaw(sprintf("drop table if exists %s", TableName));
+            ds.commit();
+        } catch (hash<ExceptionInfo> ex) {
+            # ignore cleanup failures
+        }
+    }
+
+    #! returns a table object for the test table
+    private SqlUtil::AbstractTable getTable(Datasource ds) {
+        return (new SqlUtil::Table(ds, TableName)).getTable();
+    }
+
+    #! queues the given number of rows in the operation
+    private queueRows(BulkInsertOperation op, int count) {
+        for (int i = 0; i < count; ++i) {
+            op.queueData({"id": i, "val": sprintf("value-%d", i)});
+        }
+    }
+
+    boundedStreamTest() {
+        Datasource ds = setupTable();
+        on_exit dropTable(ds);
+
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            BulkInsertOperation op(getTable(ds), {"block_size": BlockSize});
+            on_error op.discard();
+            queueRows(op, RowCount);
+            op.flush();
+            op.endStream();
+        }
+
+        list<hash<SqlMutationEventInfo>> l = obs.streamEvents();
+        # one begin, one progress report per flushed block, and one end boundary
+        assertEq(SQL_MUTATION_EVENT_STREAM_BEGIN, l[0].event);
+        assertEq(SQL_MUTATION_EVENT_STREAM_END, l.last().event);
+        assertEq(RowCount / BlockSize, (map $1, l, $1.event == SQL_MUTATION_EVENT_STREAM_PROGRESS).size());
+
+        # progress is cumulative and strictly increasing, and the declared bound is carried through
+        list<int> consumed = map $1.consumed_bytes,
+            (map $1, l, $1.event == SQL_MUTATION_EVENT_STREAM_PROGRESS);
+        assertEq(consumed, sort(consumed));
+        assertGt(0, consumed[0]);
+        assertGt(consumed[0], consumed.last());
+        assertEq(OpInfo.max_growth_bytes, l[0].declared_bytes);
+        assertEq(SQL_STMT_CLASS_STREAM, l[0].stmt_class);
+        assertEq(OpInfo.op_id, l[0].info.op_id);
+
+        # the end boundary reports the total and the operation succeeded
+        assertEq(consumed.last(), l.last().consumed_bytes);
+        assertEq(SQL_MUTATION_OUTCOME_OK, l.last().outcome);
+
+        # the rows are really there
+        ds.commit();
+        assertEq(RowCount, ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
+    }
+
+    streamOverrunTest() {
+        Datasource ds = setupTable();
+        on_exit dropTable(ds);
+
+        # stop the operation partway through the second block
+        obs.abort_after = 20;
+        bool stopped = False;
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            BulkInsertOperation op(getTable(ds), {"block_size": BlockSize});
+            try {
+                queueRows(op, RowCount);
+                op.flush();
+                op.endStream();
+            } catch (hash<ExceptionInfo> ex) {
+                assertEq("STREAM-OVER-BUDGET", ex.err);
+                stopped = True;
+                op.discard();
+            }
+        }
+        assertTrue(stopped);
+
+        # the operation was stopped at an admission point, not by a database failure
+        list<hash<SqlMutationEventInfo>> l = obs.streamEvents();
+        assertEq(SQL_MUTATION_EVENT_STREAM_END, l.last().event);
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, l.last().outcome);
+        assertTrue(l.last().replay_safe);
+
+        # it stopped partway through: some rows were written, but not all of them.  These rows are
+        # visible only inside this uncommitted transaction
+        int written = ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c;
+        assertGt(0, written);
+        assertLt(RowCount, written);
+
+        # nothing was committed: the rows written before the stop are discarded by the rollback
+        ds.rollback();
+        assertEq(0, ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
+    }
+
+    streamRejectedTest() {
+        Datasource ds = setupTable();
+        on_exit dropTable(ds);
+
+        obs.reject_begin = True;
+        bool refused = False;
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            BulkInsertOperation op(getTable(ds), {"block_size": BlockSize});
+            try {
+                queueRows(op, RowCount);
+                op.flush();
+            } catch (hash<ExceptionInfo> ex) {
+                assertEq("STREAM-REFUSED", ex.err);
+                refused = True;
+                op.discard();
+            }
+        }
+        assertTrue(refused);
+
+        # exactly one begin and one terminal event, and no progress in between
+        assertEq((SQL_MUTATION_EVENT_STREAM_BEGIN, SQL_MUTATION_EVENT_STREAM_END), obs.streamCodes());
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, obs.streamEvents().last().outcome);
+
+        # the refusal happened before the first row reached the database
+        ds.rollback();
+        assertEq(0, ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
+    }
+
+    discardTest() {
+        Datasource ds = setupTable();
+        on_exit dropTable(ds);
+
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            BulkInsertOperation op(getTable(ds), {"block_size": BlockSize});
+            queueRows(op, RowCount);
+            op.flush();
+            # abandoning the operation ends the stream and reports that it did not complete
+            op.discard();
+        }
+
+        list<hash<SqlMutationEventInfo>> l = obs.streamEvents();
+        assertEq(SQL_MUTATION_EVENT_STREAM_END, l.last().event);
+        assertEq(SQL_MUTATION_OUTCOME_ERROR, l.last().outcome);
+        # exactly one end boundary, even though the object was destroyed after discard()
+        assertEq(1, (map $1, l, $1.event == SQL_MUTATION_EVENT_STREAM_END).size());
+
+        ds.rollback();
+        assertEq(0, ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
+    }
+
+    noObserverTest() {
+        Datasource ds = getDs();
+        on_exit dropTable(ds);
+        ds.execRaw(sprintf("drop table if exists %s", TableName));
+        ds.execRaw(sprintf("create table %s (id integer, val varchar(64))", TableName));
+        ds.commit();
+
+        # with no observer registered the operation behaves exactly as before
+        assertFalse(ds.hasMutationObserver());
+        {
+            BulkInsertOperation op(getTable(ds), {"block_size": BlockSize});
+            on_error op.discard();
+            queueRows(op, RowCount);
+            op.flush();
+        }
+        ds.commit();
+        assertEq(RowCount, ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
+    }
+
+    streamBoundsDisabledTest() {
+        Datasource ds = setupTable();
+        on_exit dropTable(ds);
+
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            BulkInsertOperation op(getTable(ds), {"block_size": BlockSize, "stream_bounds": False});
+            on_error op.discard();
+            queueRows(op, RowCount);
+            op.flush();
+        }
+
+        # the operation is still observed as ordinary statements, but reports no stream boundaries
+        assertEq((), obs.streamEvents());
+        assertGt(0, obs.events.size());
+
+        ds.commit();
+        assertEq(RowCount, ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
+    }
+}

--- a/examples/test/qore/classes/Datasource/mutation-observer-pgsql.qtest
+++ b/examples/test/qore/classes/Datasource/mutation-observer-pgsql.qtest
@@ -61,6 +61,10 @@ public class MutationObserverPgsqlTest inherits QUnit::Test {
 
         const OptionColumn = 22;
 
+        # mirrors SQL_MUTATION_FAULT_AFTER_EXEC in include/qore/intern/SqlMutationContext.h, which
+        # is compiled only in debug builds and so is not exported as a %Qore constant
+        const FaultAfterExec = 1;
+
         const OpInfo = <SqlMutationInfo>{
             "op_id": "pg-op-1",
             "path_id": "mutation_observer_test.insert",
@@ -87,6 +91,7 @@ public class MutationObserverPgsqlTest inherits QUnit::Test {
         addTestCase("pgsql admission rejection", \admissionRejectionTest());
         addTestCase("pgsql prepared statement", \preparedStatementTest());
         addTestCase("pgsql pool", \poolTest());
+        addTestCase("pgsql armed abort is replay safe", \armedAbortReplaySafeTest());
 
         set_return_value(main());
     }
@@ -289,5 +294,63 @@ public class MutationObserverPgsqlTest inherits QUnit::Test {
         assertEq("tenant-1", obs.outcome().arg);
         assertEq(1, dsp.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
         dsp.rollback();
+    }
+
+    #! a deterministic replay-safe failover against a real PostgreSQL server
+    /** This is the case the dbitest mock driver cannot cover: dbitest is not installed, so it can
+        never stand in for a real database in an end-to-end test.  The abort here runs the ordinary
+        connection-loss path, so the PostgreSQL backend really does discard the transaction, and the
+        row written before the abort must not survive.
+    */
+    armedAbortReplaySafeTest() {
+        Datasource ds = setupTable();
+        on_exit dropTable(ds);
+
+        {
+            SqlMutationDeclaration decl(ds, cast<hash<SqlMutationInfo>>(OpInfo + {"attempt": 1}));
+            ds.exec(sprintf("insert into %s values (%%v, %%v)", TableName), 1, "one");
+            try {
+                call_function("dbg_ds_arm_connection_abort", ds, OpInfo.op_id, FaultAfterExec);
+            } catch (hash<ExceptionInfo> ex) {
+                if (ex.err == "NO-FUNCTION" || ex.err == "UNDEFINED-FUNCTION-CALL") {
+                    testSkip("debug build required for dbg_ds_arm_connection_abort()");
+                }
+                rethrow;
+            }
+            assertThrows("DBI:DBG:CONNECTION-ABORTED", \ds.exec(),
+                (sprintf("insert into %s values (%%v, %%v)", TableName), 2, "two"));
+        }
+
+        # the statement was executed and no commit was attempted, so the same reservation may be
+        # reused for the replay
+        hash<SqlMutationEventInfo> post = obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC).last();
+        assertEq(SQL_MUTATION_OUTCOME_LOST_CONNECTION, post.outcome);
+        assertTrue(post.replay_safe);
+        assertEq("pg-op-1", post.info.op_id);
+        assertEq("pgsql", post.driver);
+
+        # the transaction is terminated by the connection loss and is never reported as a commit
+        hash<SqlMutationEventInfo> out = obs.outcome();
+        assertEq(SQL_MUTATION_OUTCOME_LOST_CONNECTION, out.outcome);
+        assertTrue(out.replay_safe);
+        assertFalse(ds.currentThreadInTransaction());
+
+        # the server really discarded the transaction: neither row survived
+        obs.reset();
+        ds.open();
+        assertEq(0, ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
+        ds.commit();
+
+        # the replay presents the same op_id with a higher attempt and commits for real
+        obs.reset();
+        {
+            SqlMutationDeclaration decl(ds, cast<hash<SqlMutationInfo>>(OpInfo + {"attempt": 2}));
+            ds.exec(sprintf("insert into %s values (%%v, %%v)", TableName), 1, "one");
+            ds.commit();
+        }
+        assertEq(SQL_MUTATION_OUTCOME_COMMIT, obs.outcome().outcome);
+        assertEq(2, obs.outcome().info.attempt);
+        assertEq(1, ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
+        ds.commit();
     }
 }

--- a/examples/test/qore/classes/Datasource/mutation-observer-pgsql.qtest
+++ b/examples/test/qore/classes/Datasource/mutation-observer-pgsql.qtest
@@ -224,10 +224,17 @@ public class MutationObserverPgsqlTest inherits QUnit::Test {
             (sprintf("insert into %s values (%%v, %%v)", TableName), 1, "one"));
 
         # nothing was executed and no transaction was left open
-        assertEq((SQL_MUTATION_EVENT_PRE_EXEC,), obs.codes());
         assertFalse(ds.currentThreadInTransaction());
 
+        # the rejection is closed by a terminal event against the real server as well, so that a
+        # consumer tracking reservations by "op_id" sees the operation's lifetime end
+        assertEq((SQL_MUTATION_EVENT_PRE_EXEC, SQL_MUTATION_EVENT_POST_EXEC), obs.codes());
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, obs.events[1].outcome);
+        assertTrue(obs.events[1].replay_safe);
+        assertEq("pgsql", obs.events[1].driver);
+
         obs.reset();
+        # the operation really was not executed
         assertEq(0, ds.selectRow(sprintf("select count(1) as c from %s", TableName)).c);
         ds.commit();
     }

--- a/examples/test/qore/classes/Datasource/mutation-observer.qtest
+++ b/examples/test/qore/classes/Datasource/mutation-observer.qtest
@@ -72,6 +72,39 @@ class EventCollector {
     }
 }
 
+#! a user subclass of AbstractDatasource that is neither a Datasource nor a DatasourcePool
+class StubDatasource inherits Qore::SQL::AbstractDatasource {
+    nothing commit() {}
+    nothing rollback() {}
+    auto exec(string sql, ...) {}
+    auto vexec(string sql, *softlist<auto> vargs) {}
+    auto execRaw(string sql) {}
+    auto select(string sql, ...) {}
+    auto selectTyped(string sql, ...) {}
+    auto selectRow(string sql, ...) {}
+    auto selectRows(string sql, ...) {}
+    auto selectRowsTyped(string sql, ...) {}
+    auto vselect(string sql, *softlist<auto> vargs) {}
+    auto vselectTyped(string sql, *softlist<auto> vargs) {}
+    auto vselectRow(string sql, *softlist<auto> vargs) {}
+    auto vselectRows(string sql, *softlist<auto> vargs) {}
+    auto vselectRowsTyped(string sql, *softlist<auto> vargs) {}
+    nothing beginTransaction() {}
+    *string getUserName() {}
+    *string getPassword() {}
+    *string getDBName() {}
+    *string getDBEncoding() {}
+    *string getOSEncoding() {}
+    *string getHostName() {}
+    *int getPort() {}
+    string getDriverName() { return "stub"; }
+    auto getServerVersion() { return "1.0"; }
+    auto getClientVersion() { return "1.0"; }
+    bool inTransaction() { return False; }
+    hash<auto> getConfigHash() { return {}; }
+    string getConfigString() { return "stub:@stub"; }
+}
+
 public class MutationObserverTest inherits QUnit::Test {
     public {
         const OpInfo = <SqlMutationInfo>{
@@ -108,6 +141,8 @@ public class MutationObserverTest inherits QUnit::Test {
         addTestCase("armed abort identity", \armedAbortIdentityTest());
         addTestCase("armed abort is replay safe", \armedAbortReplaySafeTest());
         addTestCase("armed abort on commit is ambiguous", \armedAbortCommitAmbiguousTest());
+        addTestCase("armed abort on a pool", \armedAbortPoolTest());
+        addTestCase("armed abort argument checking", \armedAbortArgumentTest());
         addTestCase("armed abort on a prepared statement", \armedAbortStatementTest());
         addTestCase("admission rejection", \admissionRejectionTest());
         addTestCase("admission rejection in a transaction", \admissionRejectionInTransactionTest());
@@ -468,6 +503,58 @@ public class MutationObserverTest inherits QUnit::Test {
         assertEq(SQL_MUTATION_OUTCOME_COMMIT_AMBIGUOUS, out.outcome);
         assertFalse(out.replay_safe);
         assertEq(SQL_STMT_CLASS_COMMIT, out.stmt_class);
+    }
+
+    #! a DatasourcePool can be armed, and the abort reaches its allocated connection
+    armedAbortPoolTest() {
+        DatasourcePool dsp;
+        try {
+            dsp = new DatasourcePool("dbitest:u/p@db{min=1,max=2}");
+            dsp.getServerVersion();
+        } catch (hash<ExceptionInfo> ex) {
+            testSkip("dbitest driver not available: " + ex.err + ": " + ex.desc);
+        }
+        obs.reset();
+        dsp.setMutationObserver(\obs.event(), SQL_MUTATION_MASK_ALL);
+
+        {
+            SqlMutationDeclaration decl(dsp, OpInfo);
+            # the pool shares one mutation context with every connection it pools, so arming the
+            # pool covers whichever connection this thread is allocated
+            try {
+                call_function("dbg_ds_arm_connection_abort", dsp, OpInfo.op_id, FaultAfterExec);
+            } catch (hash<ExceptionInfo> ex) {
+                if (ex.err == "NO-FUNCTION" || ex.err == "UNDEFINED-FUNCTION-CALL") {
+                    testSkip("debug build required for dbg_ds_arm_connection_abort()");
+                }
+                rethrow;
+            }
+            assertThrows("DBI:DBG:CONNECTION-ABORTED", \dsp.exec(), "insert into t values (1)");
+        }
+
+        hash<SqlMutationEventInfo> post = obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC).last();
+        assertEq(SQL_MUTATION_OUTCOME_LOST_CONNECTION, post.outcome);
+        assertTrue(post.replay_safe);
+        assertEq(OpInfo.op_id, post.info.op_id);
+    }
+
+    #! an AbstractDatasource that is neither a Datasource nor a pool is a clean argument error
+    /** this is the only way to reach the argument check: the builtin's signature already rejects
+        anything that is not an AbstractDatasource
+    */
+    armedAbortArgumentTest() {
+        try {
+            call_function("dbg_ds_arm_connection_abort", new StubDatasource(), OpInfo.op_id, FaultAfterExec);
+            fail("arming an unsupported AbstractDatasource must not succeed");
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "NO-FUNCTION" || ex.err == "UNDEFINED-FUNCTION-CALL") {
+                testSkip("debug build required for dbg_ds_arm_connection_abort()");
+            }
+            # probing for a Datasource must not raise a class-compatibility error before the
+            # DatasourcePool case has been considered; the function reports its own error instead
+            assertEq("DBG-ARGUMENT-ERROR", ex.err);
+            assertRegex("StubDatasource", ex.desc);
+        }
     }
 
     #! a prepared statement reaches the same armed boundary

--- a/examples/test/qore/classes/Datasource/mutation-observer.qtest
+++ b/examples/test/qore/classes/Datasource/mutation-observer.qtest
@@ -99,6 +99,8 @@ public class MutationObserverTest inherits QUnit::Test {
         addTestCase("restartable failover", \failoverTest());
         addTestCase("failover replay identity", \failoverReplayTest());
         addTestCase("admission rejection", \admissionRejectionTest());
+        addTestCase("admission rejection in a transaction", \admissionRejectionInTransactionTest());
+        addTestCase("admission exception is terminal", \admissionExceptionTerminalTest());
         addTestCase("observer exception on admission", \observerAdmissionExceptionTest());
         addTestCase("observer exception on outcome", \observerOutcomeExceptionTest());
         addTestCase("observer removal", \observerRemovalTest());
@@ -342,20 +344,89 @@ public class MutationObserverTest inherits QUnit::Test {
             "insert into t values (1)");
 
         # the operation was not executed and no transaction was left open
-        assertEq((SQL_MUTATION_EVENT_PRE_EXEC,), obs.codes());
         assertFalse(ds.currentThreadInTransaction());
 
-        # the default error code is used when the observer does not give one
+        # the rejected admission event is paired with a terminal event, so that a consumer tracking
+        # reservations by "op_id" always sees the operation's lifetime close; without it a rejection
+        # outside a transaction would produce no terminal event at all
+        assertEq((SQL_MUTATION_EVENT_PRE_EXEC, SQL_MUTATION_EVENT_POST_EXEC), obs.codes());
+        hash<SqlMutationEventInfo> term = obs.events[1];
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, term.outcome);
+        # nothing was executed, so no commit can have been attempted
+        assertTrue(term.replay_safe);
+        # the terminal event carries the same statement class, declaration, and transaction identity
+        assertEq(SQL_STMT_CLASS_EXEC, term.stmt_class);
+        assertEq(obs.events[0].tx_id, term.tx_id);
+        assertEq(obs.events[0].tx_seq + 1, term.tx_seq);
+        # the rejection exception is reported to the observer without being consumed
+        assertEq("QUOTA-EXCEEDED", term.ex.err);
+
+        # the terminal event is a notification: a rejection decision on it is discarded, and it
+        # cannot be produced recursively
         obs.reset();
         obs.decision = <SqlMutationDecisionInfo>{"admit": False};
         assertThrows("SQL-MUTATION-REJECTED", \ds.exec(), "insert into t values (1)");
         assertFalse(ds.currentThreadInTransaction());
+        # exactly one terminal event, even though the observer rejected it too
+        assertEq((SQL_MUTATION_EVENT_PRE_EXEC, SQL_MUTATION_EVENT_POST_EXEC), obs.codes());
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, obs.events[1].outcome);
+
+        # a declared operation reports its declaration on the terminal event as well
+        obs.reset();
+        obs.decision = <SqlMutationDecisionInfo>{"admit": False};
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            assertThrows("SQL-MUTATION-REJECTED", \ds.exec(), "insert into t values (1)");
+        }
+        assertEq(2, obs.events.size());
+        assertTrue(obs.events[1].declared);
+        assertEq(OpInfo.op_id, obs.events[1].info.op_id);
 
         # an empty decision hash admits
         obs.reset();
         obs.decision = <SqlMutationDecisionInfo>{};
         assertEq(1, ds.exec("insert into t values (1)"));
         ds.rollback();
+    }
+
+    #! a rejection raised inside an open transaction closes the operation, not the transaction
+    admissionRejectionInTransactionTest() {
+        Datasource ds = getDs();
+        assertEq(1, ds.exec("insert into t values (1)"));
+        assertTrue(ds.currentThreadInTransaction());
+        int base = obs.events.size();
+
+        obs.decision = <SqlMutationDecisionInfo>{"admit": False};
+        assertThrows("SQL-MUTATION-REJECTED", \ds.exec(), "insert into t values (2)");
+        # the transaction is untouched: the rejected operation is closed, the transaction is not
+        assertTrue(ds.currentThreadInTransaction());
+        assertEq((SQL_MUTATION_EVENT_PRE_EXEC, SQL_MUTATION_EVENT_POST_EXEC),
+            (map $1.event, obs.events[base..]));
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, obs.events[base + 1].outcome);
+        # no transaction outcome was reported
+        assertEq(0, obs.withEvent(SQL_MUTATION_EVENT_OUTCOME).size());
+
+        # the surrounding transaction still reports its own terminal outcome when it ends
+        obs.decision = NOTHING;
+        ds.rollback();
+        assertEq(SQL_MUTATION_OUTCOME_ROLLBACK, obs.outcome().outcome);
+        # one transaction identity throughout: the rejection did not end it
+        assertEq(1, obs.txIdCount());
+    }
+
+    #! a rejection produced by an observer exception is terminal in the same way
+    admissionExceptionTerminalTest() {
+        Datasource ds = getDs();
+        obs.throw_err = "OBSERVER-FAILED";
+        obs.throw_on_event = SQL_MUTATION_EVENT_PRE_EXEC;
+        assertThrows("OBSERVER-FAILED", \ds.exec(), "insert into t values (1)");
+        assertFalse(ds.currentThreadInTransaction());
+
+        # admission is fail-closed, and a fail-closed rejection closes the operation just as an
+        # explicit "admit: False" decision does
+        assertEq((SQL_MUTATION_EVENT_PRE_EXEC, SQL_MUTATION_EVENT_POST_EXEC), obs.codes());
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, obs.events[1].outcome);
+        assertTrue(obs.events[1].replay_safe);
     }
 
     observerAdmissionExceptionTest() {
@@ -367,7 +438,10 @@ public class MutationObserverTest inherits QUnit::Test {
         # consent
         assertThrows("OBSERVER-ERROR", \ds.exec(), "insert into t values (1)");
         assertFalse(ds.currentThreadInTransaction());
-        assertEq((SQL_MUTATION_EVENT_PRE_EXEC,), obs.codes());
+        # the fail-closed rejection is paired with its terminal event; the observer exception is
+        # reported first and is not replaced by anything the terminal event raises
+        assertEq((SQL_MUTATION_EVENT_PRE_EXEC, SQL_MUTATION_EVENT_POST_EXEC), obs.codes());
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, obs.events[1].outcome);
     }
 
     observerOutcomeExceptionTest() {
@@ -427,6 +501,24 @@ public class MutationObserverTest inherits QUnit::Test {
         ds.exec("insert into t values (1)");
         assertEq(SQL_STMT_CLASS_EXEC, obs.events[0].stmt_class);
         ds.rollback();
+
+        # a rejected read is closed by a terminal event of its own statement class, so that it is
+        # delivered under the read mask and not the mutation mask
+        obs.reset();
+        obs.decision = <SqlMutationDecisionInfo>{"admit": False, "err": "READ-REJECTED"};
+        assertThrows("READ-REJECTED", \ds.select(), "select * from t");
+        obs.decision = NOTHING;
+        assertEq((SQL_MUTATION_EVENT_PRE_EXEC, SQL_MUTATION_EVENT_POST_EXEC), obs.codes());
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, obs.events[1].outcome);
+        assertEq(SQL_STMT_CLASS_READ, obs.events[1].stmt_class);
+
+        # with reads masked out neither event is delivered
+        obs.reset();
+        ds.setMutationObserver(\obs.event(), SQL_MUTATION_MASK_EXEC);
+        obs.decision = <SqlMutationDecisionInfo>{"admit": False, "err": "READ-REJECTED"};
+        ds.select("select * from t");
+        obs.decision = NOTHING;
+        assertEq((), obs.codes());
     }
 
     undeclaredTest() {

--- a/examples/test/qore/classes/Datasource/mutation-observer.qtest
+++ b/examples/test/qore/classes/Datasource/mutation-observer.qtest
@@ -81,6 +81,13 @@ public class MutationObserverTest inherits QUnit::Test {
             "effect": SQL_MUTATION_EFFECT_MAY_GROW,
             "max_growth_bytes": 1048576,
         };
+
+        # debug fault boundary codes; these mirror the SQL_MUTATION_FAULT_* values in
+        # include/qore/intern/SqlMutationContext.h, which are compiled only in debug builds and so
+        # are not exported as %Qore constants
+        const FaultNone = 0;
+        const FaultAfterExec = 1;
+        const FaultOnCommit = 2;
     }
 
     private {
@@ -98,6 +105,10 @@ public class MutationObserverTest inherits QUnit::Test {
         addTestCase("autocommit commit ambiguity", \autocommitAmbiguityTest());
         addTestCase("restartable failover", \failoverTest());
         addTestCase("failover replay identity", \failoverReplayTest());
+        addTestCase("armed abort identity", \armedAbortIdentityTest());
+        addTestCase("armed abort is replay safe", \armedAbortReplaySafeTest());
+        addTestCase("armed abort on commit is ambiguous", \armedAbortCommitAmbiguousTest());
+        addTestCase("armed abort on a prepared statement", \armedAbortStatementTest());
         addTestCase("admission rejection", \admissionRejectionTest());
         addTestCase("admission rejection in a transaction", \admissionRejectionInTransactionTest());
         addTestCase("admission exception is terminal", \admissionExceptionTerminalTest());
@@ -331,6 +342,152 @@ public class MutationObserverTest inherits QUnit::Test {
         assertEq(2, second.info.attempt);
         # the replay is a new transaction, so the transaction identity differs
         assertNeq(first.tx_id, second.tx_id);
+    }
+
+    #! arms a one-shot debug connection abort, skipping the test in a release build
+    /** dbg_ds_arm_connection_abort() is registered only in debug builds, so it is called by name:
+        a release-build test run sees an unresolved function and skips instead of failing to parse.
+    */
+    private armAbort(Datasource ds, string op_id, int when) {
+        try {
+            call_function("dbg_ds_arm_connection_abort", ds, op_id, when);
+        } catch (hash<ExceptionInfo> ex) {
+            if (ex.err == "NO-FUNCTION" || ex.err == "UNDEFINED-FUNCTION-CALL") {
+                testSkip("debug build required for dbg_ds_arm_connection_abort()");
+            }
+            rethrow;
+        }
+    }
+
+    #! the armed abort is keyed on an exact op_id and is consumed by the operation it matched
+    armedAbortIdentityTest() {
+        Datasource ds = getDs();
+
+        # an arming for a different operation must never disturb this one
+        armAbort(ds, "some-other-op", FaultAfterExec);
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            assertEq(1, ds.exec("insert into t values (1)"));
+        }
+        assertEq(SQL_MUTATION_OUTCOME_OK, obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC)[0].outcome);
+        ds.rollback();
+
+        # an undeclared operation carries no op_id, so nothing can match it
+        obs.reset();
+        assertEq(1, ds.exec("insert into t values (1)"));
+        assertEq(SQL_MUTATION_OUTCOME_OK, obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC)[0].outcome);
+        ds.rollback();
+
+        # the matching operation aborts, and the arming is consumed by it
+        obs.reset();
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            armAbort(ds, OpInfo.op_id, FaultAfterExec);
+            assertThrows("DBI:DBG:CONNECTION-ABORTED", \ds.exec(), "insert into t values (1)");
+        }
+        assertEq(SQL_MUTATION_OUTCOME_LOST_CONNECTION,
+            obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC)[0].outcome);
+
+        # one-shot: the same operation runs normally on the next attempt with no re-arming
+        obs.reset();
+        ds.open();
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            assertEq(1, ds.exec("insert into t values (1)"));
+        }
+        assertEq(SQL_MUTATION_OUTCOME_OK, obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC)[0].outcome);
+        ds.rollback();
+
+        # arming with an empty op_id disarms
+        obs.reset();
+        armAbort(ds, OpInfo.op_id, FaultAfterExec);
+        armAbort(ds, "", FaultNone);
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            assertEq(1, ds.exec("insert into t values (1)"));
+        }
+        assertEq(SQL_MUTATION_OUTCOME_OK, obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC)[0].outcome);
+        ds.rollback();
+    }
+
+    #! an armed abort after execution is a structural replay-safe failover
+    armedAbortReplaySafeTest() {
+        Datasource ds = getDs();
+
+        {
+            SqlMutationDeclaration decl(ds, cast<hash<SqlMutationInfo>>(OpInfo + {"attempt": 1}));
+            ds.exec("insert into t values (1)");
+            armAbort(ds, OpInfo.op_id, FaultAfterExec);
+            assertThrows("DBI:DBG:CONNECTION-ABORTED", \ds.exec(), "insert into t values (2)");
+        }
+
+        # the statement was executed and no commit was attempted, so the operation may be replayed
+        # against the same reservation
+        hash<SqlMutationEventInfo> post = obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC).last();
+        assertEq(SQL_MUTATION_OUTCOME_LOST_CONNECTION, post.outcome);
+        assertTrue(post.replay_safe);
+        assertEq("op-1", post.info.op_id);
+        assertEq(1, post.info.attempt);
+
+        # the transaction is terminated by the same connection loss, and is never reported as a
+        # commit of any kind
+        hash<SqlMutationEventInfo> out = obs.outcome();
+        assertEq(SQL_MUTATION_OUTCOME_LOST_CONNECTION, out.outcome);
+        assertTrue(out.replay_safe);
+        assertEq(SQL_STMT_CLASS_ROLLBACK, out.stmt_class);
+        assertFalse(ds.currentThreadInTransaction());
+
+        # the replay presents the same op_id with a higher attempt and commits normally
+        obs.reset();
+        ds.open();
+        {
+            SqlMutationDeclaration decl(ds, cast<hash<SqlMutationInfo>>(OpInfo + {"attempt": 2}));
+            ds.exec("insert into t values (2)");
+            ds.commit();
+        }
+        hash<SqlMutationEventInfo> replay = obs.outcome();
+        assertEq(SQL_MUTATION_OUTCOME_COMMIT, replay.outcome);
+        assertEq("op-1", replay.info.op_id);
+        assertEq(2, replay.info.attempt);
+        assertNeq(out.tx_id, replay.tx_id);
+    }
+
+    #! an armed abort during a commit is ambiguous and is never reported as a rollback
+    armedAbortCommitAmbiguousTest() {
+        Datasource ds = getDs();
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            ds.exec("insert into t values (1)");
+            armAbort(ds, OpInfo.op_id, FaultOnCommit);
+            assertThrows("DBI:DBG:CONNECTION-ABORTED", \ds.commit());
+        }
+
+        # the core cannot know whether the server applied the commit, so a consumer must not release
+        # the reservation
+        hash<SqlMutationEventInfo> out = obs.outcome();
+        assertEq(SQL_MUTATION_OUTCOME_COMMIT_AMBIGUOUS, out.outcome);
+        assertFalse(out.replay_safe);
+        assertEq(SQL_STMT_CLASS_COMMIT, out.stmt_class);
+    }
+
+    #! a prepared statement reaches the same armed boundary
+    armedAbortStatementTest() {
+        Datasource ds = getDs();
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            # arm before the statement exists: a release build skips here, and a bound but
+            # unexecuted SQLStatement must not be left behind by the skip
+            armAbort(ds, OpInfo.op_id, FaultAfterExec);
+            SQLStatement stmt(ds);
+            stmt.prepare("insert into t values (%v)");
+            stmt.bind(1);
+            assertThrows("DBI:DBG:CONNECTION-ABORTED", \stmt.exec());
+        }
+
+        hash<SqlMutationEventInfo> post = obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC).last();
+        assertEq(SQL_MUTATION_OUTCOME_LOST_CONNECTION, post.outcome);
+        assertTrue(post.replay_safe);
+        assertEq(SQL_STMT_CLASS_STMT_EXEC, post.stmt_class);
     }
 
     admissionRejectionTest() {

--- a/examples/test/qore/classes/Datasource/mutation-observer.qtest
+++ b/examples/test/qore/classes/Datasource/mutation-observer.qtest
@@ -433,8 +433,19 @@ public class MutationObserverTest inherits QUnit::Test {
         assertEq(SQL_MUTATION_OUTCOME_OK, obs.withEvent(SQL_MUTATION_EVENT_POST_EXEC)[0].outcome);
         ds.rollback();
 
+        # an arming for another boundary of the same operation is not consumed by this one
+        obs.reset();
+        armAbort(ds, OpInfo.op_id, FaultOnCommit);
+        {
+            SqlMutationDeclaration decl(ds, OpInfo);
+            assertEq(1, ds.exec("insert into t values (1)"));
+            # the after-exec boundary left the commit arming alone, so the commit still aborts
+            assertThrows("DBI:DBG:CONNECTION-ABORTED", \ds.commit());
+        }
+
         # arming with an empty op_id disarms
         obs.reset();
+        ds.open();
         armAbort(ds, OpInfo.op_id, FaultAfterExec);
         armAbort(ds, "", FaultNone);
         {
@@ -492,8 +503,11 @@ public class MutationObserverTest inherits QUnit::Test {
         Datasource ds = getDs();
         {
             SqlMutationDeclaration decl(ds, OpInfo);
-            ds.exec("insert into t values (1)");
+            # armed before any statement is executed, so the arming has to survive the after-exec
+            # boundary of the same operation: an arming is consumed only by the boundary it names
             armAbort(ds, OpInfo.op_id, FaultOnCommit);
+            ds.exec("insert into t values (1)");
+            ds.exec("insert into t values (2)");
             assertThrows("DBI:DBG:CONNECTION-ABORTED", \ds.commit());
         }
 

--- a/examples/test/qore/classes/Datasource/mutation-stream.qtest
+++ b/examples/test/qore/classes/Datasource/mutation-stream.qtest
@@ -15,10 +15,19 @@ class StreamCollector {
         list<hash<SqlMutationEventInfo>> events();
         #! abort the stream once this many bytes have been consumed; 0 = never
         int abort_after = 0;
+        #! refuse the stream at its begin boundary
+        bool reject_begin = False;
     }
 
     *hash<SqlMutationDecisionInfo> event(hash<SqlMutationEventInfo> ev) {
         events += ev;
+        if (reject_begin && ev.event == SQL_MUTATION_EVENT_STREAM_BEGIN) {
+            return <SqlMutationDecisionInfo>{
+                "admit": False,
+                "err": "STREAM-REFUSED",
+                "desc": "the stream was refused before it started",
+            };
+        }
         if (abort_after && ev.event == SQL_MUTATION_EVENT_STREAM_PROGRESS
             && ev.consumed_bytes > abort_after) {
             return <SqlMutationDecisionInfo>{
@@ -33,6 +42,7 @@ class StreamCollector {
     reset() {
         events = ();
         abort_after = 0;
+        reject_begin = False;
     }
 
     list<hash<SqlMutationEventInfo>> streamEvents() {
@@ -59,6 +69,8 @@ public class MutationStreamTest inherits QUnit::Test {
         addTestCase("driver stream", \driverStreamTest());
         addTestCase("declared bytes fallback", \declaredBytesFallbackTest());
         addTestCase("stream abort", \streamAbortTest());
+        addTestCase("stream begin rejected", \streamBeginRejectedTest());
+        addTestCase("stream driver failure", \streamDriverFailureTest());
         addTestCase("qore level stream", \qoreLevelStreamTest());
         addTestCase("unmonitored stream", \unmonitoredStreamTest());
 
@@ -132,7 +144,55 @@ public class MutationStreamTest inherits QUnit::Test {
         assertEq((SQL_MUTATION_EVENT_STREAM_BEGIN, SQL_MUTATION_EVENT_STREAM_PROGRESS,
             SQL_MUTATION_EVENT_STREAM_PROGRESS, SQL_MUTATION_EVENT_STREAM_END), map $1.event, l);
         assertEq(800, l.last().consumed_bytes);
+        # the producer's own end boundary reports the rejection: the consumer stopped the stream, so
+        # the outcome is "not executed" and not a driver failure, and nothing was committed
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, l.last().outcome);
+        assertTrue(l.last().replay_safe);
+    }
+
+    #! a stream refused before it starts still reports exactly one terminal event
+    streamBeginRejectedTest() {
+        Datasource ds = getDs();
+        obs.reject_begin = True;
+        {
+            SqlMutationDeclaration decl(ds, CopyInfo);
+            assertThrows("STREAM-REFUSED", \ds.execRaw(), "dbitest-copy 1000");
+        }
+
+        list<hash<SqlMutationEventInfo>> l = obs.streamEvents();
+        # the producer never started the stream, so it emits no end boundary of its own; the core
+        # supplies it so that the operation's lifetime always closes
+        assertEq((SQL_MUTATION_EVENT_STREAM_BEGIN, SQL_MUTATION_EVENT_STREAM_END), map $1.event, l);
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, l.last().outcome);
+        assertTrue(l.last().replay_safe);
+        assertEq(0, l.last().consumed_bytes);
+        assertEq(1000, l.last().declared_bytes);
+        assertEq("copy-1", l.last().info.op_id);
+
+        # the refusal did not leave stream state behind for the next stream on this datasource
+        obs.reset();
+        {
+            SqlMutationDeclaration decl(ds, CopyInfo);
+            assertEq(1000, ds.execRaw("dbitest-copy 1000"));
+        }
+        assertEq(SQL_MUTATION_OUTCOME_OK, obs.streamEvents().last().outcome);
+    }
+
+    #! a driver failure mid-stream stays distinguishable from a consumer rejection
+    streamDriverFailureTest() {
+        Datasource ds = getDs();
+        ds.setOption("fault", "stream");
+        {
+            SqlMutationDeclaration decl(ds, CopyInfo);
+            assertThrows("DBI-TEST-STREAM-ERROR", \ds.execRaw(), "dbitest-copy 1000");
+        }
+
+        list<hash<SqlMutationEventInfo>> l = obs.streamEvents();
+        assertEq(SQL_MUTATION_EVENT_STREAM_END, l.last().event);
+        # the database failed while the payload was being sent; this is not a refusal, and the core
+        # must not claim the operation was not executed
         assertEq(SQL_MUTATION_OUTCOME_ERROR, l.last().outcome);
+        assertEq(NOTHING, l.last().replay_safe);
     }
 
     qoreLevelStreamTest() {

--- a/examples/test/qore/classes/SQLStatement/mutation-observer-stmt.qtest
+++ b/examples/test/qore/classes/SQLStatement/mutation-observer-stmt.qtest
@@ -159,8 +159,12 @@ public class MutationObserverStmtTest inherits QUnit::Test {
         stmt.bind(1);
         assertThrows("STMT-REJECTED", \stmt.exec());
 
-        # the statement was not executed
-        assertEq((SQL_MUTATION_EVENT_PRE_EXEC,), obs.codes());
+        # the statement was not executed, and the rejected admission event is closed by a terminal
+        # event carrying the same statement class as the prepared statement itself
+        assertEq((SQL_MUTATION_EVENT_PRE_EXEC, SQL_MUTATION_EVENT_POST_EXEC), obs.codes());
+        assertEq(SQL_MUTATION_OUTCOME_NOT_EXECUTED, obs.events[1].outcome);
+        assertTrue(obs.events[1].replay_safe);
+        assertEq(SQL_STMT_CLASS_STMT_EXEC, obs.events[1].stmt_class);
         obs.decision = NOTHING;
         stmt.close();
         ds.rollback();

--- a/examples/test/qore/classes/SQLStatement/stmt-connection-lifecycle.qtest
+++ b/examples/test/qore/classes/SQLStatement/stmt-connection-lifecycle.qtest
@@ -1,0 +1,154 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+
+%prepend-module-path "${SCRIPT_DIR}/../../../../../qlib"
+%requires Util
+%requires QUnit
+
+%exec-class StmtConnectionLifecycleTest
+
+#! verifies the connection/thread-resource lifecycle of a prepared statement
+/** A prepared statement acquires the connection when it is bound, which registers the datasource as
+    a thread resource so that the connection lock is released if the thread exits.  Binding does not
+    start a transaction, so the thread resource can be registered with no transaction in progress,
+    and every path that closes the datasource or cleans up the thread has to cope with that.
+
+    Before the fix, closing a datasource in that state left the thread resource registered while
+    Datasource::close() freed the driver's connection data, so the eventual thread cleanup ran the
+    driver's rollback against a closed connection and crashed the process.
+
+    The mock dbitest driver is used so that this runs with no external database.
+*/
+public class StmtConnectionLifecycleTest inherits QUnit::Test {
+    constructor() : Test("StmtConnectionLifecycleTest", "1.0", \ARGV) {
+        addTestCase("bound statement destroyed", \boundStatementDestroyedTest());
+        addTestCase("bound statement then close", \boundStatementCloseTest());
+        addTestCase("bound statement in another thread", \boundStatementThreadTest());
+        addTestCase("destroyed datasource cleanup", \destroyedDatasourceCleanupTest());
+        addTestCase("open transaction still rolls back", \openTransactionCloseTest());
+
+        set_return_value(main());
+    }
+
+    private Datasource getDs() {
+        Datasource ds;
+        try {
+            ds = new Datasource("dbitest:u/p@db");
+            ds.setAutoCommit(False);
+            ds.open();
+        } catch (hash<ExceptionInfo> ex) {
+            testSkip("dbitest driver not available: " + ex.err + ": " + ex.desc);
+        }
+        return ds;
+    }
+
+    #! binding acquires the connection without starting a transaction
+    boundStatementDestroyedTest() {
+        Datasource ds = getDs();
+        assertFalse(ds.currentThreadInTransaction());
+        {
+            SQLStatement stmt(ds);
+            stmt.prepare("insert into t values (%v)");
+            stmt.bind(1);
+            # binding acquires the connection - currentThreadInTransaction() reports that this
+            # thread holds it - but no statement has been executed, so no transaction was started
+            assertTrue(ds.currentThreadInTransaction());
+        }
+        # destroying the statement without executing it leaves the datasource usable
+        assertEq(1, ds.exec("insert into t values (1)"));
+        ds.rollback();
+    }
+
+    #! closing the datasource in that state must not leave a thread resource behind
+    /** the resource would later run the driver's rollback against a connection whose data
+        Datasource::close() has already freed
+    */
+    boundStatementCloseTest() {
+        Datasource ds = getDs();
+        {
+            SQLStatement stmt(ds);
+            stmt.prepare("insert into t values (%v)");
+            stmt.bind(1);
+        }
+        # closing with the connection held but no transaction in progress reports nothing
+        ds.close();
+        # the connection lock was released with the connection, so the datasource is not left
+        # locked by this thread
+        assertFalse(ds.currentThreadInTransaction());
+
+        # and it can be reopened and used again
+        ds.open();
+        assertEq(1, ds.exec("insert into t values (1)"));
+        ds.rollback();
+    }
+
+    #! a thread that exits holding a bound statement releases the connection and reports nothing
+    boundStatementThreadTest() {
+        Datasource ds = getDs();
+        Counter c(1);
+        background sub () {
+            on_exit c.dec();
+            SQLStatement stmt(ds);
+            stmt.prepare("insert into t values (%v)");
+            stmt.bind(1);
+            # the thread exits here holding the connection with no transaction in progress
+        }();
+        c.waitForZero();
+
+        # no transaction was in progress, so nothing was rolled back and the connection lock was
+        # released: this thread can use the datasource immediately
+        assertFalse(ds.currentThreadInTransaction());
+        assertEq(1, ds.exec("insert into t values (1)"));
+        ds.rollback();
+    }
+
+    #! a datasource destroyed while its connection is held must not be rolled back afterwards
+    /** This is the shape that crashed the process: the datasource is destroyed first, which frees
+        the driver's connection data, and the thread resource left registered behind it then ran the
+        driver's rollback against that freed data when the thread exited.
+    */
+    destroyedDatasourceCleanupTest() {
+        Counter c(1);
+        *string driver;
+        background sub () {
+            on_exit c.dec();
+            {
+                Datasource ds("dbitest:u/p@db");
+                ds.setAutoCommit(False);
+                ds.open();
+                SQLStatement stmt(ds);
+                stmt.prepare("insert into t values (%v)");
+                stmt.bind(1);
+                driver = ds.getDriverName();
+                # the datasource is destroyed here with its connection still held
+            }
+            # and the thread exits here
+        }();
+        c.waitForZero();
+
+        # the thread body ran to completion, and cleaning the thread up afterwards did not run the
+        # driver's rollback against the connection its datasource had already closed - which
+        # crashed the process before the fix
+        assertEq("dbitest", driver);
+    }
+
+    #! closing with a real transaction open must still roll it back and report it
+    /** the no-transaction handling above must not weaken this
+    */
+    openTransactionCloseTest() {
+        Datasource ds = getDs();
+        ds.exec("insert into t values (1)");
+        assertTrue(ds.currentThreadInTransaction());
+
+        # closing while a transaction is in progress is still an error, and the transaction is
+        # still rolled back
+        assertThrows("DATASOURCE-TRANSACTION-EXCEPTION", "rolled back", \ds.close());
+        assertFalse(ds.currentThreadInTransaction());
+
+        ds.open();
+        assertEq(1, ds.exec("insert into t values (2)"));
+        ds.rollback();
+    }
+}

--- a/include/qore/intern/DatasourcePool.h
+++ b/include/qore/intern/DatasourcePool.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -277,6 +277,11 @@ public:
     DLLLOCAL int reportMutationStreamBegin(int64 declared_bytes, ExceptionSink* xsink);
     DLLLOCAL int reportMutationStreamProgress(int64 consumed_bytes, ExceptionSink* xsink);
     DLLLOCAL int reportMutationStreamEnd(int64 consumed_bytes, bool ok, ExceptionSink* xsink);
+
+#ifdef DEBUG
+    //! arms a one-shot debug connection abort on the pool-wide context; see lib/ql_debug.cpp
+    DLLLOCAL void dbgArmConnectionAbort(const char* op_id, int when);
+#endif
 
     // functions supporting DatasourceStatementHelper
     DLLLOCAL DatasourceStatementHelper* helperRefSelfImpl() {

--- a/include/qore/intern/SqlMutationContext.h
+++ b/include/qore/intern/SqlMutationContext.h
@@ -152,6 +152,30 @@
 //! the error code raised for an invalid mutation declaration
 #define SQL_MUTATION_DECLARATION_ERR "SQL-MUTATION-DECLARATION-ERROR"
 
+#ifdef DEBUG
+/** @defgroup sql_mutation_debug_fault_codes SQL mutation debug fault boundary codes
+
+    Debug builds only.  Values selecting the boundary at which an armed connection abort is
+    triggered; see dbg_ds_arm_connection_abort() in lib/ql_debug.cpp.
+*/
+///@{
+//! no fault is armed
+#define SQL_MUTATION_FAULT_NONE             0
+//! abort the connection after the statement has been executed and before any commit
+/** the operation is reported with \c LOST_CONNECTION and \c replay_safe \c True
+*/
+#define SQL_MUTATION_FAULT_AFTER_EXEC       1
+//! abort the connection while a commit is in flight
+/** the transaction is reported with \c COMMIT_AMBIGUOUS, since the core cannot know whether the
+    server applied the commit
+*/
+#define SQL_MUTATION_FAULT_ON_COMMIT        2
+///@}
+
+//! the error code raised by an armed debug connection abort
+#define SQL_MUTATION_DEBUG_ABORT_ERR "DBI:DBG:CONNECTION-ABORTED"
+#endif
+
 class Datasource;
 class ResolvedCallReferenceNode;
 
@@ -258,6 +282,33 @@ public:
     //! returns a new unique transaction identity for this context
     DLLLOCAL void getNewTransactionId(std::string& tx_id);
 
+#ifdef DEBUG
+    //! arms a one-shot connection abort for the operation with the given \c "op_id"
+    /** Debug builds only; exposed to %Qore as dbg_ds_arm_connection_abort() so that a test can
+        produce a structural connection loss at an exact operation boundary on a real driver,
+        deterministically and with no sleep, poll, retry, or randomness.
+
+        The arming lives on the context rather than on the connection because a DatasourcePool
+        shares one context with every connection it pools: a test arms the pool without knowing
+        which connection its thread will be allocated.
+
+        @param op_id the exact declared operation identity to abort on
+        @param when the boundary; see @ref sql_mutation_debug_fault_codes
+    */
+    DLLLOCAL void dbgArmFault(const char* op_id, int when);
+
+    //! returns the armed boundary if \a op_id matches the arming, disarming it; 0 otherwise
+    /** the arming is one-shot: a match consumes it, so a test can never see a second abort it did
+        not ask for
+    */
+    DLLLOCAL int dbgTakeArmedFault(const char* op_id);
+
+    //! returns true if any fault is armed
+    DLLLOCAL bool dbgFaultArmed() const {
+        return dbg_fault_armed.load(std::memory_order_relaxed);
+    }
+#endif
+
     //! delivers an event to the observer
     /** The observer is called with a clean ExceptionSink; anything it raises is assimilated into
         \a xsink afterwards, so that a driver exception already present in \a xsink is always
@@ -302,6 +353,15 @@ private:
 
     //! process-unique identity for this context, assigned lazily; 0 = not yet assigned
     mutable std::atomic<int64> ctx_id{0};
+
+#ifdef DEBUG
+    //! the operation identity the armed fault applies to; empty = no fault armed
+    std::string dbg_fault_op_id;
+    //! the armed boundary; see @ref sql_mutation_debug_fault_codes
+    int dbg_fault_when = SQL_MUTATION_FAULT_NONE;
+    //! fast-path flag; only ever written with the lock held
+    std::atomic<bool> dbg_fault_armed{false};
+#endif
 
     tmap_t tmap;
 

--- a/include/qore/intern/SqlMutationContext.h
+++ b/include/qore/intern/SqlMutationContext.h
@@ -297,11 +297,16 @@ public:
     */
     DLLLOCAL void dbgArmFault(const char* op_id, int when);
 
-    //! returns the armed boundary if \a op_id matches the arming, disarming it; 0 otherwise
-    /** the arming is one-shot: a match consumes it, so a test can never see a second abort it did
-        not ask for
+    //! returns true if the arming matches \a op_id and \a when, consuming it
+    /** The arming is one-shot, so a test can never see a second abort it did not ask for, and it is
+        consumed only by the exact boundary it names: an operation passes several boundaries, so
+        matching on the operation alone would let an earlier boundary swallow an arming meant for a
+        later one.
+
+        @param op_id the declared operation identity at the boundary being passed
+        @param when the boundary being passed; see @ref sql_mutation_debug_fault_codes
     */
-    DLLLOCAL int dbgTakeArmedFault(const char* op_id);
+    DLLLOCAL bool dbgTakeArmedFault(const char* op_id, int when);
 
     //! returns true if any fault is armed
     DLLLOCAL bool dbgFaultArmed() const {

--- a/include/qore/intern/qore_ds_private.h
+++ b/include/qore/intern/qore_ds_private.h
@@ -351,7 +351,7 @@ struct qore_ds_private {
             return false;
         }
         QoreStringNodeValueHelper op_id(decl->getKeyValue("op_id"));
-        if (ctx->dbgTakeArmedFault(op_id->c_str()) != when) {
+        if (!ctx->dbgTakeArmedFault(op_id->c_str(), when)) {
             return false;
         }
         xsink->raiseException(SQL_MUTATION_DEBUG_ABORT_ERR, "debug connection abort armed for op_id %s "

--- a/include/qore/intern/qore_ds_private.h
+++ b/include/qore/intern/qore_ds_private.h
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     The Datasource class provides the low-level interface to Qore DBI drivers.
 
@@ -111,6 +111,12 @@ struct qore_ds_private {
     int64 tx_seq = 0;
     // declared size in bytes of the bounded stream in progress; -1 = no stream in progress
     int64 stream_declared_bytes = -1;
+    //! set when a bounded stream admission point rejected the stream in progress
+    /** it distinguishes a stream that the consumer stopped from one that the driver failed, so that
+        the terminal stream event can report the exact outcome; see
+        design/datasource-mutation-observer.md
+    */
+    bool stream_rejected = false;
 
     // interface for the parent class
     DatasourceStatementHelper* dsh;
@@ -274,7 +280,54 @@ struct qore_ds_private {
         ev.tx_seq = ++tx_seq;
         ev.in_transaction = in_transaction;
         ev.autocommit = autocommit;
-        return ctx->dispatch(ev, *ds, xsink);
+        int rc = ctx->dispatch(ev, *ds, xsink);
+        if (rc && ev.isAdmission()) {
+            dispatchMutationNotExecuted(ev, xsink);
+        }
+        return rc;
+    }
+
+    //! emits the terminal event for an operation that an admission point rejected
+    /** The event closes the operation's lifetime for a consumer that tracks reservations by
+        \c "op_id": without it a rejected operation would leave an unpaired admission event, and a
+        rejection outside a transaction would produce no terminal event at all.
+
+        It cannot be emitted from SqlMutationContext::dispatch() itself, because the re-entrancy
+        depth that suppresses observer-issued operations is still held there; it is emitted here,
+        after that depth has been released.
+
+        The event is a notification: the operation has already been refused, so the return value is
+        ignored.  The rejection exception is passed for reporting only and is not consumed.
+
+        @param ev the rejected admission event
+    */
+    DLLLOCAL void dispatchMutationNotExecuted(const SqlMutationEvent& ev, ExceptionSink* xsink) {
+        assert(ev.isAdmission());
+        // a rejected stream in progress is closed by its producer's terminal event, which reports
+        // the rejection through the "stream_rejected" flag; emitting here would duplicate it
+        if (ev.event == SQL_MUTATION_EVENT_STREAM_PROGRESS) {
+            stream_rejected = true;
+            return;
+        }
+        if (ev.event == SQL_MUTATION_EVENT_STREAM_BEGIN) {
+            // the producer never started the stream, so it emits no terminal event of its own
+            stream_declared_bytes = -1;
+            SqlMutationEvent term(SQL_MUTATION_EVENT_STREAM_END, SQL_STMT_CLASS_STREAM);
+            term.declared_bytes = ev.declared_bytes;
+            term.consumed_bytes = 0;
+            term.outcome = SQL_MUTATION_OUTCOME_NOT_EXECUTED;
+            // the operation was refused before execution, so no commit can have been attempted
+            term.replay_safe = 1;
+            term.driver_xsink = xsink;
+            dispatchMutationEvent(term, xsink);
+            return;
+        }
+        assert(ev.event == SQL_MUTATION_EVENT_PRE_EXEC);
+        SqlMutationEvent term(SQL_MUTATION_EVENT_POST_EXEC, ev.stmt_class);
+        term.outcome = SQL_MUTATION_OUTCOME_NOT_EXECUTED;
+        term.replay_safe = 1;
+        term.driver_xsink = xsink;
+        dispatchMutationEvent(term, xsink);
     }
 
     //! emits a transaction start event

--- a/include/qore/intern/qore_ds_private.h
+++ b/include/qore/intern/qore_ds_private.h
@@ -330,6 +330,37 @@ struct qore_ds_private {
         dispatchMutationEvent(term, xsink);
     }
 
+#ifdef DEBUG
+    //! triggers an armed debug connection abort when the current operation matches it
+    /** Debug builds only.  The abort goes through the ordinary Datasource::connectionAborted()
+        path, so the connection is really closed and the server really discards the transaction;
+        nothing about the resulting outcome is synthesized.  The exception is required: the
+        connection_aborted paths assert that one is active.
+
+        @param when the boundary being passed; see @ref sql_mutation_debug_fault_codes
+
+        @return true if the connection was aborted, in which case an exception has been raised
+    */
+    DLLLOCAL bool dbgCheckArmedFault(int when, ExceptionSink* xsink) {
+        SqlMutationContext* ctx = getMutationCtx();
+        if (!ctx || !ctx->dbgFaultArmed()) {
+            return false;
+        }
+        ReferenceHolder<QoreHashNode> decl(ctx->getDeclaration(), xsink);
+        if (!decl) {
+            return false;
+        }
+        QoreStringNodeValueHelper op_id(decl->getKeyValue("op_id"));
+        if (ctx->dbgTakeArmedFault(op_id->c_str()) != when) {
+            return false;
+        }
+        xsink->raiseException(SQL_MUTATION_DEBUG_ABORT_ERR, "debug connection abort armed for op_id %s "
+            "triggered at boundary %d", op_id->c_str(), when);
+        connectionAborted(xsink);
+        return true;
+    }
+#endif
+
     //! emits a transaction start event
     DLLLOCAL void dispatchMutationTxBegin(ExceptionSink* xsink) {
         if (!observes(SQL_MUTATION_MASK_TX)) {
@@ -438,7 +469,15 @@ struct qore_ds_private {
         // the flag is what makes commit ambiguity structural: any failure or connection loss while
         // it is set means the core cannot know whether the server applied the commit
         commit_in_progress = true;
+#ifdef DEBUG
+        // an abort armed for the commit boundary is triggered with the flag set, so that it is
+        // classified as ambiguous exactly as a real connection loss during a commit would be
+        int rc = dbgCheckArmedFault(SQL_MUTATION_FAULT_ON_COMMIT, xsink)
+            ? -1
+            : qore_dbi_private::get(*dsl)->commit(ds, xsink);
+#else
         int rc = qore_dbi_private::get(*dsl)->commit(ds, xsink);
+#endif
         commit_in_progress = false;
         // a commit that did not demonstrably succeed is always ambiguous and is never reported as a
         // rollback: the server may have applied it

--- a/lib/Datasource.cpp
+++ b/lib/Datasource.cpp
@@ -1127,6 +1127,15 @@ QoreValue Datasource::exec_internal(bool doBind, const QoreString* query_str, co
     //printd(5, "Datasource::exec_internal() this=%p, autocommit=%d, in_transaction=%d, xsink=%d\n", this,
     //    priv->autocommit, priv->in_transaction, xsink->isException());
 
+#ifdef DEBUG
+    // the statement has been executed and no commit has been attempted: this is the replay-safe
+    // boundary a test arms to prove restartable failover on a real driver
+    if (!*xsink && priv->dbgCheckArmedFault(SQL_MUTATION_FAULT_AFTER_EXEC, xsink)) {
+        rv.discard(xsink);
+        rv = QoreValue();
+    }
+#endif
+
     if (priv->connection_aborted) {
         assert(*xsink);
         assert(!rv);

--- a/lib/Datasource.cpp
+++ b/lib/Datasource.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     NOTE that 2 copies of connection values are kept in case
     the values are changed while a connection is in use
@@ -1576,6 +1576,7 @@ int Datasource::reportMutationStreamBegin(int64 declared_bytes, ExceptionSink* x
         }
     }
     priv->stream_declared_bytes = declared_bytes;
+    priv->stream_rejected = false;
 
     if (!priv->observes(SQL_MUTATION_MASK_STREAM)) {
         return 0;
@@ -1601,6 +1602,8 @@ int Datasource::reportMutationStreamEnd(int64 consumed_bytes, bool ok, Exception
     assert(xsink);
     const int64 declared_bytes = priv->stream_declared_bytes;
     priv->stream_declared_bytes = -1;
+    const bool rejected = priv->stream_rejected;
+    priv->stream_rejected = false;
 
     if (!priv->observes(SQL_MUTATION_MASK_STREAM)) {
         return 0;
@@ -1608,7 +1611,16 @@ int Datasource::reportMutationStreamEnd(int64 consumed_bytes, bool ok, Exception
     SqlMutationEvent ev(SQL_MUTATION_EVENT_STREAM_END, SQL_STMT_CLASS_STREAM);
     ev.declared_bytes = declared_bytes;
     ev.consumed_bytes = consumed_bytes < 0 ? 0 : consumed_bytes;
-    ev.outcome = ok ? SQL_MUTATION_OUTCOME_OK : SQL_MUTATION_OUTCOME_ERROR;
+    if (ok) {
+        ev.outcome = SQL_MUTATION_OUTCOME_OK;
+    } else if (rejected) {
+        // the consumer stopped the stream at an admission point; this is distinct from a driver
+        // failure, and no commit can have been attempted, so the operation can be replayed
+        ev.outcome = SQL_MUTATION_OUTCOME_NOT_EXECUTED;
+        ev.replay_safe = 1;
+    } else {
+        ev.outcome = SQL_MUTATION_OUTCOME_ERROR;
+    }
     ev.driver_xsink = xsink;
     // stream end is a notification: it cannot reject anything that has already been streamed
     priv->dispatchMutationEvent(ev, xsink);

--- a/lib/DatasourcePool.cpp
+++ b/lib/DatasourcePool.cpp
@@ -3,7 +3,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2003 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -812,6 +812,17 @@ void DatasourcePool::setMutationObserver(ResolvedCallReferenceNode* observer, in
     AutoLocker al((QoreThreadLock*)this);
     getOrCreateMutationContext()->setObserver(observer, event_mask, arg, xsink);
 }
+
+#ifdef DEBUG
+void DatasourcePool::dbgArmConnectionAbort(const char* op_id, int when) {
+    SqlMutationContext* mctx;
+    {
+        AutoLocker al((QoreThreadLock*)this);
+        mctx = getOrCreateMutationContext();
+    }
+    mctx->dbgArmFault(op_id, when);
+}
+#endif
 
 void DatasourcePool::clearMutationObserver(ExceptionSink* xsink) {
     AutoLocker al((QoreThreadLock*)this);

--- a/lib/ManagedDatasource.cpp
+++ b/lib/ManagedDatasource.cpp
@@ -62,13 +62,17 @@ DatasourceActionHelper::~DatasourceActionHelper() {
 void ManagedDatasource::cleanup(ExceptionSink *xsink) {
     // this thread has the transaction lock
     AutoLocker al(&ds_lock);
-    assert(isInTransaction());
 
-    xsink->raiseException("DATASOURCE-TRANSACTION-EXCEPTION", "%s:%s@%s: TID %d terminated while in a transaction; " \
-        "transaction will be automatically rolled back and the lock released", getDriverName(),
-        getUsernameStr().c_str(), getDBNameStr().c_str(), q_gettid());
-    Datasource::rollback(xsink);
-    setTransactionStatus(false);
+    // the thread resource is registered whenever this thread acquires the connection, which a
+    // prepared statement does when it is bound, with or without a transaction in progress; with no
+    // transaction there is nothing to roll back and nothing to report, only the lock to release
+    if (isInTransaction()) {
+        xsink->raiseException("DATASOURCE-TRANSACTION-EXCEPTION", "%s:%s@%s: TID %d terminated while in a " \
+            "transaction; transaction will be automatically rolled back and the lock released", getDriverName(),
+            getUsernameStr().c_str(), getDBNameStr().c_str(), q_gettid());
+        Datasource::rollback(xsink);
+        setTransactionStatus(false);
+    }
     releaseLockIntern();
 }
 
@@ -402,17 +406,29 @@ int ManagedDatasource::closeUnlocked(ExceptionSink *xsink) {
     //printd(5, "ManagedDatasource::closeUnlocked() this: %p priv: %p %s:%s@%s open: %d trans: %d\n", this, qore_ds_private::get(*this), getDriverName(), getUsernameStr().c_str(), getDBNameStr().c_str(), isOpen(), isInTransaction());
 
     if (isOpen()) {
-        if (isInTransaction()) {
+        const bool in_transaction = isInTransaction();
+
+        // the thread resource is registered whenever this thread acquires the connection, which a
+        // prepared statement does when it is bound, with or without a transaction in progress.  It
+        // must be removed on every close: Datasource::close() below frees the driver's connection
+        // data, so a resource left registered would run cleanup() - and the driver's rollback -
+        // against a closed connection
+        const bool held = !remove_thread_resource(this);
+
+        if (in_transaction) {
             if (!wasConnectionAborted()) {
                 // FIXME: check for statement
                 xsink->raiseException("DATASOURCE-TRANSACTION-EXCEPTION", "%s:%s@%s: Datasource closed while in a transaction; transaction will be automatically rolled back and the lock released", getDriverName(), getUsernameStr().c_str(), getDBNameStr().c_str());
                 Datasource::rollback(xsink);
             }
-            remove_thread_resource(this);
             setTransactionStatus(false);
-            // force-exit the transaction lock
-            forceReleaseLockIntern();
             rc = -1;
+        }
+
+        if (in_transaction || held) {
+            // force-exit the transaction lock; the connection is about to be closed, so leaving the
+            // lock held would keep every other thread from ever reopening the datasource
+            forceReleaseLockIntern();
         }
 
         Datasource::close();

--- a/lib/QC_AbstractDatasource.qpp
+++ b/lib/QC_AbstractDatasource.qpp
@@ -672,6 +672,24 @@ ds.setMutationObserver(\admission.event(), SQL_MUTATION_MASK_DEFAULT, tenant_id)
     - an exception thrown by the observer propagates and the operation is not executed.  Admission
       is fail-closed by design.
 
+    Every rejected admission point - whether rejected by an \c "admit" @ref False "False" decision or
+    by a fail-closed observer exception - is followed by exactly one terminal notification carrying
+    @ref Qore::SQL::SQL_MUTATION_OUTCOME_NOT_EXECUTED "SQL_MUTATION_OUTCOME_NOT_EXECUTED" and
+    \c "replay_safe" @ref True "True", so that an observer tracking operations by \c "op_id" always
+    sees the operation's lifetime close.  This matters most when nothing else would report one: a
+    rejection outside a transaction is followed by no rollback, so no
+    @ref Qore::SQL::SQL_MUTATION_EVENT_OUTCOME "SQL_MUTATION_EVENT_OUTCOME" event is ever emitted.
+
+    |!Rejected at|!Terminal event
+    |\c SQL_MUTATION_EVENT_PRE_EXEC|\c SQL_MUTATION_EVENT_POST_EXEC, pairing the admission event
+    |\c SQL_MUTATION_EVENT_STREAM_BEGIN|\c SQL_MUTATION_EVENT_STREAM_END; the producer never started \
+        the stream, so it reports no end boundary of its own
+    |\c SQL_MUTATION_EVENT_STREAM_PROGRESS|\c SQL_MUTATION_EVENT_STREAM_END, reported by the producer \
+        of the stream it stopped
+
+    The terminal event reports the rejection exception in its \c "ex" key without consuming it, and
+    it cannot re-enter the callback that produced the rejection.
+
     At a notification event:
     - the return value is ignored;
     - an exception thrown by the observer is raised <b>after</b> the real outcome has been

--- a/lib/QC_Datasource.qpp
+++ b/lib/QC_Datasource.qpp
@@ -405,6 +405,17 @@ const SQL_MUTATION_OUTCOME_ROLLBACK_ERROR = SQL_MUTATION_OUTCOME_ROLLBACK_ERROR;
 const SQL_MUTATION_OUTCOME_LOST_CONNECTION = SQL_MUTATION_OUTCOME_LOST_CONNECTION;
 
 //! The operation was rejected at an admission point and was not executed
+/** Reported on the terminal event that follows every rejected admission point, always with
+    \c "replay_safe" @ref True "True", since a rejected operation cannot have attempted a commit.
+
+    On a @ref Qore::SQL::SQL_MUTATION_EVENT_STREAM_END "SQL_MUTATION_EVENT_STREAM_END" event this
+    outcome means that the observer stopped the stream, as distinct from
+    @ref Qore::SQL::SQL_MUTATION_OUTCOME_ERROR "SQL_MUTATION_OUTCOME_ERROR", which means that the
+    database failed while the payload was being sent.  Bytes already sent before an observer stopped
+    a stream are discarded by the surrounding rollback.
+
+    @see @ref sql_mutation_admission
+*/
 const SQL_MUTATION_OUTCOME_NOT_EXECUTED = SQL_MUTATION_OUTCOME_NOT_EXECUTED;
 ///@}
 

--- a/lib/QoreSQLStatement.cpp
+++ b/lib/QoreSQLStatement.cpp
@@ -4,7 +4,7 @@
 
     Qore Programming Language
 
-    Copyright (C) 2006 - 2024 Qore Technologies, s.r.o.
+    Copyright (C) 2006 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -405,6 +405,14 @@ int QoreSQLStatement::execIntern(DBActionHelper& dba, ExceptionSink* xsink) {
     }
 
     int rc = qore_dbi_private::get(*priv->ds->getDriver())->stmt_exec(this, xsink);
+#ifdef DEBUG
+    // a prepared statement carries the same declaration as any other operation, so it reaches the
+    // same armed replay-safe boundary; this runs before the status is set so that the statement is
+    // left exactly as a driver-side connection abort would leave it
+    if (!rc && !*xsink && dsp->dbgCheckArmedFault(SQL_MUTATION_FAULT_AFTER_EXEC, xsink)) {
+        rc = -1;
+    }
+#endif
     if (!rc)
         status = STMT_EXECED;
 

--- a/lib/SqlMutationContext.cpp
+++ b/lib/SqlMutationContext.cpp
@@ -287,6 +287,38 @@ void SqlMutationContext::getNewTransactionId(std::string& tx_id) {
     tx_id = buf;
 }
 
+#ifdef DEBUG
+void SqlMutationContext::dbgArmFault(const char* op_id, int when) {
+    AutoLocker al(m);
+    if (when == SQL_MUTATION_FAULT_NONE || !op_id || !*op_id) {
+        dbg_fault_op_id.clear();
+        dbg_fault_when = SQL_MUTATION_FAULT_NONE;
+        dbg_fault_armed.store(false, std::memory_order_relaxed);
+        return;
+    }
+    dbg_fault_op_id = op_id;
+    dbg_fault_when = when;
+    dbg_fault_armed.store(true, std::memory_order_relaxed);
+}
+
+int SqlMutationContext::dbgTakeArmedFault(const char* op_id) {
+    if (!op_id || !*op_id || !dbg_fault_armed.load(std::memory_order_relaxed)) {
+        return SQL_MUTATION_FAULT_NONE;
+    }
+    AutoLocker al(m);
+    if (dbg_fault_op_id != op_id) {
+        // an operation the test did not arm must never be disturbed
+        return SQL_MUTATION_FAULT_NONE;
+    }
+    const int when = dbg_fault_when;
+    // one-shot: the arming is consumed by the operation it matched
+    dbg_fault_op_id.clear();
+    dbg_fault_when = SQL_MUTATION_FAULT_NONE;
+    dbg_fault_armed.store(false, std::memory_order_relaxed);
+    return when;
+}
+#endif
+
 int SqlMutationContext::dispatch(const SqlMutationEvent& ev, const Datasource& ds, ExceptionSink* xsink) {
     assert(xsink);
 

--- a/lib/SqlMutationContext.cpp
+++ b/lib/SqlMutationContext.cpp
@@ -301,21 +301,23 @@ void SqlMutationContext::dbgArmFault(const char* op_id, int when) {
     dbg_fault_armed.store(true, std::memory_order_relaxed);
 }
 
-int SqlMutationContext::dbgTakeArmedFault(const char* op_id) {
-    if (!op_id || !*op_id || !dbg_fault_armed.load(std::memory_order_relaxed)) {
-        return SQL_MUTATION_FAULT_NONE;
+bool SqlMutationContext::dbgTakeArmedFault(const char* op_id, int when) {
+    if (!op_id || !*op_id || when == SQL_MUTATION_FAULT_NONE
+        || !dbg_fault_armed.load(std::memory_order_relaxed)) {
+        return false;
     }
     AutoLocker al(m);
-    if (dbg_fault_op_id != op_id) {
-        // an operation the test did not arm must never be disturbed
-        return SQL_MUTATION_FAULT_NONE;
+    // the arming is consumed only when the operation and the boundary both match: an operation
+    // passes several boundaries, so consuming it on the operation alone would let an earlier
+    // boundary silently swallow an arming meant for a later one
+    if (dbg_fault_op_id != op_id || dbg_fault_when != when) {
+        return false;
     }
-    const int when = dbg_fault_when;
-    // one-shot: the arming is consumed by the operation it matched
+    // one-shot: the arming is consumed by the boundary it matched
     dbg_fault_op_id.clear();
     dbg_fault_when = SQL_MUTATION_FAULT_NONE;
     dbg_fault_armed.store(false, std::memory_order_relaxed);
-    return when;
+    return true;
 }
 #endif
 

--- a/lib/ql_debug.cpp
+++ b/lib/ql_debug.cpp
@@ -38,7 +38,12 @@
 #include "qore/intern/ql_type.h"
 #include "qore/intern/AsyncIoControllerPriv.h"
 #include "qore/intern/QC_Counter.h"
+#include "qore/intern/QC_Datasource.h"
+#include "qore/intern/QC_DatasourcePool.h"
 #include "qore/intern/QC_Socket.h"
+#include "qore/intern/DatasourcePool.h"
+#include "qore/intern/ManagedDatasource.h"
+#include "qore/intern/SqlMutationContext.h"
 #include "qore/intern/QC_Future.h"
 #include "qore/intern/QC_FutureImpl.h"
 #include "qore/intern/QoreHttp1ClientConnection.h"
@@ -2962,6 +2967,70 @@ static QoreValue f_dbg_force_fd_swap_next_wait(const QoreListNode* params, Runti
     sock->dbgForceFdSwapNextWait();
     return QoreValue();
 }
+
+//! Debug-only: arm a one-shot connection abort for an exact mutation \c "op_id".
+/** A consumer of the datasource mutation observer cannot otherwise produce a structural
+    LOST_CONNECTION outcome on a real driver: connection_aborted is settable only from inside a
+    driver, and the mock dbitest driver is not installed, so it cannot serve an end-to-end test
+    against a real database server.
+
+    The abort itself is real, not simulated: it runs the ordinary
+    Datasource::connectionAborted() path, which ends the transaction, marks the connection aborted
+    and closes it, so the server discards the in-flight transaction exactly as it would on a genuine
+    connection loss.  The outcome the observer then sees is produced by the existing classification
+    code with no special casing.
+
+    Because the abort is applied at the core boundary rather than inside a driver, it works
+    identically on every DBI driver.
+
+    The arming is stored on the shared mutation context, so arming a DatasourcePool covers whichever
+    pooled connection the calling thread is allocated.
+
+    @param ds the Datasource or DatasourcePool to arm
+    @param op_id the exact declared operation identity to abort on; an empty string disarms
+    @param when the boundary; see @ref sql_mutation_debug_fault_codes
+ */
+static QoreValue f_dbg_ds_arm_connection_abort(const QoreListNode* params, RuntimeConfig& rc,
+        ExceptionSink* xsink) {
+    const QoreObject* obj = get_param_value(params, 0).get<const QoreObject>();
+    if (!obj) {
+        xsink->raiseException("DBG-ARGUMENT-ERROR",
+            "dbg_ds_arm_connection_abort() requires an AbstractDatasource argument");
+        return QoreValue();
+    }
+    const QoreStringNode* op_id = get_param_value(params, 1).get<const QoreStringNode>();
+    const int when = (int)get_param_value(params, 2).getAsBigInt();
+
+    QoreObject* o = const_cast<QoreObject*>(obj);
+    SqlMutationContext* ctx = nullptr;
+
+    ReferenceHolder<ManagedDatasource> mds(
+        reinterpret_cast<ManagedDatasource*>(o->getReferencedPrivateData(CID_DATASOURCE, xsink)), xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    if (mds) {
+        ctx = mds->getOrCreateMutationContext();
+    } else {
+        ReferenceHolder<DatasourcePool> dsp(
+            reinterpret_cast<DatasourcePool*>(o->getReferencedPrivateData(CID_DATASOURCEPOOL, xsink)), xsink);
+        if (*xsink) {
+            return QoreValue();
+        }
+        if (!dsp) {
+            xsink->raiseException("DBG-ARGUMENT-ERROR", "dbg_ds_arm_connection_abort() requires a Datasource "
+                "or DatasourcePool argument; got an object of class '%s'", o->getClassName());
+            return QoreValue();
+        }
+        // the pool owns the context under its own lock, so it does the arming itself
+        dsp->dbgArmConnectionAbort(op_id ? op_id->c_str() : nullptr, when);
+        return QoreValue();
+    }
+
+    assert(ctx);
+    ctx->dbgArmFault(op_id ? op_id->c_str() : nullptr, when);
+    return QoreValue();
+}
 #endif
 
 // --- code flag oracle (debug builds only) ---
@@ -3184,6 +3253,11 @@ void init_debug_functions(QoreNamespace& qns) {
     qns.addBuiltinVariant("dbg_force_fd_swap_next_wait", f_dbg_force_fd_swap_next_wait,
         QCF_NO_FLAGS, QDOM_DEFAULT, nothingTypeInfo, 1,
         QC_SOCKET->getTypeInfo(), QORE_PARAM_NO_ARG, "sock");
+    qns.addBuiltinVariant("dbg_ds_arm_connection_abort", f_dbg_ds_arm_connection_abort,
+        QCF_NO_FLAGS, QDOM_DEFAULT, nothingTypeInfo, 3,
+        QC_ABSTRACTDATASOURCE->getTypeInfo(), QORE_PARAM_NO_ARG, "ds",
+        stringTypeInfo, QORE_PARAM_NO_ARG, "op_id",
+        bigIntTypeInfo, QORE_PARAM_NO_ARG, "when");
 #endif
 
     // code flag oracle; the mask on each of these is the point of the declaration, so it must match

--- a/lib/ql_debug.cpp
+++ b/lib/ql_debug.cpp
@@ -3002,33 +3002,33 @@ static QoreValue f_dbg_ds_arm_connection_abort(const QoreListNode* params, Runti
     const int when = (int)get_param_value(params, 2).getAsBigInt();
 
     QoreObject* o = const_cast<QoreObject*>(obj);
-    SqlMutationContext* ctx = nullptr;
 
-    ReferenceHolder<ManagedDatasource> mds(
-        reinterpret_cast<ManagedDatasource*>(o->getReferencedPrivateData(CID_DATASOURCE, xsink)), xsink);
+    // probe for each supported class with tryGetReferencedPrivateData(), which returns nullptr on a
+    // class mismatch instead of raising; getReferencedPrivateData() would raise OBJECT-INCOMPATIBLE
+    // on the first probe and make the second unreachable
+    ReferenceHolder<ManagedDatasource> mds(o->tryGetReferencedPrivateData<ManagedDatasource>(CID_DATASOURCE, xsink),
+        xsink);
     if (*xsink) {
         return QoreValue();
     }
     if (mds) {
-        ctx = mds->getOrCreateMutationContext();
-    } else {
-        ReferenceHolder<DatasourcePool> dsp(
-            reinterpret_cast<DatasourcePool*>(o->getReferencedPrivateData(CID_DATASOURCEPOOL, xsink)), xsink);
-        if (*xsink) {
-            return QoreValue();
-        }
-        if (!dsp) {
-            xsink->raiseException("DBG-ARGUMENT-ERROR", "dbg_ds_arm_connection_abort() requires a Datasource "
-                "or DatasourcePool argument; got an object of class '%s'", o->getClassName());
-            return QoreValue();
-        }
+        mds->getOrCreateMutationContext()->dbgArmFault(op_id ? op_id->c_str() : nullptr, when);
+        return QoreValue();
+    }
+
+    ReferenceHolder<DatasourcePool> dsp(o->tryGetReferencedPrivateData<DatasourcePool>(CID_DATASOURCEPOOL, xsink),
+        xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    if (dsp) {
         // the pool owns the context under its own lock, so it does the arming itself
         dsp->dbgArmConnectionAbort(op_id ? op_id->c_str() : nullptr, when);
         return QoreValue();
     }
 
-    assert(ctx);
-    ctx->dbgArmFault(op_id ? op_id->c_str() : nullptr, when);
+    xsink->raiseException("DBG-ARGUMENT-ERROR", "dbg_ds_arm_connection_abort() requires a Datasource or "
+        "DatasourcePool argument; got an object of class '%s'", o->getClassName());
     return QoreValue();
 }
 #endif

--- a/modules/dbi_test/src/dbi_test-module.cpp
+++ b/modules/dbi_test/src/dbi_test-module.cpp
@@ -139,7 +139,10 @@ static int dbitest_run_copy(Datasource* ds, int64 total_bytes, int64 chunk, Exce
     if (chunk <= 0) {
         chunk = 4096;
     }
+    DbiTestConn* conn = get_conn(ds);
     if (ds->reportMutationStreamBegin(total_bytes, xsink)) {
+        // the consumer refused the stream before it started; a real driver sends nothing and
+        // reports no end boundary of its own
         return -1;
     }
     int64 consumed = 0;
@@ -147,6 +150,15 @@ static int dbitest_run_copy(Datasource* ds, int64 total_bytes, int64 chunk, Exce
         consumed += chunk;
         if (consumed > total_bytes) {
             consumed = total_bytes;
+        }
+        if (conn->faultIs("stream") && consumed >= total_bytes / 2) {
+            // the server failed while the payload was being sent; this is a driver failure and not
+            // a consumer rejection, and the two must remain distinguishable at the end boundary
+            xsink->raiseException("DBI-TEST-STREAM-ERROR", "injected stream failure");
+            ExceptionSink end_xsink;
+            ds->reportMutationStreamEnd(consumed, false, &end_xsink);
+            end_xsink.clear();
+            return -1;
         }
         if (ds->reportMutationStreamProgress(consumed, xsink)) {
             // the caller aborted the stream; report the end so that the consumer sees the boundary
@@ -473,7 +485,7 @@ static void dbitest_module_init(QoreModuleInitContext& ctx, ExceptionSink& xsink
     methods.add(QDBI_METHOD_OPT_GET, dbitest_opt_get);
 
     methods.registerOption(DBITEST_OPT_FAULT, "the fault to inject: \"\", \"select\", \"exec\", \"commit\", "
-        "\"rollback\", \"abort-on-exec\", \"abort-on-commit\", or \"stmt-exec\"", stringTypeInfo);
+        "\"rollback\", \"abort-on-exec\", \"abort-on-commit\", \"stmt-exec\", or \"stream\"", stringTypeInfo);
     methods.registerOption(DBITEST_OPT_ROWS, "the number of rows reported as affected by exec operations",
         bigIntTypeInfo);
     methods.registerOption(DBITEST_OPT_STREAM_CHUNK, "the chunk size in bytes used by the simulated bounded stream",

--- a/qlib/BulkSqlUtil/AbstractBulkOperation.qc
+++ b/qlib/BulkSqlUtil/AbstractBulkOperation.qc
@@ -81,11 +81,14 @@ on_error ds.rollback();
                 "block_size": sprintf("the row block size used for bulk DML / batch operations; default: %y",
                     OptionDefaults.block_size),
                 "info_log": "a call reference / closure for informational logging",
+                "stream_bounds": sprintf("report the operation as a bounded stream to a datasource mutation "
+                    "observer, if one is registered; default: %y", OptionDefaults.stream_bounds),
             };
 
             #! default option values
-            const hash<string, int> OptionDefaults = {
+            const hash<string, auto> OptionDefaults = {
                 "block_size": 1000,
+                "stream_bounds": True,
             };
         }
 
@@ -122,6 +125,15 @@ on_error ds.rollback();
 
             #! True when input_keys has been initialized, including by an empty record
             bool input_template_set = False;
+
+            #! True if this operation reports itself as a bounded stream when an observer is present
+            bool stream_bounds;
+
+            #! True once the stream begin boundary has been reported
+            bool stream_started = False;
+
+            #! total payload bytes reported to the observer so far
+            int stream_consumed = 0;
         }
 
         #! creates the object from the supplied arguments
@@ -131,6 +143,8 @@ on_error ds.rollback();
             - \c "block_size": the number of rows executed at once (default: 1000)
             - \c "info_log": an optional info logging callback; must accept a string format specifier and sprintf()-
               style arguments
+            - \c "stream_bounds": report the operation as a bounded stream to a datasource mutation observer, if one
+              is registered (default: @ref True "True"); see @ref bulk_bounded_streams
         */
         constructor(string name, SqlUtil::Table target, *hash opts) {
             opname = name;
@@ -145,6 +159,8 @@ on_error ds.rollback();
             - \c "block_size": the number of rows executed at once (default: 1000)
             - \c "info_log": an optional info logging callback; must accept a string format specifier and sprintf()-
               style arguments
+            - \c "stream_bounds": report the operation as a bounded stream to a datasource mutation observer, if one
+              is registered (default: @ref True "True"); see @ref bulk_bounded_streams
         */
         constructor(string name, SqlUtil::AbstractTable target, *hash opts) {
             opname = name;
@@ -157,8 +173,15 @@ on_error ds.rollback();
             discard() before destroying the object
         */
         destructor() {
-            if (hbuf.firstValue())
+            if (hbuf.firstValue()) {
+                # the operation is being destroyed with data it never wrote, so the stream did not
+                # complete; the boundary is reported before the error is raised
+                streamEnd(False);
                 throw "BLOCK-ERROR", sprintf("there %s still %d row%s of data in the internal cache; make sure to call %s::flush() or %s::discard() before destroying the object to flush all data to the database", hbuf.firstValue().size() == 1 ? "is" : "are", hbuf.firstValue().size(), hbuf.firstValue().size() == 1 ? "" : "s", self.className(), self.className());
+            }
+            # backstop for callers that commit on the datasource directly rather than through
+            # commit() or endStream(); everything queued was written
+            streamEnd(True);
         }
 
         #! queues row data in the block buffer; the block buffer is flushed to the DB if the buffer size reaches the limit defined by the \c block_size option; does not commit the transaction
@@ -388,6 +411,94 @@ on_error ds.rollback();
 
             if (opts.info_log)
                 info_log = opts.info_log;
+
+            stream_bounds = exists opts.stream_bounds
+                ? parse_boolean(opts.stream_bounds)
+                : OptionDefaults.stream_bounds;
+        }
+
+        #! reports the begin boundary of the bounded stream if it has not been reported yet
+        /** The boundary is reported lazily from the first flush, so an operation that never writes
+            anything reports nothing at all.
+
+            @throw SQL-MUTATION-REJECTED the observer refused the operation; the error code and
+            description are supplied by the observer
+        */
+        private streamBegin() {
+            if (stream_started || !stream_bounds) {
+                return;
+            }
+            AbstractDatasource ds = table.getDatasource();
+            if (!ds.hasMutationObserver()) {
+                return;
+            }
+            # a rejection here throws, and nothing has been written yet
+            ds.reportMutationStreamBegin(0);
+            stream_started = True;
+        }
+
+        #! reports progress after a block has been written; throws if the observer stops the stream
+        /** This is an admission point: an observer that has seen more bytes than it will admit stops
+            the operation here, before the surrounding transaction can commit.
+
+            @param bytes the payload size of the block just written
+        */
+        private streamProgress(int bytes) {
+            if (!stream_started) {
+                return;
+            }
+            stream_consumed += bytes;
+            table.getDatasource().reportMutationStreamProgress(stream_consumed);
+        }
+
+        #! reports the end boundary of the bounded stream exactly once
+        /** @param ok False if the operation did not complete successfully
+        */
+        private streamEnd(bool ok) {
+            if (!stream_started) {
+                return;
+            }
+            # cleared first so that the boundary can never be reported twice, even if the observer
+            # raises an exception from it
+            stream_started = False;
+            table.getDatasource().reportMutationStreamEnd(stream_consumed, ok);
+        }
+
+        #! returns the payload size in bytes of the buffered block about to be written
+        /** The measure is the serialized size of the values themselves, which is the same measure a
+            producer uses to compute the \c "max_growth_bytes" of its declaration, so that declared
+            and consumed byte counts are comparable.
+
+            @return the total payload size in bytes of the current block
+        */
+        private int getBlockBytes() {
+            int bytes = 0;
+            foreach auto vals in ((hbuf + cval).iterator()) {
+                if (vals.typeCode() == NT_LIST) {
+                    map bytes += getValueBytes($1), vals;
+                } else {
+                    # a constant column value is repeated once per row in the block
+                    bytes += getValueBytes(vals) * hbuf.firstValue().lsize();
+                }
+            }
+            return bytes;
+        }
+
+        #! returns the serialized size in bytes of a single bound value
+        private int getValueBytes(auto val) {
+            switch (val.typeCode()) {
+                case NT_NOTHING:
+                case NT_NULL:
+                    # the canonical representation of a NULL
+                    return 2;
+                case NT_STRING:
+                    return val.strlen();
+                case NT_BINARY:
+                    return val.size();
+                case NT_BOOLEAN:
+                    return 1;
+            }
+            return sprintf("%s", val).strlen();
         }
 
         #! sets up the block buffer given the initial template hash of lists for inserting
@@ -529,6 +640,14 @@ on_error ds.rollback();
 
         #! flushes queued data to the database
         private flushIntern() {
+            # report the stream boundary before anything is written, so that an observer that
+            # refuses the operation stops it before the first row reaches the database
+            streamBegin();
+            int bytes = stream_started ? getBlockBytes() : 0;
+
+            # any failure from here on ends the stream; the boundary is reported exactly once
+            on_error streamEnd(False);
+
             # flush data to the DB; implemented in subclasses
             flushImpl();
             # update row count
@@ -539,6 +658,10 @@ on_error ds.rollback();
                     row_count);
             # reset internal buffer
             map hbuf.$1 = (), keys hbuf;
+
+            # this is an admission point: an observer that has seen more than it will admit stops
+            # the operation here, after this block and before the transaction can commit
+            streamProgress(bytes);
         }
 
         #! discards any buffered batched data; this method should be called before destroying the object if an error occurs
@@ -576,11 +699,49 @@ on_error ds.rollback();
         */
         discard() {
             delete hbuf;
+            # the operation is being abandoned, so anything already written is not going to be
+            # committed by it
+            streamEnd(False);
+        }
+
+        #! reports the end of the bounded stream without flushing or ending the transaction
+        /** Call this before committing when the transaction is committed on the datasource directly
+            rather than through commit(), so that a mutation observer sees the stream's end boundary
+            before the transaction outcome rather than after it.  It is a no-op when no stream is in
+            progress, and calling it more than once is harmless.
+
+            @par Example:
+            @code{.py}
+{
+    on_success {
+        op.flush();
+        op.endStream();
+        ds.commit();
+    }
+    on_error {
+        op.discard();
+        ds.rollback();
+    }
+    map op.queueData($1), data.iterator();
+}
+            @endcode
+
+            @see
+            - flush()
+            - discard()
+
+            @since %BulkSqlUtil 1.5
+        */
+        endStream() {
+            streamEnd(True);
         }
 
         #! flushes any queued data and commits the transaction
         nothing commit() {
             flush();
+            # the stream boundary is reported before the transaction outcome, so that a consumer
+            # sees the operation close before the commit it belongs to
+            streamEnd(True);
             table.commit();
         }
 

--- a/qlib/BulkSqlUtil/BulkInsertOperation.qc
+++ b/qlib/BulkSqlUtil/BulkInsertOperation.qc
@@ -100,6 +100,8 @@ on_error ds.rollback();
             @param opts an optional hash of options for the object as follows:
             - \c "info_log": an optional info logging callback; must accept a string format specifier and sprintf()-
               style arguments
+            - \c "stream_bounds": report the operation as a bounded stream to a datasource mutation observer, if one
+              is registered (default: @ref True "True"); see @ref bulk_bounded_streams
             - \c "block_size": the number of rows executed at once (default: 1000)
             - \c "returning": optional column names or returning descriptors to retrieve for every inserted row
             - \c "rowcode": a per-row @ref closure or @ref call_reference for batch inserts; this must take a single
@@ -117,6 +119,8 @@ on_error ds.rollback();
             @param opts an optional hash of options for the object as follows:
             - \c "info_log": an optional info logging callback; must accept a string format specifier and sprintf()-
               style arguments
+            - \c "stream_bounds": report the operation as a bounded stream to a datasource mutation observer, if one
+              is registered (default: @ref True "True"); see @ref bulk_bounded_streams
             - \c "block_size": the number of rows executed at once (default: 1000)
             - \c "returning": optional column names or returning descriptors to retrieve for every inserted row
             - \c "rowcode": a per-row @ref closure or @ref call_reference for batch inserts; this must take a single

--- a/qlib/BulkSqlUtil/BulkSqlUtil.qm
+++ b/qlib/BulkSqlUtil/BulkSqlUtil.qm
@@ -36,7 +36,7 @@
 %requires(reexport) SqlUtil
 
 module BulkSqlUtil {
-    version = "1.4";
+    version = "1.5";
     desc = "user module performing bulk DML operations with SqlUtil";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -66,7 +66,46 @@ module BulkSqlUtil {
 
     See the above classes for detailed information and examples.
 
+    @section bulk_bounded_streams Bounded Streams
+
+    A bulk operation writes its data incrementally, one \c block_size block at a time, so it is a
+    bounded stream in the sense of the
+    @ref Qore::SQL::AbstractDatasource::setMutationObserver() "datasource mutation observer": it reports a
+    @ref Qore::SQL::SQL_MUTATION_EVENT_STREAM_BEGIN "STREAM_BEGIN" boundary before the first block reaches the
+    database, a @ref Qore::SQL::SQL_MUTATION_EVENT_STREAM_PROGRESS "STREAM_PROGRESS" event after each block, and a
+    @ref Qore::SQL::SQL_MUTATION_EVENT_STREAM_END "STREAM_END" boundary when the operation ends.
+
+    \c STREAM_BEGIN and \c STREAM_PROGRESS are admission points, so an observer can stop a bulk operation that has
+    written more than it will admit.  Because progress is reported after each block rather than at the end, the
+    operation is stopped <b>before the surrounding transaction can commit</b>, and the rows already written are
+    discarded by the caller's rollback.
+
+    Two properties make this useful in practice:
+    - it is driver-neutral: the reporting is implemented over the ordinary block flush path, so it does not depend
+      on a native bulk-load mechanism such as PostgreSQL \c COPY, and it behaves identically on DBI drivers with and
+      without @ref Qore::SQL::DBI_CAP_HAS_ARRAY_BIND "array bind" support
+    - it costs nothing when unused: no events are reported unless a mutation observer is registered on the
+      datasource, so operations on unmonitored datasources behave exactly as before
+
+    The consumed byte count is the serialized size of the values written, which is the same measure a producer uses
+    to compute the \c "max_growth_bytes" of its declaration, so declared and consumed byte counts are comparable.
+
+    Reporting can be turned off per operation with the \c "stream_bounds" option.  When the transaction is committed
+    on the datasource directly rather than through
+    @ref BulkSqlUtil::AbstractBulkOperation::commit() "AbstractBulkOperation::commit()", call
+    @ref BulkSqlUtil::AbstractBulkOperation::endStream() "AbstractBulkOperation::endStream()" first so that the
+    observer sees the stream's end boundary before the transaction outcome.
+
     @section bulksqlutil_relnotes Release Notes
+
+    @subsection bulksqlutil_v1_5 BulkSqlUtil v1.5
+    - bulk operations now report themselves as bounded streams to a datasource mutation observer, so that an
+      observer can stop an operation that exceeds what it will admit before the transaction commits; see
+      @ref bulk_bounded_streams
+    - added @ref BulkSqlUtil::AbstractBulkOperation::endStream() "AbstractBulkOperation::endStream()" and the
+      \c "stream_bounds" option
+    - the type of @ref BulkSqlUtil::AbstractBulkOperation::OptionDefaults "AbstractBulkOperation::OptionDefaults"
+      widened from \c hash<string, int> to \c hash<string, auto> to carry the boolean \c "stream_bounds" default
 
     @subsection bulksqlutil_v1_4 BulkSqlUtil v1.4
     - bulk inserts now forward caller-requested \c returning columns through every flush block and deliver each

--- a/qlib/BulkSqlUtil/BulkUpsertOperation.qc
+++ b/qlib/BulkSqlUtil/BulkUpsertOperation.qc
@@ -1,7 +1,7 @@
 # -*- mode: qore; indent-tabs-mode: nil -*-
 #! Qore BulkUpsertOperation class definition
 
-/*  BulkUpsertOperation.qc Copyright 2015 - 2024 Qore Technologies, s.r.o.
+/*  BulkUpsertOperation.qc Copyright 2015 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -85,6 +85,8 @@ on_error ds.rollback();
             - \c "block_size": the number of rows executed at once (default: 1000)
             - \c "info_log": an optional info logging callback; must accept a string format specifier and sprintf()-
               style arguments
+            - \c "stream_bounds": report the operation as a bounded stream to a datasource mutation observer, if one
+              is registered (default: @ref True "True"); see @ref bulk_bounded_streams
             - \c "upsert_strategy": the upsert strategy to use; default SqlUtil::AbstractTable::UpsertAuto; see
               @ref upsert_options for possible values for the upsert strategy
         */
@@ -97,6 +99,8 @@ on_error ds.rollback();
             - \c "block_size": the number of rows executed at once (default: 1000)
             - \c "info_log": an optional info logging callback; must accept a string format specifier and sprintf()-
               style arguments
+            - \c "stream_bounds": report the operation as a bounded stream to a datasource mutation observer, if one
+              is registered (default: @ref True "True"); see @ref bulk_bounded_streams
             - \c "upsert_strategy": the upsert strategy to use; default SqlUtil::AbstractTable::UpsertAuto; see
               @ref upsert_options for possible values for the upsert strategy
         */


### PR DESCRIPTION
Implements Phase 1 of #5389, plus one unrelated crash fix found along the way.

Phase 1 gives the datasource mutation observer the three things a consumer needs to reconcile a
managed write durably, and it lands entirely in this repository — no driver work, no module
releases, and no dependency on a native bulk-load mechanism such as PostgreSQL `COPY`.

## 1. Terminal `NOT_EXECUTED` outcome for a rejected mutation

`SQL_MUTATION_OUTCOME_NOT_EXECUTED` was declared and exported but assigned nowhere, and
`design/datasource-mutation-observer.md` contradicted itself about it — the outcome table listed it
for a rejected admission, the admission-events section said it was deliberately not emitted.

The hole that left is real: when an admission point rejects an operation with **no transaction
open** — autocommit, or before `TX_BEGIN` — no rollback follows, so no `OUTCOME` event is ever
emitted and the admission event is left unpaired. A consumer tracking reservations by `op_id` then
has no event-driven boundary at which to release the reservation.

Every rejected admission point is now followed by exactly one terminal event carrying
`NOT_EXECUTED` and `replay_safe` `True`, for both an explicit `admit: False` decision and a
fail-closed observer exception:

| Rejected at | Terminal event | Emitted by |
|---|---|---|
| `PRE_EXEC` | `POST_EXEC`, carrying the rejected event's statement class so it is gated by the same mask bit | the core |
| `STREAM_BEGIN` | `STREAM_END` | the core — the producer never started the stream, so it reports no end boundary of its own |
| `STREAM_PROGRESS` | `STREAM_END` | the producer, which is required to report the end of a stream it started |

That last row needed a different mechanism than the others: emitting from the core would have
duplicated the producer's own `STREAM_END`. Instead the core records the rejection and maps
`reportMutationStreamEnd(consumed, False)` to `NOT_EXECUTED` rather than `ERROR` — which
incidentally gives consumers a distinction they did not have before. On a stream, `ERROR` now means
*the database failed while the payload was being sent*, and `NOT_EXECUTED` means *the consumer
stopped it*.

The terminal event cannot be emitted from `SqlMutationContext::dispatch()`, where the re-entrancy
depth that suppresses observer-issued operations is still held; it is emitted from the dispatch
wrapper after that depth is released, which also makes it structurally unable to re-enter the
callback that produced the rejection.

## 2. Debug-only `op_id`-keyed connection abort

There was no way to produce a structural `LOST_CONNECTION` outcome on a real driver:
`connection_aborted` is settable only from inside a driver, and the only driver that can be made to
fail on command is the `dbitest` mock, which is deliberately not installed and so cannot stand in
for a real database in an end-to-end test.

A debug build now registers one builtin:

```qore
dbg_ds_arm_connection_abort(AbstractDatasource ds, string op_id, int when);
```

One-shot, armed against an exact declared `op_id`, at either the after-exec boundary
(`LOST_CONNECTION` + `replay_safe` `True`) or the commit boundary (`COMMIT_AMBIGUOUS`, triggered with
`commit_in_progress` set). An arming that does not match the current operation is left untouched, and
a match consumes it.

The outcome is real, not simulated: the abort runs the ordinary `connectionAborted()` path, so the
connection is really closed and the server really discards the in-flight transaction, and the
resulting outcome comes from the existing classification code with no special casing. Because the
abort is applied at the core boundary rather than inside a driver, it behaves identically on every
DBI driver — the PostgreSQL test asserts that neither row written before the abort survived it.

The arming lives on the `SqlMutationContext`, which a `DatasourcePool` shares with every connection
it pools, so a test can arm the pool without knowing which connection its thread will be allocated.

Everything is under `#ifdef DEBUG`: a release build registers no function and carries no fault
state. Tests call it via `call_function()` and skip when absent, following the
`dbg_force_fd_swap_next_wait()` precedent, so a release-build run skips rather than failing to parse.

## 3. Bulk operations reported as bounded streams

The core stream API was complete on both sides and `module-pgsql` calls it from its COPY path, but
nothing in SqlUtil or BulkSqlUtil ever used it, and that COPY path is only reachable by handing the
driver raw `COPY ... FROM STDIN` SQL.

A bulk operation already writes incrementally, one `block_size` block at a time, so it *is* a bounded
stream. It now reports itself as one: `STREAM_BEGIN` before the first block reaches the database,
`STREAM_PROGRESS` after each block, `STREAM_END` when the operation ends.

Because `STREAM_PROGRESS` is an admission point reported after every block rather than once at the
end, an observer stops the operation **before the surrounding transaction can commit**. The test
proves this directly by counting the rows visible inside the uncommitted transaction and asserting
some, but not all, were written.

Two properties matter:

- **driver-neutral** — the reporting sits in `AbstractBulkOperation::flushIntern()`, above
  `flushImpl()`, so it does not depend on a native bulk-load mechanism and behaves identically on
  drivers with and without `DBI_CAP_HAS_ARRAY_BIND`, which `BulkInsertOperation::flushImpl()` already
  handles on both paths
- **free when unused** — nothing is reported unless an observer is registered, so unmonitored
  operations are unaffected

`commit()` reports the end boundary before the transaction outcome, and `endStream()` is added for
callers that commit on the datasource directly, so a consumer sees the operation close before the
commit it belongs to. `stream_bounds` turns the reporting off. BulkSqlUtil goes to 1.5.

## 4. Unrelated crash fix

Found while testing the above, but independent of it — a bound-but-never-executed `SQLStatement`
crashed the process:

```qore
Datasource ds("pgsql:user/pass@db");
ds.setAutoCommit(False);
ds.open();
{
    SQLStatement stmt(ds);
    stmt.prepare("select 1 where 1 = %v");
    stmt.bind(1);          # bound, never executed
}
printf("done\n");          # prints, then SIGSEGV at exit
```

`ManagedDatasource::endDBActionIntern()` registers the datasource as a thread resource whenever this
thread acquires the connection, which `bind()` does without starting a transaction.
`closeUnlocked()` removed that resource only inside its `if (isInTransaction())` branch, so closing
in that state left it registered while `Datasource::close()` freed the driver's connection data; the
thread's later cleanup then ran the driver's rollback against freed memory. `cleanup()` also
asserted `isInTransaction()`, so a debug build aborted on the assertion instead.

The invariant is that the thread resource tracks *the connection being held by this thread*, not *a
transaction being in progress*. Both places that maintain it are fixed. Leaving the lock held would
also have kept every other thread from ever reopening the datasource.

This is a core defect, not a driver one: it reproduces identically on `pgsql` and on `dbitest`, with
no mutation observer involved, and on released versions of the library.

## Testing

- release and debug builds; `BulkSqlUtil-qmod` and `docs-BulkSqlUtil` rebuilt
- full suite green; targeted: `qore/classes/{Datasource,DatasourcePool,SQLStatement}` and
  `qlib/{SqlUtil,DbDataProvider,DataProvider}`
- new coverage: 4 `dbitest` fault cases, 6 `BulkSqlUtilStream` cases, 5 statement-lifecycle cases,
  and 2 real-PostgreSQL cases (replay-safe failover, terminal `NOT_EXECUTED`)
- the crash regression test was verified to fail without its fix
- debug-only cases verified to skip, not fail, in a release build

## Notes for review

- `AbstractBulkOperation::OptionDefaults` widened from `hash<string, int>` to `hash<string, auto>` to
  carry the boolean `stream_bounds` default; noted in the release notes
- `mutation-observer.qtest`, `mutation-observer-pgsql.qtest`, `mutation-stream.qtest` and
  `mutation-observer-stmt.qtest` previously asserted the *absence* of the terminal event; those
  assertions are updated to the new contract rather than removed
- Phase 2 of #5389 (native COPY / direct-path / `LOAD DATA` / BCP fast paths) is deliberately not
  included; it is a per-driver performance project and is not required by the consumer

Closes part of #5389.
