### PR TITLE
fix(GroqDataProvider): stop referencing hardcoded Groq model names

### DIFF
--- a/examples/test/qlib/GroqDataProvider/GroqDataProvider.qtest
+++ b/examples/test/qlib/GroqDataProvider/GroqDataProvider.qtest
@@ -61,6 +61,9 @@ public class GroqDataProviderTest inherits QUnit::Test {
         };
 
         const OptionColumn = 22;
+
+        #! Maximum live models to try before failing the live chat test
+        const MaxLiveChatAttempts = 8;
     }
 
     private {
@@ -77,12 +80,14 @@ public class GroqDataProviderTest inherits QUnit::Test {
         addTestCase("chat-completion sends OpenAI-shape body, "
             "converts Unix created field, preserves LPU usage timings",
             \chatRequestTest());
+        addTestCase("list-models provider lists models",    \listModelsTest());
+        addTestCase("models exposed as reference data",     \referenceDataTest());
         addTestCase("request type schema is enforceable",   \requestSchemaTest());
 
         # Live test requires a real Groq connection.
-        # Cost: 1 token-bounded llama-3.1-8b-instant request (free tier eligible).
+        # Cost: 1 token-bounded chat request (free tier eligible) + model list GETs.
         if (conn_name) {
-            addTestCase("live: ping + chat-completion (llama-3.1-8b-instant)",
+            addTestCase("live: ping + list-models + chat-completion",
                 \liveGroqTest());
         }
         set_return_value(main());
@@ -119,14 +124,30 @@ public class GroqDataProviderTest inherits QUnit::Test {
         list<hash<DataProviderActionInfo>> actions = select
             DataProvider::DataProviderActionCatalog::getActions("Groq"),
             $1.action != AbstractDataProvider::GenericApiCallActionName;
-        assertEq(1, actions.size());
-        assertEq("chat-completion", actions[0].action);
-        assertEq("/chat-completion", actions[0].path);
-        assertEq(DPAT_API, actions[0].action_code);
-        assertTrue(exists actions[0].options.messages);
-        assertTrue(actions[0].options.messages.required);
-        assertTrue(exists actions[0].options.model);
-        assertTrue(actions[0].options.model.required);
+        assertEq(2, actions.size());
+        hash<string, hash<DataProviderActionInfo>> amap =
+            map {$1.action: $1}, actions;
+
+        hash<DataProviderActionInfo> chat = amap."chat-completion";
+        assertEq("/chat-completion", chat.path);
+        assertEq(DPAT_API, chat.action_code);
+        assertTrue(exists chat.options.messages);
+        assertTrue(chat.options.messages.required);
+        assertTrue(exists chat.options.model);
+        assertTrue(chat.options.model.required);
+        # the model option offers live values from the models endpoint but
+        # accepts any value the user enters
+        assertEq("models", chat.options.model.ref_data);
+        assertTrue(chat.options.model.allowed_values_creatable);
+        # no hardcoded model names offered: available models are fetched live
+        assertNothing(chat.options.model.allowed_values);
+        assertNothing(chat.options.model.example_value);
+
+        hash<DataProviderActionInfo> lm = amap."list-models";
+        assertEq("/list-models", lm.path);
+        assertEq(DPAT_API, lm.action_code);
+        assertFalse(lm.mutates_state);
+        assertTrue(exists lm.output_type);
     }
 
     private rootProviderTest() {
@@ -137,10 +158,13 @@ public class GroqDataProviderTest inherits QUnit::Test {
         # GenericApiCallAutoInjection.qtest in RestClientDataProvider)
         list<string> children = select prov.getChildProviderNames(),
             $1 != AbstractDataProvider::GenericApiCallChildName;
-        assertEq(("chat-completion",), children);
+        assertEq(("chat-completion", "list-models"), children);
         AbstractDataProvider chat = prov.getChildProvider("chat-completion");
         assertTrue(chat instanceof
             GroqDataProvider::GroqChatCompletionDataProvider);
+        AbstractDataProvider lm = prov.getChildProvider("list-models");
+        assertTrue(lm instanceof
+            GroqDataProvider::GroqListModelsDataProvider);
     }
 
     private chatProviderTest() {
@@ -160,7 +184,7 @@ public class GroqDataProviderTest inherits QUnit::Test {
             "id": "test-id",
             "object": "chat.completion",
             "created": 1700000000,
-            "model": "llama-3.3-70b-versatile",
+            "model": "test-model",
             "choices": (
                 {
                     "index": 0,
@@ -185,7 +209,7 @@ public class GroqDataProviderTest inherits QUnit::Test {
 
         GroqDataProvider::GroqChatCompletionDataProvider prov(fake);
         hash<auto> req = {
-            "model": "llama-3.3-70b-versatile",
+            "model": "test-model",
             "messages": (
                 {"role": "user", "content": "Hi"},
             ),
@@ -197,7 +221,7 @@ public class GroqDataProviderTest inherits QUnit::Test {
         assertEq("POST", fake.last_method);
         assertEq("chat/completions", fake.last_path);
         # Request body forwarded unchanged
-        assertEq("llama-3.3-70b-versatile", fake.last_request.model);
+        assertEq("test-model", fake.last_request.model);
         assertEq(0.7, fake.last_request.temperature);
         # Response shape + Unix-seconds to date conversion
         assertEq("test-id", resp.id);
@@ -212,6 +236,70 @@ public class GroqDataProviderTest inherits QUnit::Test {
         assertEq("req_abc123", resp.x_groq.id);
     }
 
+    private listModelsTest() {
+        FakeGroqRestClientIo fake();
+        fake.response_body = {
+            "object": "list",
+            "data": (
+                {
+                    "id": "test-model-a",
+                    "object": "model",
+                    "created": 1700000000,
+                    "owned_by": "Test Org",
+                    "active": True,
+                    "context_window": 8192,
+                },
+                {
+                    "id": "test-model-b",
+                    "object": "model",
+                    "created": 1700000001,
+                    "owned_by": "Test Org",
+                    "active": True,
+                    "context_window": 131072,
+                },
+            ),
+        };
+
+        GroqDataProvider::GroqListModelsDataProvider prov(fake);
+        assertEq("list-models", prov.getName());
+        hash<DataProviderInfo> info = prov.getInfo();
+        assertTrue(info.supports_request);
+        assertNothing(prov.getRequestType());
+        assertTrue(exists prov.getResponseType());
+
+        auto resp = prov.doRequest();
+        assertEq("GET", fake.last_method);
+        assertEq("models", fake.last_path);
+        assertEq("list", resp.object);
+        assertEq(2, resp."data".size());
+        assertEq("test-model-a", resp."data"[0].id);
+        # Unix-seconds created fields converted to dates
+        assertEq(NT_DATE, resp."data"[0].created.typeCode());
+        assertEq(1700000000, int(resp."data"[0].created - 1970-01-01Z));
+        assertEq(131072, resp."data"[1].context_window);
+    }
+
+    private referenceDataTest() {
+        FakeGroqRestClientIo fake();
+        fake.response_body = {
+            "object": "list",
+            "data": (
+                {"id": "test-model-a", "active": True},
+                {"id": "test-model-gone", "active": False},
+                {"id": "test-model-b"},
+            ),
+        };
+
+        GroqDataProvider::GroqChatCompletionDataProvider prov(fake);
+        assertTrue(prov.getSupportedReferenceData().models);
+        *list<hash<AllowedValueInfo>> vals = prov.getReferenceData("models");
+        assertEq("GET", fake.last_method);
+        assertEq("models", fake.last_path);
+        # inactive models are not offered
+        assertEq(("test-model-a", "test-model-b"), map $1.value, vals);
+        assertEq("test-model-a", vals[0].display_name);
+    }
+
     private requestSchemaTest() {
         GroqDataProvider::GroqChatCompletionRequestDataType t();
         hash<auto> fields = t.getFields();
@@ -220,11 +308,19 @@ public class GroqDataProviderTest inherits QUnit::Test {
         assertTrue(exists fields.temperature);
         assertTrue(exists fields.max_tokens);
         assertTrue(exists fields.tool_choice);
+
+        # the model field takes its values from the models endpoint but must
+        # also accept values not in the list
+        hash<DataFieldInfo> model_info = fields.model.getInfo();
+        assertEq("models", model_info.attr.ref_data);
+        assertTrue(model_info.allowed_values_creatable);
+        assertNothing(model_info.allowed_values);
     }
 
-    #! Exercises Groq's live chat-completion endpoint
-    /** Verifies the actual wire format against Groq's production LPU
-        endpoint with a token-bounded request on `llama-3.1-8b-instant`.
+    #! Exercises Groq's live model-list and chat-completion endpoints
+    /** Selects a model from the live model list rather than hardcoding one,
+        so the test keeps working as Groq's served model set changes, and
+        verifies the actual wire format with a token-bounded request.
         Cost: free tier eligible (capped via max_tokens=16).
     */
     private liveGroqTest() {
@@ -234,12 +330,46 @@ public class GroqDataProviderTest inherits QUnit::Test {
             ping.info ?? "no info"));
 
         AbstractDataProvider prov = conn.getDataProvider();
+
+        # the live model list drives the rest of the test
+        auto models = prov.getChildProvider("list-models").doRequest();
+        assertEq("list", models.object);
+        assertTrue(models."data".size() > 0,
+            "Groq returned a non-empty model list");
+        assertEq(NT_STRING, models."data"[0].id.typeCode());
+
         AbstractDataProvider chat = prov.getChildProvider("chat-completion");
-        auto resp = chat.doRequest({
-            "model": "llama-3.1-8b-instant",
-            "messages": ({"role": "user", "content": "Say hi in one word."},),
-            "max_tokens": 16,
-        });
+
+        # the same list backs the model field's reference data
+        *list<hash<AllowedValueInfo>> vals = chat.getReferenceData("models");
+        assertTrue(vals.size() > 0,
+            "Groq models exposed as reference data");
+
+        # try listed active models until one serves a chat completion; models
+        # that reject chat requests (audio, TTS, guard, etc.) return client
+        # errors and are skipped
+        list<string> candidates = map $1.id, models."data", $1.active ?? True;
+        auto resp;
+        foreach string model in (candidates) {
+            if ($# == MaxLiveChatAttempts) {
+                break;
+            }
+            try {
+                resp = chat.doRequest({
+                    "model": model,
+                    "messages": ({"role": "user", "content": "Say hi in one word."},),
+                    "max_tokens": 16,
+                });
+                break;
+            } catch (hash<ExceptionInfo> ex) {
+                if (ex.arg.status_code >= 400 && ex.arg.status_code < 500) {
+                    continue;
+                }
+                rethrow;
+            }
+        }
+        assertTrue(exists resp,
+            "at least one listed model served a chat completion");
         assertTrue(resp.choices[0].message.content.val(),
             "Groq returned non-empty assistant content");
         assertTrue(resp.usage.total_tokens > 0,

--- a/examples/test/qlib/GroqRestClient/GroqRestClient.qtest
+++ b/examples/test/qlib/GroqRestClient/GroqRestClient.qtest
@@ -51,7 +51,7 @@ public class GroqRestClientTest inherits QUnit::Test {
     private defaultUrlTest() {
         GroqRestClient::GroqLlmProvider p(
             <QoreLlmUtils::LlmBackendConfig>{
-                "model": "llama-3.3-70b-versatile",
+                "model": "test-model",
                 "api_key": "test-key",
             });
         assertEq("groq", p.getMode());
@@ -62,7 +62,7 @@ public class GroqRestClientTest inherits QUnit::Test {
         GroqRestClient::GroqLlmProvider p(
             <QoreLlmUtils::LlmBackendConfig>{
                 "url": "https://custom.example.com",
-                "model": "llama-3.3-70b-versatile",
+                "model": "test-model",
                 "api_key": "k",
             });
         assertEq("https://custom.example.com", p.getConfig().url);
@@ -81,7 +81,7 @@ public class GroqRestClientTest inherits QUnit::Test {
     private chatPathTest() {
         GroqRestClient::GroqLlmProvider p(
             <QoreLlmUtils::LlmBackendConfig>{
-                "model": "llama-3.3-70b-versatile",
+                "model": "test-model",
                 "api_key": "k",
             });
         # OpenAI-compatible default — Groq does NOT override the path
@@ -109,6 +109,14 @@ public class GroqRestClientTest inherits QUnit::Test {
             "api": "v2",
         });
         assertEq("/openai/v2", opts2.default_path);
+
+        # legacy api values that already include the "openai/" path prefix
+        # must not double it in default_path
+        hash<auto> opts3 = GroqRestClient::GroqRestClientBase::getOptions({
+            "apikey": "k",
+            "api": "openai/v1",
+        });
+        assertEq("/openai/v1", opts3.default_path);
     }
 
     private syncConnectionPathTest() {

--- a/examples/test/qlib/QoreLlmUtils/QoreLlmUtils.qtest
+++ b/examples/test/qlib/QoreLlmUtils/QoreLlmUtils.qtest
@@ -173,6 +173,8 @@ public class QoreLlmUtilsTest inherits QUnit::Test {
         addTestCase("LlmBackend Gemini schema sanitizer strips dialect "
             "metadata and preserves property names",
             \geminiSchemaMetadataKeywordSanitizerTest());
+        addTestCase("LlmBackend Gemini schema sanitizer supplies array "
+            "item schemas", \geminiSchemaArrayItemsSanitizerTest());
         addTestCase("LlmBackend Gemini response_format metadata is "
             "stripped from responseSchema",
             \geminiResponseSchemaMetadataIntegrationTest());
@@ -1874,6 +1876,52 @@ public class QoreLlmUtilsTest inherits QUnit::Test {
             {"type": "object", "properties": {}}, True);
         assertEq({}, noargs_compact.properties,
             "empty properties sanitizes to an empty map in compact mode");
+    }
+
+    geminiSchemaArrayItemsSanitizerTest() {
+        hash<auto> schema = {
+            "type": "object",
+            "properties": {
+                "missing_items": {"type": "array"},
+                "empty_items": {"type": "array", "items": {}},
+                "typed_items": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                },
+            },
+        };
+        foreach bool compact in (False, True) {
+            hash<auto> rv = GeminiBodyShape::sanitizeSchema(schema, compact);
+            assertEq({"type": "string"},
+                rv.properties.missing_items.items,
+                sprintf("missing items gets provider-safe fallback "
+                    "(compact=%y)", compact));
+            assertEq({"type": "string"},
+                rv.properties.empty_items.items,
+                sprintf("empty items gets provider-safe fallback "
+                    "(compact=%y)", compact));
+            assertEq({"type": "integer"},
+                rv.properties.typed_items.items,
+                sprintf("typed items remains exact (compact=%y)", compact));
+        }
+
+        hash<auto> body = GeminiBodyShape::shapeChatBody((
+            <ChatMessage>{"role": "user", "content": "run"},
+        ), (<ToolDefinition>{
+            "name": "list_tool",
+            "description": "list tool",
+            "parameters": schema,
+        },), NOTHING, {
+            "max_output_tokens": 64,
+            "temperature": 0.0,
+        });
+        hash<auto> params = body.tools[0].functionDeclarations[0].parameters;
+        assertEq({"type": "string"},
+            params.properties.missing_items.items,
+            "Gemini function declaration contains fallback items schema");
+        assertEq({"type": "string"},
+            params.properties.empty_items.items,
+            "Gemini function declaration replaces empty items schema");
     }
 
     geminiResponseSchemaMetadataIntegrationTest() {

--- a/qlib/GeminiBodyShape.qm
+++ b/qlib/GeminiBodyShape.qm
@@ -97,6 +97,9 @@ module GeminiBodyShape {
       between them
     - provides @ref requestErrorDetail() to surface the upstream provider error
       message and status from a failed request
+    - unconstrained array parameters in function tools receive a
+      provider-safe item schema so Gemini and Vertex AI accept MCP and data
+      provider tools with soft-list inputs
 */
 
 #! Contains all public definitions in the GeminiBodyShape module
@@ -191,6 +194,18 @@ auto sub sanitizeSchemaValue(auto value, bool compact, int depth,
                     cast<list>(input{key}), key == "allOf",
                     compact, depth + 1, field_name);
             }
+        }
+        # An unconstrained array is legal JSON Schema and is commonly
+        # produced for Qore softlist<auto> data-provider fields as
+        # {"type":"array","items":{}}.  Gemini's protobuf-backed Schema
+        # treats that empty child message like an absent field and rejects
+        # the complete function catalog with INVALID_ARGUMENT.  Keep the
+        # provider-neutral schema permissive and apply the same conservative
+        # string-item fallback used by QoreLlmUtils at this provider boundary.
+        if (rv.type == "array"
+                && (rv.items.typeCode() != NT_HASH
+                    || !cast<hash>(rv.items))) {
+            rv.items = {"type": "string"};
         }
         if (compact && rv.properties.typeCode() == NT_HASH
                 && GeminiBodyShape::shouldFlattenCompactSchemaProperties(

--- a/qlib/GroqDataProvider/GroqChatCompletionRequestDataType.qc
+++ b/qlib/GroqDataProvider/GroqChatCompletionRequestDataType.qc
@@ -131,16 +131,16 @@ public class GroqChatCompletionRequestDataType inherits HashDataType {
             "model": {
                 "display_name": "Model",
                 "short_desc": "The Groq-hosted model to use",
-                "desc": "Name of the Groq-hosted model.  Common values include:\n\n"
-                    "- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n"
-                    "- `llama-3.1-8b-instant` — fast, small Llama 3.1\n"
-                    "- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n"
-                    "- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\n"
-                    "Consult Groq's [models list](https://console.groq.com/docs/models) for "
-                    "the currently-served set.",
+                "desc": "ID of the Groq-hosted model to use.  See the "
+                    "[Groq models documentation](https://console.groq.com/docs/models) for the "
+                    "currently-available models; the `list-models` action returns the live list "
+                    "served by the API.",
                 "type": AbstractDataProviderTypeMap."string",
                 "required": True,
-                "example_value": "llama-3.3-70b-versatile",
+                "allowed_values_creatable": True,
+                "attr": {
+                    "ref_data": "models",
+                },
             },
             "messages": {
                 "display_name": "Messages",

--- a/qlib/GroqDataProvider/GroqDataProvider.qc
+++ b/qlib/GroqDataProvider/GroqDataProvider.qc
@@ -45,6 +45,8 @@ public class GroqDataProvider inherits GroqDataProviderCommon {
         const DefaultChildMap = {
             "chat-completion":
                 Class::forName("GroqDataProvider::GroqChatCompletionDataProvider"),
+            "list-models":
+                Class::forName("GroqDataProvider::GroqListModelsDataProvider"),
         };
     }
 

--- a/qlib/GroqDataProvider/GroqDataProvider.qm
+++ b/qlib/GroqDataProvider/GroqDataProvider.qm
@@ -44,14 +44,14 @@ module GroqDataProvider {
             "display_name": "Groq",
             "short_desc": "Groq LPU inference for open-weight models at very high throughput",
             "desc": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for "
-                "open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high "
-                "token-per-second throughput.\n\n"
+                "open-weight LLMs at exceptionally high token-per-second throughput.\n\n"
                 "Groq exposes an OpenAI-compatible chat-completions API, so existing "
                 "OpenAI-shape consumers (chat, tools, structured output, streaming) work "
-                "unchanged.\n\n"
+                "unchanged.  See the "
+                "[Groq models documentation](https://console.groq.com/docs/models) for the "
+                "currently-available models.\n\n"
                 "**Common use cases**:\n"
-                "- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token "
-                "on 70B-class models\n"
+                "- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token\n"
                 "- **High-throughput tool-calling agents** where total response time matters\n"
                 "- **Open-weight model deployments** without owning GPU infrastructure",
             "scheme": "groq",
@@ -69,9 +69,11 @@ module GroqDataProvider {
             "short_desc": "Generate a chat completion from a Groq-hosted open-weight model",
             "desc": "Sends a list of chat messages to a Groq-hosted model using the "
                 "OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated "
-                "response.\n\n"
+                "response.  See the "
+                "[Groq models documentation](https://console.groq.com/docs/models) for the "
+                "currently-available models.\n\n"
                 "**Example use cases**:\n"
-                "- Low-latency chat with `llama-3.3-70b-versatile`\n"
+                "- Low-latency chat and conversational agents\n"
                 "- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n"
                 "- Structured extraction (pass `response_format` with a JSON schema)",
             "action_code": DPAT_API,
@@ -92,6 +94,23 @@ module GroqDataProvider {
             ),
             "output_type": GroqChatCompletionDataProvider::ResponseType,
         });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GroqDataProvider::AppName,
+            "path": "/list-models",
+            "action": "list-models",
+            "display_name": "List Models",
+            "short_desc": "List the models currently available on the Groq API",
+            "desc": "Returns the list of models currently served by the Groq API using the "
+                "`/v1/models` endpoint, including context window sizes and active flags.  See "
+                "the [Groq models documentation](https://console.groq.com/docs/models) for "
+                "details on each model.",
+            "action_code": DPAT_API,
+            "mutates_state": False,
+            "groups": ("Models",),
+            "options": {},
+            "output_type": GroqListModelsDataProvider::ResponseType,
+        });
     };
 }
 
@@ -108,6 +127,11 @@ module GroqDataProvider {
     - @ref GroqDataProvider::GroqDataProvider "GroqDataProvider" — the root provider
     - @ref GroqDataProvider::GroqChatCompletionDataProvider
       "GroqChatCompletionDataProvider" — OpenAI-compatible chat
+    - @ref GroqDataProvider::GroqListModelsDataProvider
+      "GroqListModelsDataProvider" — lists the currently-available models
+
+    See the [Groq models documentation](https://console.groq.com/docs/models)
+    for the currently-available models.
 
     @par Example:
     @code{.py}
@@ -116,9 +140,12 @@ module GroqDataProvider {
 GroqRestConnection rc = get_connection("groq");
 GroqDataProvider::GroqDataProvider prov(rc.getAsync());
 
+# list the models currently served by the API
+hash<auto> models = prov.getChildProvider("list-models").doRequest();
+
 AbstractDataProvider chat = prov.getChildProvider("chat-completion");
 hash<auto> result = chat.doRequest({
-    "model": "llama-3.3-70b-versatile",
+    "model": models."data"[0].id,
     "messages": (
         {"role": "user", "content": "Hello!"},
     ),

--- a/qlib/GroqDataProvider/GroqDataProviderCommon.qc
+++ b/qlib/GroqDataProvider/GroqDataProviderCommon.qc
@@ -120,6 +120,40 @@ public class GroqDataProviderCommon inherits DataProvider::AbstractDataProvider 
         }
     }
 
+    #! Returns information on supported reference data
+    *hash<string, bool> getSupportedReferenceData() {
+        return {
+            "models": True,
+        };
+    }
+
+    #! Returns reference data of the given kind if available
+    private *list<hash<AllowedValueInfo>> getReferenceDataImpl(string type, *hash<auto> action_opts) {
+        switch (type) {
+            case "models": return getReferenceModels();
+        }
+    }
+
+    #! Returns the currently-available models as allowed values
+    private *list<hash<AllowedValueInfo>> getReferenceModels() {
+        list<hash<AllowedValueInfo>> rv;
+        foreach hash<auto> model in (doRestCommand("GET", "models").body."data") {
+            # skip models flagged as inactive
+            if (exists model.active && !model.active) {
+                continue;
+            }
+            string id = string(model.id);
+            string desc = sprintf("Groq model: %s", id);
+            rv += <AllowedValueInfo>{
+                "display_name": id,
+                "short_desc": desc,
+                "desc": desc,
+                "value": id,
+            };
+        }
+        return rv;
+    }
+
     #! Makes a REST call and returns the response; handles rate limit and I/O errors
     private hash<auto> doRestCommand(string method, string path, auto body, *hash<auto> hdr) {
         int retries = 0;

--- a/qlib/GroqDataProvider/GroqListModelsDataProvider.qc
+++ b/qlib/GroqDataProvider/GroqListModelsDataProvider.qc
@@ -1,0 +1,88 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GroqListModelsDataProvider class definition
+
+/** GroqListModelsDataProvider.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the GroqDataProvider module
+public namespace GroqDataProvider {
+#! Data provider for the Groq `/v1/models` endpoint (list currently-available models)
+public class GroqListModelsDataProvider inherits GroqDataProviderCommon {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list-models",
+            "type": "GroqListModelsDataProvider",
+            "constructor_options": ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Response type
+        static GroqListModelsResponseDataType ResponseType =
+            new GroqListModelsResponseDataType();
+    }
+
+    #! Creates the object from a RestClientIo client
+    constructor(RestClientIo::RestClientIo rest) : GroqDataProviderCommon(rest) {
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) : GroqDataProviderCommon(options) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! No request body — the request type is empty
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return NOTHING;
+    }
+
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+
+    #! Lists the models currently served by the Groq API
+    /** Converts each model's Unix-seconds `created` field on the response into
+        a Qore date to match the typed `*date` field in the response schema.
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        hash<auto> body = doRestCommand("GET", "models").body;
+        if (body."data".typeCode() == NT_LIST) {
+            body."data" = map $1.created.typeCode() == NT_INT
+                ? ($1 + {"created": 1970-01-01Z + seconds($1.created)})
+                : $1, body."data";
+        }
+        return body;
+    }
+}
+}

--- a/qlib/GroqDataProvider/GroqListModelsResponseDataType.qc
+++ b/qlib/GroqDataProvider/GroqListModelsResponseDataType.qc
@@ -1,0 +1,105 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GroqListModelsResponseDataType class definition
+
+/** GroqListModelsResponseDataType.qc Copyright 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the GroqDataProvider module
+public namespace GroqDataProvider {
+#! Data type for a single model entry returned by the Groq `/v1/models` endpoint
+public class GroqModelDataType inherits HashDataType {
+    private {
+        #! Field definitions
+        const Fields = {
+            "id": {
+                "display_name": "Model ID",
+                "desc": "The model ID; use this value in the `model` field of requests.",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "object": {
+                "display_name": "Object Type",
+                "desc": "Object type discriminator (typically 'model').",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "created": {
+                "display_name": "Created",
+                "desc": "When the model was created.  Groq emits a Unix-seconds integer on the "
+                    "wire; the data provider converts it to a Qore date before returning.",
+                "type": AbstractDataProviderTypeMap."*date",
+            },
+            "owned_by": {
+                "display_name": "Owned By",
+                "desc": "The organization that owns the model.",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "active": {
+                "display_name": "Active",
+                "desc": "Whether the model is currently active and can serve requests.",
+                "type": AbstractDataProviderTypeMap."*softbool",
+            },
+            "context_window": {
+                "display_name": "Context Window",
+                "desc": "The model's context window size in tokens.",
+                "type": AbstractDataProviderTypeMap."*softint",
+            },
+            "max_completion_tokens": {
+                "display_name": "Max Completion Tokens",
+                "desc": "The maximum number of completion tokens the model can emit.",
+                "type": AbstractDataProviderTypeMap."*softint",
+            },
+            "public_apps": {
+                "display_name": "Public Apps",
+                "desc": "Public application information for the model, if any.",
+                "type": AbstractDataProviderTypeMap."auto",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Data type for the Groq `/v1/models` list response
+public class GroqListModelsResponseDataType inherits HashDataType {
+    private {
+        #! Field definitions
+        const Fields = {
+            "object": {
+                "display_name": "Object Type",
+                "desc": "Object type discriminator (typically 'list').",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "data": {
+                "display_name": "Models",
+                "desc": "The list of models currently served by the Groq API.",
+                "type": new ListDataType("GroqModelList", new GroqModelDataType(), True),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+}

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/cs.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/cs.json
@@ -3,10 +3,6 @@
   "locales": {
     "cs": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "Odešle seznam chatových zpráv modelu hostovanému na Groqu pomocí koncového bodu `/v1/chat/completions` kompatibilního s OpenAI a vrátí vygenerovanou odpověď.\n\n**Příklady použití**:\n- Chat s nízkou latencí pomocí `llama-3.3-70b-versatile`\n- Rychlí agenti s voláním nástrojů (předejte v požadavku `tools` a `tool_choice`)\n- Strukturovaná extrakce (předejte `response_format` se schématem JSON)"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "Doplnění chatu"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "Penalizovat opakované tokeny úměrně jejich frekvenci"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Název modelu hostovaného na Groqu. Běžné hodnoty zahrnují:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — rychlý, malý Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B s kontextem 32K\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nAktuálně poskytovanou sadu naleznete v [seznamu modelů](https://console.groq.com/docs/models) Groq."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "Provést vlastní volání API do Groq"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "Poskytuje přístup k platformě [Groq](https://groq.com) — inferenci akcelerované LPU pro LLM s otevřenými vahami (Llama, Mixtral, Gemma, Qwen) s výjimečně vysokou propustností tokenů za sekundu.\n\nGroq nabízí rozhraní chat-completions API kompatibilní s OpenAI, takže existující integrace formátu OpenAI (chat, nástroje, strukturovaný výstup, streamování) fungují beze změny.\n\n**Běžné případy použití**:\n- **Chat s nízkou latencí** — LPU od Groqu poskytuje čas do prvního tokenu pod jednu sekundu u modelů třídy 70B\n- **Agenti s voláním nástrojů s vysokou propustností**, kde záleží na celkové době odezvy\n- **Nasazení modelů s otevřenými vahami** bez nutnosti vlastnit infrastrukturu GPU"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/de.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/de.json
@@ -3,10 +3,6 @@
   "locales": {
     "de": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "Sendet eine Liste von Chat-Nachrichten an ein von Groq gehostetes Modell über den OpenAI-kompatiblen Endpunkt `/v1/chat/completions` und gibt die generierte Antwort zurück.\n\n**Beispiel-Anwendungsfälle**:\n- Chat mit geringer Latenz mit `llama-3.3-70b-versatile`\n- Schnelle Tool-aufrufende Agenten (`tools` und `tool_choice` in der Anforderung übergeben)\n- Strukturierte Extraktion (`response_format` mit einem JSON-Schema übergeben)"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "Chat-Vervollständigung"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "Wiederholte Token proportional zu ihrer Häufigkeit bestrafen"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Name des von Groq gehosteten Modells. Häufige Werte sind:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — schnelles, kleines Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B mit 32K-Kontext\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nKonsultieren Sie Groqs [Modellliste](https://console.groq.com/docs/models) für das aktuell bereitgestellte Set."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "Einen benutzerdefinierten API-Aufruf an Groq ausführen"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "Bietet Zugriff auf [Groq](https://groq.com) – LPU-beschleunigte Inferenz für Open-Weight-LLMs (Llama, Mixtral, Gemma, Qwen) bei außergewöhnlich hohem Token-pro-Sekunde-Durchsatz.\n\nGroq stellt eine OpenAI-kompatible Chat-Completions-API bereit, sodass bestehende OpenAI-förmige Consumer (Chat, Tools, strukturierte Ausgabe, Streaming) unverändert funktionieren.\n\n**Häufige Anwendungsfälle**:\n- **Chat mit geringer Latenz** – Groqs LPU liefert Time-to-First-Token im Subsekundenbereich bei Modellen der 70B-Klasse\n- **Tool-aufrufende Agenten mit hohem Durchsatz**, bei denen die Gesamtreaktionszeit eine Rolle spielt\n- **Bereitstellungen von Open-Weight-Modellen** ohne eigene GPU-Infrastruktur"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/es.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/es.json
@@ -3,10 +3,6 @@
   "locales": {
     "es": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "Envía una lista de mensajes de chat a un modelo alojado en Groq utilizando el extremo `/v1/chat/completions` compatible con OpenAI y devuelve la respuesta generada.\n\n**Casos de uso de ejemplo**:\n- Chat de baja latencia con `llama-3.3-70b-versatile`\n- Agentes rápidos de llamada a herramientas (pase `tools` y `tool_choice` en la solicitud)\n- Extracción estructurada (pase `response_format` con un esquema JSON)"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "Completado de chat"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "Penalizar tokens repetidos proporcionalmente a su frecuencia"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Nombre del modelo alojado en Groq. Los valores comunes incluyen:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — Llama 3.1 pequeño y rápido\n- `mixtral-8x7b-32768` — Mixtral 8x7B con contexto de 32K\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsulte la [lista de modelos](https://console.groq.com/docs/models) de Groq para conocer el conjunto disponible actualmente."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "Realizar una llamada de API personalizada a Groq"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "Proporciona acceso a [Groq](https://groq.com): inferencia acelerada por LPU para LLM de pesos abiertos (Llama, Mixtral, Gemma, Qwen) con un rendimiento de tokens por segundo excepcionalmente alto.\n\nGroq expone una API de chat-completions compatible con OpenAI, por lo que los consumidores existentes con formato OpenAI (chat, herramientas, salidas estructuradas, transmisión) funcionan sin cambios.\n\n**Casos de uso comunes**:\n- **Chat de baja latencia**: la LPU de Groq ofrece un tiempo hasta el primer token inferior a un segundo en modelos de clase 70B\n- **Agentes de llamadas a herramientas de alto rendimiento** donde el tiempo total de respuesta es fundamental\n- **Despliegues de modelos de pesos abiertos** sin necesidad de poseer infraestructura de GPU"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/fr.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/fr.json
@@ -3,10 +3,6 @@
   "locales": {
     "fr": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "Envoie une liste de messages de chat à un modèle hébergé par Groq à l'aide du point de terminaison `/v1/chat/completions` compatible OpenAI et renvoie la réponse générée.\n\n**Exemples de cas d'utilisation** :\n- Chat à faible latence avec `llama-3.3-70b-versatile`\n- Agents d'appel d'outils rapides (transmettez `tools` et `tool_choice` dans la requête)\n- Extraction structurée (transmettez `response_format` avec un schéma JSON)"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "Complétion de chat"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "Pénaliser les jetons répétés proportionnellement à leur fréquence"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Nom du modèle hébergé par Groq.  Les valeurs courantes incluent :\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — Llama 3.1 rapide et léger\n- `mixtral-8x7b-32768` — Mixtral 8x7B avec contexte de 32K\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsultez la [liste des modèles](https://console.groq.com/docs/models) de Groq pour connaître l'ensemble actuellement disponible."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "Passer un appel d'API personnalisé à Groq"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "Fournit un accès à [Groq](https://groq.com) — inférence accélérée par LPU pour les LLM open-weight (Llama, Mixtral, Gemma, Qwen) avec un débit de tokens par seconde exceptionnellement élevé.\n\nGroq expose une API chat-completions compatible OpenAI, permettant aux consommateurs existants de formats OpenAI (chat, outils, sorties structurées, streaming) de fonctionner sans modification.\n\n**Cas d'utilisation courants** :\n- **Chat à faible latence** — le LPU de Groq offre un délai jusqu'au premier token inférieur à la seconde sur les modèles de classe 70B\n- **Agents d'appel d'outils à haut débit** où le temps de réponse global est primordial\n- **Déploiements de modèles open-weight** sans posséder d'infrastructure GPU"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/it.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/it.json
@@ -3,10 +3,6 @@
   "locales": {
     "it": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "Invia un elenco di messaggi di chat a un modello ospitato su Groq utilizzando l'endpoint `/v1/chat/completions` compatibile con OpenAI e restituisce la risposta generata.\n\n**Casi d'uso di esempio**:\n- Chat a bassa latenza con `llama-3.3-70b-versatile`\n- Agenti veloci per la chiamata di strumenti (passare `tools` e `tool_choice` nella richiesta)\n- Estrazione strutturata (passare `response_format` con uno schema JSON)"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "Completamento chat"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "Penalizza i token ripetuti proporzionalmente alla loro frequenza"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Nome del modello ospitato su Groq.  I valori comuni includono:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — Llama 3.1 piccolo e veloce\n- `mixtral-8x7b-32768` — Mixtral 8x7B con contesto da 32K\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsulta l'[elenco dei modelli](https://console.groq.com/docs/models) di Groq per il set attualmente fornito."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "Effettua una chiamata API personalizzata a Groq"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "Fornisce l'accesso a [Groq](https://groq.com) — inferenza con accelerazione LPU per LLM a pesi aperti (Llama, Mixtral, Gemma, Qwen) con una velocità di trasmissione di token al secondo eccezionalmente elevata.\n\nGroq espone un'API chat-completions compatibile con OpenAI, quindi i consumer esistenti in formato OpenAI (chat, strumenti, output strutturato, streaming) funzionano senza modifiche.\n\n**Casi d'uso comuni**:\n- **Chat a bassa latenza** — la LPU di Groq offre un tempo al primo token inferiore al secondo sui modelli di classe 70B\n- **Agenti con chiamata di strumenti ad alto throughput** in cui il tempo di risposta totale è fondamentale\n- **Distribuzioni di modelli a pesi aperti** senza possedere un'infrastruttura GPU"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/ja.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/ja.json
@@ -3,10 +3,6 @@
   "locales": {
     "ja": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "OpenAI互換の`/v1/chat/completions`エンドポイントを使用してGroqホストモデルにチャットメッセージのリストを送信し、生成されたレスポンスを返します。\n\n**主な使用例**:\n- `llama-3.3-70b-versatile`を使用した低レイテンシチャット\n- 高速なツール呼び出しエージェント（リクエスト内で`tools`および`tool_choice`を渡します）\n- 構造化抽出（JSONスキーマとともに`response_format`を渡します）"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "チャット補完"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "出現頻度に比例して重複トークンにペナルティを適用"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Groqホストモデルの名前。一般的な値は以下の通りです:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — 高速で小型のLlama 3.1\n- `mixtral-8x7b-32768` — 32KコンテキストのMixtral 8x7B\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\n現在提供されているモデル一覧については、Groqの[モデル一覧](https://console.groq.com/docs/models)を参照してください。"
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "GroqへのカスタムAPI呼び出しの実行"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "非常に高いトークン/秒のスループットでオープンウェイトLLM（Llama、Mixtral、Gemma、Qwen）のLPU高速化推論を提供する[Groq](https://groq.com)へのアクセスを提供します。\n\nGroqはOpenAI互換のチャット補完APIを公開しているため、既存のOpenAI形式のコンシューマー（チャット、ツール、構造化出力、ストリーミング）をそのまま利用できます。\n\n**一般的な使用例**:\n- **低レイテンシチャット** — GroqのLPUは70Bクラスのモデルで1秒未満の最初のトークン生成時間（TTFT）を実現\n- **高スループットのツール呼び出しエージェント** — 応答全体の時間が重視される場合\n- **オープンウェイトモデルのデプロイ** — GPUインフラストラクチャを所有する必要がありません"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/ko.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/ko.json
@@ -3,10 +3,6 @@
   "locales": {
     "ko": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "OpenAI 호환 `/v1/chat/completions` 엔드포인트를 사용하여 Groq 호스팅 모델에 채팅 메시지 목록을 보내고 생성된 응답을 반환합니다.\n\n**사용 사례 예시**:\n- `llama-3.3-70b-versatile`(으)로 지연 시간이 짧은 채팅\n- 빠른 도구 호출 에이전트 (요청에 `tools` 및 `tool_choice` 전달)\n- 구조화된 추출 (JSON 스키마와 함께 `response_format` 전달)"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "채팅 완성"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "반복되는 토큰의 빈도에 비례하여 페널티 부여"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Groq 호스팅 모델의 이름입니다. 일반적인 값은 다음과 같습니다:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — 빠르고 작은 Llama 3.1\n- `mixtral-8x7b-32768` — 32K 컨텍스트를 갖춘 Mixtral 8x7B\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\n현재 서비스 중인 세트는 Groq의 [모델 목록](https://console.groq.com/docs/models)을 참조하세요."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "Groq에 커스텀 API 호출 수행"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "오픈 가중치 LLM(Llama, Mixtral, Gemma, Qwen)에 대해 매우 높은 초당 토큰 처리량으로 LPU 가속 추론을 제공하는 [Groq](https://groq.com)에 대한 액세스를 제공합니다.\n\nGroq는 OpenAI 호환 채팅 완성 API를 노출하므로 기존 OpenAI 형태의 소비자(채팅, 도구, 구조화된 출력, 스트리밍)가 변경 없이 작동합니다.\n\n**일반적인 사용 사례**:\n- **낮은 지연 시간 채팅** — Groq의 LPU는 70B급 모델에서 1초 미만의 최초 토큰 생성 시간을 제공합니다\n- 전체 응답 시간이 중요한 **고처리량 도구 호출 에이전트**\n- GPU 인프라를 소유하지 않고 **오픈 가중치 모델 배포**"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/pl.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/pl.json
@@ -3,10 +3,6 @@
   "locales": {
     "pl": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "Wysyła listę wiadomości czatu do modelu hostowanego przez Groq za pomocą punktu końcowego `/v1/chat/completions` zgodnego z OpenAI i zwraca wygenerowaną odpowiedź.\n\n**Przykładowe przypadki użycia**:\n- Czat o niskim opóźnieniu z użyciem `llama-3.3-70b-versatile`\n- Szybcy agenci wywołujący narzędzia (przekaż `tools` oraz `tool_choice` w żądaniu)\n- Ustrukturyzowana ekstrakcja danych (przekaż `response_format` ze schematem JSON)"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "Uzupełnianie czatu"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "Nakładaj karę na powtarzające się tokeny proporcjonalnie do ich częstotliwości"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Nazwa modelu hostowanego przez Groq. Typowe wartości to m.in.:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — szybki, mały model Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B z kontekstem 32K\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nSprawdź [listę modeli](https://console.groq.com/docs/models) platformy Groq, aby zobaczyć aktualnie obsługiwany zestaw."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "Wykonaj niestandardowe wywołanie API do Groq"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "Zapewnia dostęp do [Groq](https://groq.com) — wnioskowania przyspieszanego przez LPU dla modeli LLM open-weight (Llama, Mixtral, Gemma, Qwen) przy wyjątkowo wysokiej przepustowości tokenów na sekundę.\n\nGroq udostępnia interfejs API chat-completions zgodny z OpenAI, więc dotychczasowi konsumenci formatu OpenAI (czat, narzędzia, ustrukturyzowane dane wyjściowe, strumieniowanie) działają bez zmian.\n\n**Typowe przypadki użycia**:\n- **Czat o niskim opóźnieniu** — procesory LPU firmy Groq zapewniają czas do pierwszego tokena poniżej sekundy w modelach klasy 70B\n- **Agenci wywołujący narzędzia o wysokiej przepustowości**, gdzie kluczowy jest całkowity czas odpowiedzi\n- **Wdrażanie modeli open-weight** bez konieczności posiadania własnej infrastruktury GPU"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/root.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/root.json
@@ -12,8 +12,8 @@
           "message": "Groq LPU inference for open-weight models at very high throughput"
         },
         "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure"
+          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.  See the [Groq models documentation](https://console.groq.com/docs/models) for the currently-available models.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
+          "message": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.  See the [Groq models documentation](https://console.groq.com/docs/models) for the currently-available models.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure"
         },
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.display_name": {
           "source": "Make an API call",
@@ -348,8 +348,8 @@
           "message": "Generate a chat completion from a Groq-hosted open-weight model"
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)"
+          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.  See the [Groq models documentation](https://console.groq.com/docs/models) for the currently-available models.\n\n**Example use cases**:\n- Low-latency chat and conversational agents\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
+          "message": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.  See the [Groq models documentation](https://console.groq.com/docs/models) for the currently-available models.\n\n**Example use cases**:\n- Low-latency chat and conversational agents\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)"
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bWVzc2FnZXM.display_name": {
           "source": "Messages",
@@ -372,8 +372,8 @@
           "message": "The Groq-hosted model to use"
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set."
+          "source": "ID of the Groq-hosted model to use.  See the [Groq models documentation](https://console.groq.com/docs/models) for the currently-available models; the `list-models` action returns the live list served by the API.",
+          "message": "ID of the Groq-hosted model to use.  See the [Groq models documentation](https://console.groq.com/docs/models) for the currently-available models; the `list-models` action returns the live list served by the API."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.dGVtcGVyYXR1cmU.display_name": {
           "source": "Temperature",
@@ -530,6 +530,18 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.dXNlcg.desc": {
           "source": "Opaque identifier representing the end user.  Logged server-side for abuse tracking and usage attribution; does not affect generation.",
           "message": "Opaque identifier representing the end user.  Logged server-side for abuse tracking and usage attribution; does not affect generation."
+        },
+        "app.R3JvcQ.action.bGlzdC1tb2RlbHM.display_name": {
+          "source": "List Models",
+          "message": "List Models"
+        },
+        "app.R3JvcQ.action.bGlzdC1tb2RlbHM.short_desc": {
+          "source": "List the models currently available on the Groq API",
+          "message": "List the models currently available on the Groq API"
+        },
+        "app.R3JvcQ.action.bGlzdC1tb2RlbHM.desc": {
+          "source": "Returns the list of models currently served by the Groq API using the `/v1/models` endpoint, including context window sizes and active flags.  See the [Groq models documentation](https://console.groq.com/docs/models) for details on each model.",
+          "message": "Returns the list of models currently served by the Groq API using the `/v1/models` endpoint, including context window sizes and active flags.  See the [Groq models documentation](https://console.groq.com/docs/models) for details on each model."
         }
       }
     }

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/sk.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/sk.json
@@ -3,10 +3,6 @@
   "locales": {
     "sk": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "Odošle zoznam chatových správ modelu hostovanému v službe Groq pomocou koncového bodu `/v1/chat/completions` kompatibilného s OpenAI a vráti vygenerovanú odpoveď.\n\n**Príklady použitia**:\n- Chat s nízkou latenciou pomocou `llama-3.3-70b-versatile`\n- Rýchli agenti volajúci nástroje (v požiadavke odovzdajte `tools` a `tool_choice`)\n- Štruktúrovaná extrakcia (odovzdajte `response_format` so schémou JSON)"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "Dopĺňanie chatu"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "Penalizovať opakované tokeny úmerne k ich frekvencii"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Názov modelu hostovaného v službe Groq. Medzi bežné hodnoty patria:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — rýchly, malý Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B s kontextom 32K\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nAktuálne poskytovanú sadu nájdete v [zozname modelov](https://console.groq.com/docs/models) služby Groq."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "Vykonať vlastné volanie API do služby Groq"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "Poskytuje prístup k službe [Groq](https://groq.com) – inferencia akcelerovaná pomocou LPU pre modely LLM s otvorenou váhou (Llama, Mixtral, Gemma, Qwen) pri mimoriadne vysokej priepustnosti tokenov za sekundu.\n\nGroq sprístupňuje API chat-completions kompatibilné s OpenAI, takže existujúci spotrebitelia formátu OpenAI (chat, nástroje, štruktúrovaný výstup, streamovanie) fungujú bez zmien.\n\n**Bežné prípady použitia**:\n- **Chat s nízkou latenciou** – LPU od spoločnosti Groq poskytuje čas do prvého tokenu pod jednu sekundu pri modeloch triedy 70B\n- **Agenti s volaním nástrojov s vysokou priepustnosťou**, kde záleží na celkovom čase odozvy\n- **Nasadenia modelov s otvorenou váhou** bez vlastnenia GPU infraštruktúry"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/uk.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/uk.json
@@ -3,10 +3,6 @@
   "locales": {
     "uk": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "Надсилає список повідомлень чату до моделі, розміщеної на Groq, за допомогою сумісної з OpenAI кінцевої точки `/v1/chat/completions` і повертає згенеровану відповідь.\n\n**Приклади використання**:\n- Чат із низькою затримкою з `llama-3.3-70b-versatile`\n- Швидкі агенти з викликом інструментів (передайте `tools` та `tool_choice` у запиті)\n- Структуроване вилучення (передайте `response_format` зі схемою JSON)"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "Доповнення чату"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "Штрафувати повторювані токени пропорційно до їхньої частоти"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Назва моделі, розміщеної на Groq. Поширені значення:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — швидка, невелика Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B із контекстом 32K\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nПерегляньте [список моделей](https://console.groq.com/docs/models) Groq для ознайомлення з актуальним переліком доступних моделей."
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "Зробити спеціальний виклик API до Groq"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "Надає доступ до [Groq](https://groq.com) — інференсу на базі LPU для LLM із відкритими вагами (Llama, Mixtral, Gemma, Qwen) із надзвичайно високою пропускною здатністю токенів за секунду.\n\nGroq надає сумісний з OpenAI API автодоповнення чату, тому наявні клієнти у форматі OpenAI (чат, інструменти, структурований вивід, потокове передавання) працюють без змін.\n\n**Поширені варіанти використання**:\n- **Чат із низькою затримкою** — LPU від Groq забезпечує час до першого токена менше секунди для моделей класу 70B\n- **Високопродуктивні агенти з викликом інструментів**, де важливий загальний час відповіді\n- **Розгортання моделей із відкритими вагами** без володіння інфраструктурою GPU"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/zh-Hant.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/zh-Hant.json
@@ -3,10 +3,6 @@
   "locales": {
     "zh-Hant": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "使用與 OpenAI 相容的 `/v1/chat/completions` 端點向託管於 Groq 的模型傳送聊天訊息清單，並傳回產生的回應。\n\n**範例使用案例**：\n- 與 `llama-3.3-70b-versatile` 進行低延遲聊天\n- 快速工具呼叫代理（在請求中傳遞 `tools` 和 `tool_choice`）\n- 結構化擷取（傳遞帶有 JSON 結構描述的 `response_format`）"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "聊天生成"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "依重複權杖的出現頻率等比例施加懲罰"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "託管於 Groq 的模型名稱。常見值包括：\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — 快速且小型的 Llama 3.1\n- `mixtral-8x7b-32768` — 具備 32K 上下文的 Mixtral 8x7B\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\n請查閱 Groq 的[模型清單](https://console.groq.com/docs/models)以獲取目前提供的集合。"
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "向 Groq 發出自訂 API 呼叫"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "提供對 [Groq](https://groq.com) 的存取 — 以極高的每秒 token 輸送量為開放權重 LLM（Llama、Mixtral、Gemma、Qwen）提供 LPU 加速推論。\n\nGroq 公開了與 OpenAI 相容的聊天完成 API，因此現有的 OpenAI 形態取用者（聊天、工具、結構化輸出、串流）可直接使用而無需變更。\n\n**常見使用案例**：\n- **低延遲聊天** — Groq 的 LPU 在 70B 級模型上提供次秒級的首個 token 時間\n- **高輸送量工具呼叫代理**，適用於重視總回應時間的場景\n- **開放權重模型部署**，無需擁有 GPU 基礎架構"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/zh-TW.json
+++ b/qlib/GroqDataProvider/i18n/data-provider.R3JvcQ/zh-TW.json
@@ -3,10 +3,6 @@
   "locales": {
     "zh-TW": {
       "messages": {
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.desc": {
-          "source": "Sends a list of chat messages to a Groq-hosted model using the OpenAI-compatible `/v1/chat/completions` endpoint and returns the generated response.\n\n**Example use cases**:\n- Low-latency chat with `llama-3.3-70b-versatile`\n- Fast tool-calling agents (pass `tools` and `tool_choice` in the request)\n- Structured extraction (pass `response_format` with a JSON schema)",
-          "message": "使用相容於 OpenAI 的 `/v1/chat/completions` 端點將聊天訊息清單傳送至 Groq 託管的模型，並傳回產生的回應。\n\n**範例使用案例**：\n- 使用 `llama-3.3-70b-versatile` 的低延遲聊天\n- 快速工具呼叫代理（在請求中傳遞 `tools` 與 `tool_choice`）\n- 結構化擷取（傳遞包含 JSON 結構描述的 `response_format`）"
-        },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.display_name": {
           "source": "Chat Completion",
           "message": "對話補全"
@@ -22,10 +18,6 @@
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.ZnJlcXVlbmN5X3BlbmFsdHk.short_desc": {
           "source": "Penalize repeated tokens proportional to their frequency",
           "message": "根據重複權杖的頻率成比例地進行懲罰"
-        },
-        "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.desc": {
-          "source": "Name of the Groq-hosted model.  Common values include:\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — fast, small Llama 3.1\n- `mixtral-8x7b-32768` — Mixtral 8x7B with 32K context\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\nConsult Groq's [models list](https://console.groq.com/docs/models) for the currently-served set.",
-          "message": "Groq 託管模型的名稱。常見值包括：\n\n- `llama-3.3-70b-versatile` — Meta Llama 3.3 70B Instruct\n- `llama-3.1-8b-instant` — 快速且小型的 Llama 3.1\n- `mixtral-8x7b-32768` — 具 32K 上下文的 Mixtral 8x7B\n- `gemma2-9b-it` — Google Gemma 2 9B Instruct\n\n請參閱 Groq 的 [模型清單](https://console.groq.com/docs/models) 以取得目前提供的模型集。"
         },
         "app.R3JvcQ.action.Y2hhdC1jb21wbGV0aW9u.option.bW9kZWw.display_name": {
           "source": "Model",
@@ -514,10 +506,6 @@
         "app.R3JvcQ.action.bWFrZS1hcGktY2FsbA.short_desc": {
           "source": "Make a custom API call to Groq",
           "message": "向 Groq 發出自訂 API 呼叫"
-        },
-        "app.R3JvcQ.desc": {
-          "source": "Provides access to [Groq](https://groq.com) — LPU-accelerated inference for open-weight LLMs (Llama, Mixtral, Gemma, Qwen) at exceptionally high token-per-second throughput.\n\nGroq exposes an OpenAI-compatible chat-completions API, so existing OpenAI-shape consumers (chat, tools, structured output, streaming) work unchanged.\n\n**Common use cases**:\n- **Low-latency chat** — Groq's LPU delivers sub-second time-to-first-token on 70B-class models\n- **High-throughput tool-calling agents** where total response time matters\n- **Open-weight model deployments** without owning GPU infrastructure",
-          "message": "提供對 [Groq](https://groq.com) 的存取權 — 針對開源權重大型語言模型 (Llama、Mixtral、Gemma、Qwen) 的 LPU 加速推論，具備極高的每秒權杖吞吐量。\n\nGroq 公開了相容於 OpenAI 的 chat-completions API，因此現有採用 OpenAI 形式的取用端（聊天、工具、結構化輸出、串流）無須修改即可運作。\n\n**常見使用案例**：\n- **低延遲聊天** — Groq 的 LPU 在 70B 級別模型上提供次秒級的首權杖時間 (TTFT)\n- **高吞吐量工具呼叫代理**（當總回應時間至關重要時）\n- 無須擁有 GPU 基礎架構的**開源權重模型部署**"
         },
         "app.R3JvcQ.display_name": {
           "source": "Groq",

--- a/qlib/GroqRestClient.qm
+++ b/qlib/GroqRestClient.qm
@@ -55,9 +55,10 @@ module GroqRestClient {
     The %GroqRestClient module provides an API for calling
     [Groq](https://groq.com) REST API services.
 
-    Groq runs Llama, Mixtral, Gemma, Qwen, and other open-weight models on
-    its custom LPU inference engine at exceptionally high token-per-second
-    throughput.  The API is OpenAI-compatible, so
+    Groq runs open-weight models on its custom LPU inference engine at
+    exceptionally high token-per-second throughput; see the
+    [Groq models documentation](https://console.groq.com/docs/models) for
+    the currently-available models.  The API is OpenAI-compatible, so
     @ref GroqRestClient::GroqLlmProvider "GroqLlmProvider" subclasses
     @ref OpenAiRestClient::OpenAiLlmProvider with the Groq default URL and
     mode string.
@@ -86,8 +87,11 @@ module GroqRestClient {
 %requires GroqRestClient
 
 GroqRestClient rest({"apikey": api_key});
-hash<auto> ans = rest.post("/v1/chat/completions", {
-    "model": "llama-3.3-70b-versatile",
+# list the currently-available models; relative paths resolve under
+# /openai/v1 on the connection
+hash<auto> models = rest.get("models").body;
+hash<auto> ans = rest.post("chat/completions", {
+    "model": models."data"[0].id,
     "messages": (
         {"role": "user", "content": "Hello!"},
     ),
@@ -139,7 +143,10 @@ public class GroqRestClientBase {
     static hash<auto> getOptions(hash<auto> opts) {
         hash<auto> rv = DefaultOptions + opts;
         if (opts.api) {
-            rv.default_path = "/openai/" + opts.api;
+            # tolerate legacy api values that already include the "openai/"
+            # path prefix (e.g. "openai/v1"), which would otherwise double
+            # the prefix in default_path
+            rv.default_path = "/openai/" + regex_subst(opts.api, "^/?openai/", "");
         }
         if (rv.apikey) {
             rv.token = rv.apikey;
@@ -213,9 +220,10 @@ public class GroqRestConnection inherits RestClient::RestConnection {
             "display_name": "Groq REST Connection",
             "short_desc": "A connection to the Groq LPU inference REST API",
             "desc": "A connection to the [Groq](https://groq.com) LPU inference REST API.\n\n"
-                "Groq serves OSS models (Llama, Mixtral, Gemma, Qwen, Whisper, etc.) at "
-                "exceptionally high throughput on its custom LPU hardware via an "
-                "OpenAI-compatible API surface.\n\n"
+                "Groq serves open-weight models at exceptionally high throughput on its custom "
+                "LPU hardware via an OpenAI-compatible API surface; see the "
+                "[Groq models documentation](https://console.groq.com/docs/models) for the "
+                "currently-available models.\n\n"
                 "Requires an API key for Bearer authentication.  Get your API key from the "
                 "[Groq Console](https://console.groq.com/keys).",
             "cls": Class::forName("GroqRestConnection"),
@@ -352,7 +360,9 @@ public class GroqRestConnection inherits RestClient::RestConnection {
 
     - \c url (optional): override the default \c https://api.groq.com/openai
     - \c api_key (required): Groq API key
-    - \c model (required): Groq model name, e.g. \c "llama-3.3-70b-versatile"
+    - \c model (required): Groq model name; see the
+      [Groq models documentation](https://console.groq.com/docs/models) for
+      the currently-available models
 */
 public class GroqLlmProvider inherits OpenAiRestClient::OpenAiLlmProvider {
     public {


### PR DESCRIPTION
Groq decommissions models over time, so model names baked into descriptions, defaults, or examples eventually go stale.  Remove all hardcoded model references from GroqDataProvider and GroqRestClient and point descriptions at https://console.groq.com/docs/models instead.

- add a list-models action / data provider for GET /v1/models
- serve the chat-completion model field's allowed values live from the models endpoint via reference data (inactive models filtered), with allowed_values_creatable so any model ID can still be entered
- normalize legacy "openai/v1" api option values that doubled the /openai prefix in request paths (404 on every request)
- select the live-test model from the live model list instead of hardcoding one; regenerate the Groq presentation catalogs

Tests: cmake --build build --target GroqRestClient-qmod GroqDataProvider-qmod; QORE_MODULE_DIR=qlib qore examples/test/qlib/GroqDataProvider/GroqDataProvider.qtest (8/8 mock, 9/9 incl. live with -c groq); GroqRestClient.qtest (9/9); bin/qore-data-provider-i18n --check --owner GroqDataProvider (clean)