### PR TITLE
feat: Gmail drafts/labels/threading, Calendar reads, Deepgram and OpenAI transcription (qorus#514)

### DIFF
--- a/doxygen/lang/900_release_notes.dox.tmpl
+++ b/doxygen/lang/900_release_notes.dox.tmpl
@@ -1614,6 +1614,18 @@ DataFrame::DataFrame df = DataFrame::DataFrame::fromColumnarResult(selected);
       - added per-database-driver SVG logo registry with logos for PostgreSQL, MySQL, Oracle, SQL Server
         (FreeTDS), SQLite, and ODBC; unknown drivers fall back to the generic database logo
 
+    - @ref deepgramdataproviderintro "DeepgramDataProvider" module
+      - the \c transcribe-file action accepts audio content directly through the new \c audio option (a
+        file value or raw binary data, sent as the request body with the file's MIME type), so audio
+        obtained from an upstream step can be transcribed without a public URL; the \c url option is now
+        optional, and exactly one of \c url or \c audio must be given
+
+    - @ref deepgramrestclientintro "DeepgramRestClient" module
+      - fixed a bug where the \c Authorization header built from the \c apikey option was placed in an
+        unread \c default_headers option, so requests and the connection ping were sent without
+        authentication and failed with HTTP 401
+        (<a href="https://github.com/qoretechnologies/qorus/issues/523">qorus#523</a>)
+
     - @ref elasticsearchdataproviderintro "ElasticSearchDataProvider" module
       - added Bulk API support with NDJSON format and partial failure handling
         (<a href="https://github.com/qoretechnologies/qore/issues/5016">issue 5016</a>)
@@ -1645,6 +1657,26 @@ DataFrame::DataFrame df = DataFrame::DataFrame::fromColumnarResult(selected);
       - message watches persist the last delivered timestamp and same-second message IDs when the host
         application configures checkpoint storage, preventing retained messages from being processed again
         after a service reload
+      - added the \c create-draft, \c list-drafts, \c get-draft, \c send-draft, and \c delete-draft actions,
+        so a flow can compose a message for human review instead of sending it immediately
+      - added the \c modify-message-labels, \c list-labels, \c create-label, and \c untrash-message actions,
+        so messages can be filed, marked read or unread, and restored without destroying them
+      - added \c thread_id, \c in_reply_to, and \c references options to \c send-message (and to
+        \c create-draft), so replies stay in the conversation they answer; message watch events carry the
+        \c In-Reply-To header and attachment watch events carry the source \c thread_id
+      - added the \c list-with-metadata action, which returns each matching message's headers, snippet,
+        labels, and thread ID in one step instead of only IDs
+      - the \c list, \c get, and \c get-attachment actions are now classified as read-only
+        (\c mutates_state = \c False)
+
+    - @ref googlecalendardataproviderintro "GoogleCalendarDataProvider" module
+      - added the \c list-events, \c get-event, and \c list-calendars read actions, so a calendar can be
+        read as a first-class step (with \c timeMin / \c timeMax windows, single-event expansion,
+        ordering, free-text search, and paging) instead of through a hand-written generic API call
+
+    - @ref googledataproviderintro "GoogleDataProvider" module
+      - date values in query arguments are serialized as RFC 3339 timestamps, as Google APIs require
+        (ex: \c timeMin / \c timeMax in Calendar \c events.list), instead of an unparseable digit string
 
     - @ref grokrestclientintro "GrokRestClient" module
       - registers @ref QoreLlmUtils::LlmProviderRegistry "LlmProviderRegistry" mode
@@ -1678,6 +1710,11 @@ DataFrame::DataFrame df = DataFrame::DataFrame::fromColumnarResult(selected);
       - added memory-based backpressure to \c LoggerAppenderQueue to prevent unbounded memory growth when
         producers outpace consumers — configurable memory limit, push timeout/drop control, and monitoring
       - added a \c max_bytes parameter to \c LoggerAppenderQueueThreadPool for memory-limited pool logging
+
+    - @ref openaidataproviderintro "OpenAiDataProvider" module
+      - added the \c transcribe-audio action (the \c /v1/audio/transcriptions API), which uploads an audio
+        file and returns its transcript, so audio obtained from an upstream step can be transcribed with the
+        \c gpt-4o-transcribe, \c gpt-4o-mini-transcribe, or \c whisper-1 models
 
     - @ref openairestclientintro "OpenAiRestClient" module
       - @ref OpenAiRestClient::OpenAiLlmProvider "OpenAiLlmProvider" is now formally the

--- a/examples/test/qlib/DeepgramDataProvider/DeepgramDataProvider.qtest
+++ b/examples/test/qlib/DeepgramDataProvider/DeepgramDataProvider.qtest
@@ -306,6 +306,16 @@ public class DeepgramDataProviderTest inherits QUnit::Test {
             ({"audio": {"name": "clip.wav"}},));
         # nothing was sent
         assertFalse(exists fake.last_method);
+
+        # an unset option can arrive as a key with no value; it must not count as an audio source
+        fake.response = <RestClient::RestResponseInfo>{
+            "body": {"results": {}},
+            "headers": {},
+        };
+        prov.doRequest({"url": "https://example.com/a.wav", "audio": NOTHING, "model": "nova-3"});
+        assertEq("POST", fake.last_method);
+        assertFalse(fake.last_raw);
+        assertEq("https://example.com/a.wav", fake.last_body.url);
     }
 
     #! Proves that the real REST client sends the audio bytes verbatim

--- a/examples/test/qlib/DeepgramDataProvider/DeepgramDataProvider.qtest
+++ b/examples/test/qlib/DeepgramDataProvider/DeepgramDataProvider.qtest
@@ -8,6 +8,9 @@
 %requires Util
 %requires QUnit
 %requires Logger
+%requires Mime
+%requires json
+%requires HttpServer
 %requires ConnectionProvider
 %requires DataProvider
 %requires DeepgramRestClient
@@ -19,23 +22,56 @@ class FakeDeepgramRestClientIo inherits RestClientIo::RestClientIo {
     public {
         string last_method;
         string last_path;
-        *hash<auto> last_body;
+        auto last_body;
+        *hash<auto> last_hdr;
+        #! True when the last request went through the raw (unserialized) request path
+        bool last_raw = False;
         hash<auto> response;
     }
     constructor() : RestClientIo({"url": "https://api.deepgram.com"}) {}
 
     hash<RestClient::RestResponseInfo> restPost(string path, auto body, *hash<auto> hdr) {
-        last_method = "POST";
-        last_path = path;
-        last_body = body;
-        return cast<hash<RestClient::RestResponseInfo>>(response);
+        return record("POST", path, body, hdr, False);
     }
     hash<RestClient::RestResponseInfo> restGet(string path, *hash<auto> hdr) {
-        last_method = "GET";
-        last_path = path;
-        return cast<hash<RestClient::RestResponseInfo>>(response);
+        return record("GET", path, NOTHING, hdr, False);
+    }
+    hash<RestClient::RestResponseInfo> restDoRawRequest(string method, string path, *data body,
+            *hash<auto> hdr) {
+        return record(method, path, body, hdr, True);
     }
     string getSafeUrl() { return "https://api.deepgram.com"; }
+
+    private hash<RestClient::RestResponseInfo> record(string method, string path, auto body,
+            *hash<auto> hdr, bool raw) {
+        last_method = method;
+        last_path = path;
+        last_body = body;
+        last_hdr = hdr;
+        last_raw = raw;
+        return cast<hash<RestClient::RestResponseInfo>>(response);
+    }
+}
+
+#! Captures the request exactly as it arrives on the wire and answers with a fixed transcript
+class ListenCapture inherits AbstractHttpRequestHandler {
+    public {
+        string method;
+        string path;
+        hash<auto> hdr;
+        *binary body;
+    }
+
+    hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+        method = hdr.method;
+        path = hdr.path;
+        self.hdr = hdr;
+        self.body = exists body ? binary(body) : NOTHING;
+        return makeResponse({"Content-Type": MimeTypeJson}, 200, make_json({
+            "metadata": {"request_id": "wire-1"},
+            "results": {"channels": ({"alternatives": ({"transcript": "wire ok"},)},)},
+        }));
+    }
 }
 
 public class DeepgramDataProviderTest inherits QUnit::Test {
@@ -49,6 +85,9 @@ public class DeepgramDataProviderTest inherits QUnit::Test {
 
         #! Public Deepgram audio sample used by the live transcribe test
         const LiveAudioUrl = "https://dpgr.am/spacewalk.wav";
+
+        #! Bytes standing in for an audio file: "RIFF" + bytes that are not valid UTF-8 + "WAVE"
+        const AudioBytes = <52494646ff80000057415645>;
     }
 
     private {
@@ -64,6 +103,14 @@ public class DeepgramDataProviderTest inherits QUnit::Test {
             \transcribeFileQueryStringTest());
         addTestCase("transcribe-file omits NOTHING params from the query string",
             \transcribeFileSkipNothingTest());
+        addTestCase("transcribe-file uploads a file value as the raw request body",
+            \transcribeFileAudioFileTest());
+        addTestCase("transcribe-file accepts raw audio bytes and derives the MIME type",
+            \transcribeFileAudioBinaryTest());
+        addTestCase("transcribe-file requires exactly one of url / audio",
+            \transcribeFileAudioSourceErrorTest());
+        addTestCase("transcribe-file sends audio bytes unserialized on the wire",
+            \transcribeFileAudioWireTest());
         addTestCase("synthesize-speech surfaces audio bytes + content-type",
             \synthesizeSpeechTest());
         addTestCase("app declares Speech AppGroup",       \speechAppGroupTest());
@@ -104,6 +151,19 @@ public class DeepgramDataProviderTest inherits QUnit::Test {
 
         list<string> action_codes = sort(map $1.action, actions);
         assertEq(("synthesize-speech", "transcribe-file"), action_codes);
+
+        # transcribe-file: url is no longer required; audio is a file input in the same
+        # required group, and each excludes the other
+        hash<DataProviderActionInfo> tf = (select actions, $1.action == "transcribe-file")[0];
+        assertFalse(tf.options.url.required ?? False);
+        assertTrue(tf.options.url.preselected);
+        assertEq(("audio_source",), tf.options.url.required_groups);
+        assertEq(("audio",), tf.options.url.exclusive_with);
+        assertEq("*file", tf.options.audio.type.getName());
+        assertFalse(tf.options.audio.required ?? False);
+        assertTrue(tf.options.audio.preselected);
+        assertEq(("audio_source",), tf.options.audio.required_groups);
+        assertEq(("url",), tf.options.audio.exclusive_with);
     }
 
     private transcribeFileQueryStringTest() {
@@ -125,8 +185,10 @@ public class DeepgramDataProviderTest inherits QUnit::Test {
         });
 
         assertEq("POST", fake.last_method);
-        # URL is in the JSON body — not the query string
+        # URL is in the JSON body — not the query string — through the normal (serialized) path
+        assertFalse(fake.last_raw);
         assertEq("https://example.com/audio.wav", fake.last_body.url);
+        assertFalse(exists fake.last_hdr."Content-Type");
         # All other params go in the query string
         assertTrue(fake.last_path =~ /^\/v1\/listen\?/);
         assertTrue(fake.last_path =~ /model=nova-3/);
@@ -163,6 +225,126 @@ public class DeepgramDataProviderTest inherits QUnit::Test {
         assertFalse(fake.last_path =~ /utterances=/);
         assertFalse(fake.last_path =~ /keywords=/);
         assertFalse(fake.last_path =~ /callback=/);
+    }
+
+    private transcribeFileAudioFileTest() {
+        FakeDeepgramRestClientIo fake();
+        fake.response = <RestClient::RestResponseInfo>{
+            "body": {
+                "metadata": {"request_id": "up-1"},
+                "results": {"channels": ({"alternatives":
+                    ({"transcript": "uploaded audio"},)},)},
+            },
+        };
+        DeepgramDataProvider::DeepgramTranscribeFileDataProvider prov(fake);
+        auto resp = prov.doRequest({
+            "audio": {
+                "name": "clip.wav",
+                "mime_type": "audio/wav",
+                "content": make_base64_string(AudioBytes),
+            },
+            "model": "nova-3",
+            "smart_format": True,
+            "diarize": True,
+        });
+
+        assertEq("POST", fake.last_method);
+        # the decoded bytes are the body, sent through the raw (unserialized) request path
+        # with the file's MIME type as the Content-Type
+        assertTrue(fake.last_raw);
+        assertEq(AudioBytes, fake.last_body);
+        assertEq("audio/wav", fake.last_hdr."Content-Type");
+        # all other params still go in the query string; the audio source never does
+        assertTrue(fake.last_path =~ /^\/v1\/listen\?/);
+        assertTrue(fake.last_path =~ /model=nova-3/);
+        assertTrue(fake.last_path =~ /smart_format=true/);
+        assertTrue(fake.last_path =~ /diarize=true/);
+        assertFalse(fake.last_path =~ /audio=/);
+        assertFalse(fake.last_path =~ /url=/);
+
+        assertEq("uploaded audio",
+            resp.results.channels[0].alternatives[0].transcript);
+        assertEq("up-1", resp.metadata.request_id);
+    }
+
+    private transcribeFileAudioBinaryTest() {
+        FakeDeepgramRestClientIo fake();
+        fake.response = <RestClient::RestResponseInfo>{
+            "body": {"metadata": {}, "results": {}},
+        };
+        DeepgramDataProvider::DeepgramTranscribeFileDataProvider prov(fake);
+
+        # raw bytes: there is no name to derive a MIME type from, so the generic default is sent
+        prov.doRequest({"audio": AudioBytes, "model": "nova-2"});
+        assertEq("POST", fake.last_method);
+        assertTrue(fake.last_raw);
+        assertEq(AudioBytes, fake.last_body);
+        assertEq(MimeTypeOctetStream, fake.last_hdr."Content-Type");
+        assertTrue(fake.last_path =~ /^\/v1\/listen\?/);
+        assertTrue(fake.last_path =~ /model=nova-2/);
+
+        # a file value without a MIME type derives the Content-Type from its name; the
+        # framework base64-encodes raw content, which must be decoded again before sending
+        prov.doRequest({"audio": {"name": "clip.mp3", "content": AudioBytes}});
+        assertTrue(fake.last_raw);
+        assertEq(AudioBytes, fake.last_body);
+        assertEq("audio/mpeg", fake.last_hdr."Content-Type");
+    }
+
+    private transcribeFileAudioSourceErrorTest() {
+        FakeDeepgramRestClientIo fake();
+        DeepgramDataProvider::DeepgramTranscribeFileDataProvider prov(fake);
+
+        assertThrows("DEEPGRAM-TRANSCRIBE-ERROR", "neither", \prov.doRequest(),
+            ({"model": "nova-3"},));
+        assertThrows("DEEPGRAM-TRANSCRIBE-ERROR", "both", \prov.doRequest(), ({
+            "url": "https://example.com/a.wav",
+            "audio": AudioBytes,
+        },));
+        # a file value without content is rejected by the file type before any I/O
+        assertThrows("RUNTIME-TYPE-ERROR", "content", \prov.doRequest(),
+            ({"audio": {"name": "clip.wav"}},));
+        # nothing was sent
+        assertFalse(exists fake.last_method);
+    }
+
+    #! Proves that the real REST client sends the audio bytes verbatim
+    /** The fake above only shows which client method the provider calls; this case runs the real
+        @ref DeepgramRestClient::DeepgramRestClientIo "DeepgramRestClientIo" against a local HTTP
+        server and checks what actually arrives: the raw bytes (not a JSON string, not base64,
+        no charset appended) and the file's Content-Type.
+    */
+    private transcribeFileAudioWireTest() {
+        ListenCapture capture();
+        HttpServer http(<HttpServerOptionInfo>{
+            "logger": new Logger("deepgram-test", LoggerLevel::getLevelError()),
+        });
+        http.setHandler("listen", "", MimeTypeJson, capture);
+        http.setDefaultHandler("listen", capture);
+        int port = http.addListener(<HttpListenerOptionInfo>{"service": 0}).port;
+        on_exit http.stop();
+
+        DeepgramDataProvider::DeepgramTranscribeFileDataProvider prov({
+            "apikey": "test-key",
+            "url": sprintf("http://localhost:%d", port),
+        });
+        auto resp = prov.doRequest({
+            "audio": {
+                "name": "clip.wav",
+                "mime_type": "audio/wav",
+                "content": make_base64_string(AudioBytes),
+            },
+            "model": "nova-3",
+        });
+
+        assertEq("POST", capture.method);
+        # the server reports the request path without the leading slash
+        assertTrue(capture.path =~ /^\/?v1\/listen\?/);
+        assertTrue(capture.path =~ /model=nova-3/);
+        assertEq(AudioBytes, capture.body);
+        assertEq("audio/wav", capture.hdr."content-type");
+        assertEq("Token test-key", capture.hdr.authorization);
+        assertEq("wire ok", resp.results.channels[0].alternatives[0].transcript);
     }
 
     private synthesizeSpeechTest() {

--- a/examples/test/qlib/DeepgramRestClient/DeepgramRestClient.qtest
+++ b/examples/test/qlib/DeepgramRestClient/DeepgramRestClient.qtest
@@ -7,11 +7,27 @@
 %requires Util
 %requires QUnit
 %requires DeepgramRestClient
+%requires HttpServer
+%requires Logger
+%requires Mime
+%requires json
 
 %exec-class DeepgramRestClientTest
 
+#! Captures the request headers exactly as they arrive on the wire and answers like /v1/projects
+class ProjectsCapture inherits AbstractHttpRequestHandler {
+    public {
+        list<hash<auto>> requests = ();
+    }
+
+    hash<HttpResponseInfo> handleRequest(hash<auto> cx, hash<auto> hdr, *data body) {
+        requests += hdr;
+        return makeResponse({"Content-Type": MimeTypeJson}, 200, make_json({"projects": ()}));
+    }
+}
+
 public class DeepgramRestClientTest inherits QUnit::Test {
-    constructor() : Test("DeepgramRestClient Test", "1.0") {
+    constructor() : Test("DeepgramRestClient Test", "1.1") {
         addTestCase("connection scheme registered",       \connectionSchemeTest());
         addTestCase("apikey maps to Authorization: Token header",
             \tokenAuthMappingTest());
@@ -19,6 +35,8 @@ public class DeepgramRestClientTest inherits QUnit::Test {
             \defaultUrlTest());
         addTestCase("existing headers are preserved",
             \preserveExistingHeadersTest());
+        addTestCase("Authorization header is sent on the wire",
+            \wireAuthorizationTest());
         set_return_value(main());
     }
 
@@ -35,8 +53,10 @@ public class DeepgramRestClientTest inherits QUnit::Test {
         hash<auto> opts = DeepgramRestClient::DeepgramRestClientBase::getOptions({
             "apikey": "secret-key-123",
         });
-        # apikey is rewritten to Authorization: Token header
+        # apikey is rewritten to an Authorization: Token header in the option the REST clients read
         assertEq("Token secret-key-123", opts.headers.Authorization);
+        # the unread default_headers option must not be used (qorus#523)
+        assertEq(NOTHING, opts.default_headers);
         # apikey itself is removed from the options hash to avoid Bearer fallback
         assertEq(NOTHING, opts.apikey);
     }
@@ -49,13 +69,42 @@ public class DeepgramRestClientTest inherits QUnit::Test {
     }
 
     private preserveExistingHeadersTest() {
-        # If the caller already supplied headers, they should be merged
-        # (not overwritten) by the Authorization injection.
+        # headers supplied by the caller are merged (not overwritten) by the Authorization injection, and
+        # legacy default_headers entries are folded into headers
         hash<auto> opts = DeepgramRestClient::DeepgramRestClientBase::getOptions({
             "apikey": "k",
             "headers": {"X-Trace-Id": "abc"},
+            "default_headers": {"X-Legacy": "1"},
         });
-        assertEq("Token k",      opts.headers.Authorization);
-        assertEq("abc",          opts.headers."X-Trace-Id");
+        assertEq("Token k", opts.headers.Authorization);
+        assertEq("abc", opts.headers."X-Trace-Id");
+        assertEq("1", opts.headers."X-Legacy");
+        assertEq(NOTHING, opts.default_headers);
+    }
+
+    #! Both clients must actually send the header: this is the regression test for qorus#523
+    private wireAuthorizationTest() {
+        ProjectsCapture capture();
+        HttpServer http(<HttpServerOptionInfo>{
+            "logger": new Logger("deepgram-test", LoggerLevel::getLevelError()),
+        });
+        http.setHandler("projects", "", MimeTypeJson, capture);
+        http.setDefaultHandler("projects", capture);
+        int port = http.addListener(<HttpListenerOptionInfo>{"service": 0}).port;
+        on_exit http.stop();
+        hash<auto> opts = {
+            "apikey": "wire-key",
+            "url": sprintf("http://localhost:%d", port),
+        };
+
+        DeepgramRestClient sync_client(opts);
+        sync_client.get("v1/projects");
+        assertEq(1, capture.requests.size());
+        assertEq("Token wire-key", capture.requests[0].authorization, "sync client");
+
+        DeepgramRestClientIo async_client(opts);
+        async_client.restGet("/v1/projects");
+        assertEq(2, capture.requests.size());
+        assertEq("Token wire-key", capture.requests[1].authorization, "async client");
     }
 }

--- a/examples/test/qlib/DeepgramRestClient/DeepgramRestClient.qtest
+++ b/examples/test/qlib/DeepgramRestClient/DeepgramRestClient.qtest
@@ -73,12 +73,14 @@ public class DeepgramRestClientTest inherits QUnit::Test {
         # legacy default_headers entries are folded into headers
         hash<auto> opts = DeepgramRestClient::DeepgramRestClientBase::getOptions({
             "apikey": "k",
-            "headers": {"X-Trace-Id": "abc"},
-            "default_headers": {"X-Legacy": "1"},
+            "headers": {"X-Trace-Id": "abc", "X-Shared": "explicit"},
+            "default_headers": {"X-Legacy": "1", "X-Shared": "legacy"},
         });
         assertEq("Token k", opts.headers.Authorization);
         assertEq("abc", opts.headers."X-Trace-Id");
         assertEq("1", opts.headers."X-Legacy");
+        # on a collision the caller's explicit header wins over the legacy option
+        assertEq("explicit", opts.headers."X-Shared");
         assertEq(NOTHING, opts.default_headers);
     }
 

--- a/examples/test/qlib/GmailDataProvider/GmailActionRequests.qtest
+++ b/examples/test/qlib/GmailDataProvider/GmailActionRequests.qtest
@@ -1,0 +1,542 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%modern
+%allow-injection
+
+%prepend-module-path "${SCRIPT_DIR}/../../../../qlib"
+%requires QUnit
+%requires Logger
+%requires DataProvider
+%requires RestClient
+%requires RestClientIo
+%requires GoogleRestClient
+%requires GoogleDataProvider
+%requires GmailDataProvider
+
+%exec-class GmailActionRequestsTest
+
+#! Records the events raised by a watch provider
+class RecordingObserver inherits DataProvider::Observer {
+    public {
+        list<hash<auto>> events = ();
+    }
+
+    update(string event_id, hash<auto> data_) {
+        push events, data_;
+    }
+}
+
+#! A Gmail REST client that records every request and answers from canned data instead of the network
+/** Every Gmail API provider sends its request through restDoRequest(), so that is the method overridden;
+    the recorded requests let a test check the exact HTTP method, path, query, and body an action produces
+*/
+class MockGmailApiRestClient inherits GoogleRestClient::GoogleRestClientIo {
+    public {
+        #! every request made, oldest first: method, path, body
+        list<hash<auto>> requests = ();
+
+        #! the response to a message listing
+        hash<auto> list_response = {};
+
+        #! message ID -> the message returned when it is retrieved
+        hash<auto> messages = {};
+
+        #! attachment ID -> the attachment returned when it is retrieved
+        hash<auto> attachments = {};
+
+        #! the account's labels
+        list<hash<auto>> labels = ();
+
+        #! the account's drafts
+        list<hash<auto>> drafts = ();
+    }
+
+    constructor() : GoogleRestClientIo(MockGmailApiRestClient::getRestOptions()) {
+    }
+
+    #! Returns REST options that do not narrow when the client copies them
+    static hash<auto!> getRestOptions() {
+        hash<auto!> opts = {
+            "api_profile": "gmail",
+            "url": "https://example.com",
+            "oauth2_client_id": "test",
+            "oauth2_client_secret": "test",
+            "oauth2_redirect_url": "https://localhost",
+            "token": "test",
+        };
+        return opts;
+    }
+
+    #! Returns the paths of the requests made with the given HTTP method, oldest first
+    list<string> getPaths(string method) {
+        return map $1.path, requests, $1.method == method;
+    }
+
+    hash<RestClient::RestResponseInfo> restDoRequest(string method, string path, auto body, *hash<auto> hdr) {
+        push requests, {"method": method, "path": path, "body": body};
+        return <RestClient::RestResponseInfo>{
+            "status_code": 200,
+            "headers": {},
+            "body": answer(method, path, body),
+        };
+    }
+
+    #! Answers one request from the canned data
+    private auto answer(string method, string path, auto body) {
+        if (method == "GET") {
+            if (path =~ /users\/me\/messages\?/) {
+                return list_response;
+            }
+            if (*string aid = (path =~ x/users\/me\/messages\/[^\/\?]+\/attachments\/([^\/\?]+)/)[0]) {
+                return attachments{aid};
+            }
+            if (*string id = (path =~ x/users\/me\/messages\/([^\/\?]+)/)[0]) {
+                return messages{id} ?? {"id": id};
+            }
+            if (path =~ /users\/me\/labels$/) {
+                return {"labels": labels};
+            }
+            if (path =~ /users\/me\/drafts(\?|$)/) {
+                return {"drafts": drafts};
+            }
+        } else if (method == "POST") {
+            if (path =~ /users\/me\/drafts$/) {
+                return {
+                    "id": "r-1",
+                    "message": {
+                        "id": "m-draft",
+                        "threadId": body.message.threadId ?? "t-draft",
+                    },
+                };
+            }
+            if (path =~ /users\/me\/messages\/send$/) {
+                return {
+                    "id": "m-sent",
+                    "threadId": body.threadId ?? "t-sent",
+                    "labelIds": ("SENT",),
+                };
+            }
+            if (*string id = (path =~ x/users\/me\/messages\/([^\/\?]+)\/modify$/)[0]) {
+                return {
+                    "id": id,
+                    "threadId": "t-" + id,
+                    "labelIds": body.addLabelIds,
+                };
+            }
+        }
+        throw "MOCK-ERROR", sprintf("unexpected request %s %y", method, path);
+    }
+}
+
+#! Gmail attachment watch provider exposing a single polling cycle
+class TestGmailAttachmentWatch inherits GmailAttachmentWatchDataProvider {
+    constructor(GoogleRestClient::GoogleRestClientIo rest, *hash<auto> options)
+            : GmailAttachmentWatchDataProvider(rest, options) {
+    }
+
+    hash<WatchCycleInfo> runCycle() { return runWatchCycle(fetchWatchItems()); }
+}
+
+public class GmailActionRequestsTest inherits QUnit::Test {
+    private {
+        #! why the Gmail Discovery document could not be loaded, if it could not
+        *string discovery_error;
+
+        #! the Message-ID of the message being answered in the threading tests
+        const OriginalMessageId = "<original@mail.example.com>";
+
+        #! 2026-07-29T10:00:00Z in milliseconds
+        const BaseMs = 1785664800000;
+    }
+
+    constructor() : Test("GmailActionRequestsTest", "1.0") {
+        addTestCase("MIME threading headers", \mimeThreadingTest());
+        addTestCase("send-message request shape", \sendMessageRequestTest());
+        addTestCase("create-draft request shape", \createDraftRequestTest());
+        addTestCase("modify-message-labels request shape", \modifyMessageLabelsRequestTest());
+        addTestCase("list-with-metadata request shape", \listWithMetadataRequestTest());
+        addTestCase("draft and label reference data", \referenceDataTest());
+        addTestCase("attachment events carry the thread ID", \attachmentEventThreadTest());
+
+        # the Discovery document is fetched from Google; no Gmail API provider can be built without it, so the
+        # tests that build one are skipped rather than failed when it cannot be fetched
+        try {
+            GoogleDataProviderBase::getRequestInfo(GoogleDiscoveryGmailApiName);
+        } catch (hash<ExceptionInfo> ex) {
+            discovery_error = sprintf("%s: %s", ex.err, ex.desc);
+        }
+
+        set_return_value(main());
+    }
+
+    #! Skips the current test if the Gmail Discovery document is not available
+    private checkDiscovery() {
+        if (discovery_error) {
+            testSkip(sprintf("the Gmail Discovery document is not available: %s", discovery_error));
+        }
+    }
+
+    #! Returns the value of the given header in a serialized MIME message, if present
+    private static *string getHeader(string mime, string name) {
+        int end = mime.find("\r\n\r\n");
+        string headers = end >= 0 ? mime.substr(0, end) : mime;
+        string prefix = name + ": ";
+        foreach string line in (headers.split("\r\n")) {
+            if (line.substr(0, prefix.size()) == prefix) {
+                return line.substr(prefix.size());
+            }
+        }
+    }
+
+    #! Returns the decoded MIME message from a Gmail API message body
+    private static string getMime(hash<auto> body) {
+        return parse_base64_url_string(body.raw).toString();
+    }
+
+    #! Returns a message as Gmail returns it in the metadata format
+    private static hash<auto> makeMetadataMessage(string id, string thread_id, string subject) {
+        return {
+            "id": id,
+            "threadId": thread_id,
+            "labelIds": ("INBOX",),
+            "snippet": subject,
+            "internalDate": string(BaseMs),
+            "payload": {
+                "mimeType": "text/plain",
+                "headers": (
+                    {"name": "Subject", "value": subject},
+                    {"name": "From", "value": "sender@example.com"},
+                ),
+                "body": {"size": 0},
+            },
+        };
+    }
+
+    #! A reply must carry In-Reply-To and References and name its thread; a fresh message must carry neither
+    mimeThreadingTest() {
+        hash<auto> base = {
+            "to": ("someone@example.com",),
+            "subject": "Re: hello",
+            "body": "thanks",
+        };
+
+        # a reply that names only the message it answers
+        hash<auto> body = GmailMessageSendDataProvider::makeMessageBody(base + {
+            "thread_id": "t-1",
+            "in_reply_to": OriginalMessageId,
+        });
+        assertEq(("raw", "threadId"), keys body);
+        assertEq("t-1", body.threadId, "the thread is named in the API body, not in the MIME message");
+        string mime = getMime(body);
+        assertEq("someone@example.com", getHeader(mime, "To"));
+        assertEq(OriginalMessageId, getHeader(mime, "In-Reply-To"));
+        assertEq(OriginalMessageId, getHeader(mime, "References"),
+            "In-Reply-To alone also serves as References, so Gmail threads the reply");
+
+        # an explicit References value wins
+        string refs = "<older@mail.example.com> " + OriginalMessageId;
+        body = GmailMessageSendDataProvider::makeMessageBody(base + {
+            "in_reply_to": OriginalMessageId,
+            "references": refs,
+        });
+        assertEq(("raw",), keys body, "no thread is named without thread_id");
+        mime = getMime(body);
+        assertEq(OriginalMessageId, getHeader(mime, "In-Reply-To"));
+        assertEq(refs, getHeader(mime, "References"));
+
+        # References without In-Reply-To is passed through as given
+        body = GmailMessageSendDataProvider::makeMessageBody(base + {"references": refs});
+        mime = getMime(body);
+        assertNothing(getHeader(mime, "In-Reply-To"));
+        assertEq(refs, getHeader(mime, "References"));
+
+        # a fresh message carries no threading headers at all
+        body = GmailMessageSendDataProvider::makeMessageBody(base);
+        assertEq(("raw",), keys body);
+        mime = getMime(body);
+        assertNothing(getHeader(mime, "In-Reply-To"));
+        assertNothing(getHeader(mime, "References"));
+        assertEq("Re: hello", getHeader(mime, "Subject"));
+    }
+
+    #! send-message must post the thread ID beside the MIME message and nothing else new
+    sendMessageRequestTest() {
+        checkDiscovery();
+        MockGmailApiRestClient rest();
+        GmailMessageSendDataProvider prov(rest);
+
+        hash<auto> res = prov.doRequest({
+            "to": "someone@example.com",
+            "subject": "Re: hello",
+            "body": "thanks",
+            "thread_id": "t-1",
+            "in_reply_to": OriginalMessageId,
+        });
+        assertEq(1, rest.requests.size());
+        hash<auto> req = rest.requests[0];
+        assertEq("POST", req.method);
+        assertEq("gmail/v1/users/me/messages/send", req.path);
+        # the body follows the Discovery schema's field order
+        assertEq(("raw", "threadId"), sort(keys req.body));
+        assertEq("t-1", req.body.threadId);
+        string mime = getMime(req.body);
+        assertEq(OriginalMessageId, getHeader(mime, "In-Reply-To"));
+        assertEq(OriginalMessageId, getHeader(mime, "References"));
+        assertEq("m-sent", res.id);
+        assertEq("t-1", res.threadId);
+
+        # without the threading options the body is exactly what it was before
+        rest.requests = ();
+        prov.doRequest({"to": "someone@example.com", "subject": "hello", "body": "hi"});
+        assertEq(("raw",), keys rest.requests[0].body);
+        assertNothing(getHeader(getMime(rest.requests[0].body), "In-Reply-To"));
+    }
+
+    #! create-draft must post the same message wrapped in a draft, without sending anything
+    createDraftRequestTest() {
+        checkDiscovery();
+        MockGmailApiRestClient rest();
+        GmailCreateDraftDataProvider prov(rest);
+
+        hash<auto> res = prov.doRequest({
+            "to": "someone@example.com",
+            "subject": "Re: hello",
+            "body": "thanks",
+            "thread_id": "t-1",
+            "in_reply_to": OriginalMessageId,
+        });
+        assertEq(1, rest.requests.size(), "a draft is stored with one request and never sent");
+        hash<auto> req = rest.requests[0];
+        assertEq("POST", req.method);
+        assertEq("gmail/v1/users/me/drafts", req.path);
+        assertEq(("message",), keys req.body, "the draft body wraps the message");
+        assertEq(("raw", "threadId"), keys req.body.message);
+        assertEq("t-1", req.body.message.threadId);
+        string mime = getMime(req.body.message);
+        assertEq("someone@example.com", getHeader(mime, "To"));
+        assertEq(OriginalMessageId, getHeader(mime, "In-Reply-To"));
+        assertEq(OriginalMessageId, getHeader(mime, "References"));
+        assertEq("r-1", res.id);
+        assertEq("t-1", res.message.threadId);
+
+        # a draft outside any thread
+        rest.requests = ();
+        prov.doRequest({"to": "someone@example.com", "subject": "hello", "body": "hi"});
+        assertEq(("raw",), keys rest.requests[0].body.message);
+    }
+
+    #! modify-message-labels must post both label lists to the message's modify endpoint
+    modifyMessageLabelsRequestTest() {
+        checkDiscovery();
+        MockGmailApiRestClient rest();
+        GmailModifyMessageLabelsDataProvider prov(rest);
+
+        hash<auto> res = prov.doRequest({
+            "id": "m1",
+            "addLabelIds": ("Label_1", "STARRED"),
+            "removeLabelIds": "UNREAD",
+        });
+        assertEq(1, rest.requests.size());
+        hash<auto> req = rest.requests[0];
+        assertEq("POST", req.method);
+        assertEq("gmail/v1/users/me/messages/m1/modify", req.path, "the message ID is a path argument");
+        assertEq({
+            "addLabelIds": ("Label_1", "STARRED"),
+            "removeLabelIds": ("UNREAD",),
+        }, req.body, "a single label is sent as a list too");
+        assertEq("m1", res.id);
+        assertEq(("Label_1", "STARRED"), res.labelIds);
+
+        # only one of the lists
+        rest.requests = ();
+        prov.doRequest({"id": "m2", "addLabelIds": "Label_1"});
+        assertEq({"addLabelIds": ("Label_1",)}, rest.requests[0].body);
+    }
+
+    #! list-with-metadata must list once and then retrieve each listed message in the requested format
+    listWithMetadataRequestTest() {
+        checkDiscovery();
+        MockGmailApiRestClient rest();
+        rest.list_response = {
+            "messages": (
+                {"id": "m1", "threadId": "t1"},
+                {"id": "m2", "threadId": "t2"},
+            ),
+            "nextPageToken": "page2",
+            "resultSizeEstimate": 2,
+        };
+        rest.messages = {
+            "m1": makeMetadataMessage("m1", "t1", "first"),
+            "m2": makeMetadataMessage("m2", "t2", "second"),
+        };
+        GmailListWithMetadataDataProvider prov(rest);
+
+        hash<auto> res = prov.doRequest({"q": "in:inbox", "maxResults": 2});
+        list<string> gets = rest.getPaths("GET");
+        assertEq(3, gets.size(), "one listing and one retrieval per listed message");
+        assertEq(3, rest.requests.size(), "and nothing else");
+        assertRegex("^gmail/v1/users/me/messages\\?", gets[0]);
+        assertRegex("q=in%3Ainbox", gets[0]);
+        assertRegex("maxResults=2", gets[0]);
+        assertRegex("^gmail/v1/users/me/messages/m1\\?", gets[1]);
+        assertRegex("format=metadata", gets[1], "the metadata format is the default");
+        foreach string header in (("Subject", "From", "To", "Date")) {
+            assertRegex("metadataHeaders=" + header + "(&|$)", gets[1],
+                sprintf("the default header list includes %s", header));
+        }
+        assertRegex("^gmail/v1/users/me/messages/m2\\?", gets[2]);
+
+        assertEq(2, res.messages.size());
+        assertEq("m1", res.messages[0].id);
+        assertEq("t1", res.messages[0].threadId);
+        assertEq("first", res.messages[0].payload.headers[0].value, "the retrieved message replaces the bare ID");
+        assertEq("second", res.messages[1].payload.headers[0].value);
+        assertEq("page2", res.nextPageToken, "the listing's paging information is passed through");
+        assertEq(2, res.resultSizeEstimate);
+
+        # a specific header list is passed to each retrieval; labels narrow the listing
+        rest.requests = ();
+        prov.doRequest({
+            "q": "in:inbox",
+            "labelIds": ("INBOX", "UNREAD"),
+            "metadata_headers": ("Subject", "Message-ID"),
+        });
+        gets = rest.getPaths("GET");
+        assertRegex("labelIds=INBOX", gets[0]);
+        assertRegex("labelIds=UNREAD", gets[0]);
+        assertRegex("metadataHeaders=Subject", gets[1]);
+        assertRegex("metadataHeaders=Message-ID", gets[1]);
+        assertFalse(gets[1] =~ /metadataHeaders=From/, "only the requested headers are named");
+
+        # the full format retrieves bodies, so no header list is sent
+        rest.requests = ();
+        prov.doRequest({"q": "in:inbox", "format": "full", "metadata_headers": ("Subject",)});
+        gets = rest.getPaths("GET");
+        assertRegex("format=full", gets[1]);
+        assertFalse(gets[1] =~ /metadataHeaders/, "Gmail ignores the header list unless the metadata format is used");
+
+        # an empty listing costs no retrievals
+        rest.list_response = {"resultSizeEstimate": 0};
+        rest.requests = ();
+        res = prov.doRequest({"q": "in:inbox"});
+        assertEq(1, rest.requests.size());
+        assertEq((), res.messages);
+        assertEq(0, res.resultSizeEstimate);
+
+        # the search criteria are required
+        assertThrows("INVALID-REQUEST", "\"q\"", sub () {
+            prov.doRequest({"maxResults": 2});
+        });
+    }
+
+    #! The draft and label actions must offer the account's drafts and labels as dropdown values
+    referenceDataTest() {
+        checkDiscovery();
+        MockGmailApiRestClient rest();
+        rest.labels = (
+            {"id": "INBOX", "name": "INBOX", "type": "system"},
+            {"id": "Label_1", "name": "Projects/Alpha", "type": "user"},
+        );
+        rest.drafts = (
+            {"id": "r-1", "message": {"id": "m1", "threadId": "t1"}},
+            {"id": "r-2", "message": {"id": "m2", "threadId": "t2"}},
+        );
+
+        GmailGetDraftDataProvider prov(rest);
+        assertEq({"drafts": True, "labels": True}, prov.getSupportedReferenceData());
+        assertEq({"labels": True}, prov.getSupportedElementReferenceData(),
+            "list-typed label options take their values from element reference data");
+
+        *list<hash<AllowedValueInfo>> labels = prov.getReferenceData("labels");
+        assertEq(("INBOX", "Label_1"), (map $1.value, labels), "a label is identified by its ID");
+        assertEq(("INBOX", "Projects/Alpha"), (map $1.display_name, labels), "and shown by its name");
+        assertEq(labels, prov.getElementReferenceData("labels"));
+        assertEq(("gmail/v1/users/me/labels", "gmail/v1/users/me/labels"), rest.getPaths("GET"));
+
+        rest.requests = ();
+        *list<hash<AllowedValueInfo>> drafts = prov.getReferenceData("drafts");
+        assertEq(("r-1", "r-2"), (map $1.value, drafts), "a draft is identified by its draft ID");
+        assertRegex("m1", drafts[0].short_desc, "and described by the message it holds");
+        assertRegex("t1", drafts[0].short_desc);
+        assertEq(("gmail/v1/users/me/drafts?maxResults=100",), rest.getPaths("GET"));
+
+        assertNothing(prov.getReferenceData("messages"), "unknown reference data is not an error");
+        assertThrows("UNSUPPORTED-REFERENCE-DATA", sub () {
+            prov.getReferenceDataEx("messages");
+        });
+
+        # every hand-written action provider shares the same reference data
+        foreach AbstractDataProvider other in ((
+            new GmailDeleteDraftDataProvider(rest),
+            new GmailSendDraftDataProvider(rest),
+            new GmailModifyMessageLabelsDataProvider(rest),
+            new GmailListWithMetadataDataProvider(rest),
+            new GmailCreateDraftDataProvider(rest),
+        )) {
+            assertEq({"drafts": True, "labels": True}, other.getSupportedReferenceData(), other.getName());
+            assertEq({"labels": True}, other.getSupportedElementReferenceData(), other.getName());
+        }
+    }
+
+    #! An attachment event must identify the thread of its source message, so a consumer can reply in it
+    attachmentEventThreadTest() {
+        checkDiscovery();
+        MockGmailApiRestClient rest();
+        rest.list_response = {
+            "messages": ({"id": "m1", "threadId": "t-1"},),
+        };
+        rest.messages.m1 = {
+            "id": "m1",
+            "threadId": "t-1",
+            "labelIds": ("INBOX",),
+            "snippet": "report",
+            "internalDate": string(BaseMs),
+            "payload": {
+                "mimeType": "multipart/mixed",
+                "headers": (
+                    {"name": "Subject", "value": "report"},
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Date", "value": "Wed, 29 Jul 2026 10:00:00 +0000"},
+                    {"name": "Message-ID", "value": OriginalMessageId},
+                ),
+                "body": {"size": 0},
+                "parts": (
+                    {
+                        "partId": "0",
+                        "mimeType": "text/plain",
+                        "headers": ({"name": "Content-Type", "value": "text/plain"},),
+                        "body": {"size": 2, "data": make_base64_url_string("hi")},
+                    },
+                    {
+                        "partId": "1",
+                        "mimeType": "text/csv",
+                        "filename": "report.csv",
+                        "headers": (
+                            {"name": "Content-Type", "value": "text/csv; name=\"report.csv\""},
+                            {"name": "Content-Disposition", "value": "attachment; filename=\"report.csv\""},
+                        ),
+                        "body": {"attachmentId": "a1", "size": 5},
+                    },
+                ),
+            },
+        };
+        rest.attachments.a1 = {"size": 5, "data": make_base64_url_string("a,b,c")};
+
+        TestGmailAttachmentWatch watch(rest, {"q": "in:inbox"});
+        RecordingObserver obs();
+        watch.registerObserver(obs);
+        assertEq(1, watch.runCycle().dispatched);
+        assertEq(1, obs.events.size(), "one event per attachment");
+        hash<auto> event = obs.events[0];
+        assertEq("m1", event.message_id, "the event names its source message");
+        assertEq("t-1", event.thread_id, "and the source message's thread");
+        assertEq("report.csv", event.filename);
+        assertEq("a,b,c", event.body);
+
+        # the example event and the event type say the same
+        assertEq({"message_id": "m1", "thread_id": "t-1"},
+            GmailAttachmentWatchDataProvider::getSourceInfo({"id": "m1", "threadId": "t-1"}));
+        assertEq("*string", GmailAttachmentEventDataType.getFields().thread_id.getType().getName());
+    }
+}

--- a/examples/test/qlib/GmailDataProvider/GmailActionRequests.qtest
+++ b/examples/test/qlib/GmailDataProvider/GmailActionRequests.qtest
@@ -461,6 +461,17 @@ public class GmailActionRequestsTest inherits QUnit::Test {
         assertRegex("t1", drafts[0].short_desc);
         assertEq(("gmail/v1/users/me/drafts?maxResults=100",), rest.getPaths("GET"));
 
+        # the result never exceeds the advertised maximum, even when the server hands back a larger page
+        int max_drafts = GmailApiDataProviderBase::MaxReferenceDrafts;
+        rest.drafts = map ("id": sprintf("r-%d", $1), "message": {"id": sprintf("m-%d", $1), "threadId": "t"}),
+            xrange(1, max_drafts + 100);
+        rest.requests = ();
+        drafts = prov.getReferenceData("drafts");
+        assertEq(max_drafts, drafts.size(), "the drafts reference data is capped");
+        assertEq(sprintf("r-%d", max_drafts), drafts[max_drafts - 1].value, "and keeps the first entries");
+        assertEq(("gmail/v1/users/me/drafts?maxResults=100",), rest.getPaths("GET"),
+            "a page is never requested beyond the page size");
+
         assertNothing(prov.getReferenceData("messages"), "unknown reference data is not an error");
         assertThrows("UNSUPPORTED-REFERENCE-DATA", sub () {
             prov.getReferenceDataEx("messages");

--- a/examples/test/qlib/GmailDataProvider/GmailDataProvider.qtest
+++ b/examples/test/qlib/GmailDataProvider/GmailDataProvider.qtest
@@ -50,6 +50,14 @@ public class GmailDataProviderTest inherits QUnit::Test {
         addTestCase("gmail attachment events address their source message",
             \gmailAttachmentEventSourceMessageTest());
         addTestCase("gmail watch checkpoint semantics", \gmailWatchCheckpointTest());
+        addTestCase("gmail draft actions", \gmailDraftActionTest());
+        addTestCase("gmail label actions", \gmailLabelActionTest());
+        addTestCase("gmail search with metadata action", \gmailListWithMetadataActionTest());
+        addTestCase("gmail read-only actions", \gmailReadOnlyActionTest());
+        addTestCase("gmail reply threading", \gmailThreadingTest());
+        addTestCase("gmail drafts live", \gmailDraftLiveTest());
+        addTestCase("gmail labels live", \gmailLabelLiveTest());
+        addTestCase("gmail search with metadata live", \gmailListWithMetadataLiveTest());
 
         try {
             setupConnection();
@@ -162,6 +170,172 @@ public class GmailDataProviderTest inherits QUnit::Test {
             "the attachment watch deletion option describes the same");
     }
 
+    #! Returns the registered action, failing if it is unknown
+    private static hash<DataProviderActionInfo> getAction(string action) {
+        return DataProviderActionCatalog::getAppActionEx(GmailDataProvider::AppName, action);
+    }
+
+    #! Returns @ref True if the action declares an output type either way
+    private static bool hasOutputType(hash<DataProviderActionInfo> action) {
+        return action.hasKey("get_output_type") || action.hasKey("output_type");
+    }
+
+    #! A consumer must be able to draft a message and to find, retrieve, send, and delete drafts
+    gmailDraftActionTest() {
+        hash<DataProviderActionInfo> create = getAction("create-draft");
+        assertEq("/create-draft", create.path);
+        assertEq(DPAT_API, create.action_code);
+        assertEq(keys getAction("send-message").options, keys create.options,
+            "a draft takes exactly the options a sent message takes");
+        assertTrue(create.options.to.required);
+        assertTrue(create.options.subject.required);
+        assertTrue(create.options.body.required);
+        assertTrue(hasOutputType(create));
+        assertTrue(DataProviderActionCatalog::actionMutatesState(create));
+
+        hash<DataProviderActionInfo> list = getAction("list-drafts");
+        assertEq("/drafts/list", list.path);
+        assertEq(DPAT_API, list.action_code);
+        assertEq(("q", "maxResults", "includeSpamTrash", "pageToken"), keys list.options);
+        assertFalse(list.options.q.required, "all drafts can be listed");
+        assertEq(False, list.mutates_state);
+        assertTrue(hasOutputType(list));
+
+        hash<DataProviderActionInfo> get = getAction("get-draft");
+        assertEq("/get-draft", get.path);
+        assertEq(DPAT_API, get.action_code);
+        assertTrue(get.options.id.required);
+        assertEq("drafts", get.options.id.ref_data, "the draft can be chosen from a dropdown");
+        assertEq(("full", "metadata", "minimal", "raw"), (map $1.value, get.options.format.allowed_values));
+        assertFalse(get.options.format.required);
+        assertEq(False, get.mutates_state);
+        assertTrue(hasOutputType(get));
+
+        hash<DataProviderActionInfo> send = getAction("send-draft");
+        assertEq("/send-draft", send.path);
+        assertEq(DPAT_API, send.action_code);
+        assertEq(("id",), keys send.options);
+        assertTrue(send.options.id.required);
+        assertEq("drafts", send.options.id.ref_data);
+        assertTrue(hasOutputType(send));
+        assertTrue(DataProviderActionCatalog::actionMutatesState(send));
+
+        hash<DataProviderActionInfo> del = getAction("delete-draft");
+        assertEq("/delete-draft", del.path);
+        assertEq(DPAT_API, del.action_code);
+        assertEq(("id",), keys del.options);
+        assertTrue(del.options.id.required);
+        assertEq("drafts", del.options.id.ref_data);
+        # the Gmail API returns no content for a permanent delete, as for delete-message
+        assertFalse(hasOutputType(del));
+        assertTrue(DataProviderActionCatalog::actionMutatesState(del));
+    }
+
+    #! A consumer must be able to list and create labels and to relabel a message
+    gmailLabelActionTest() {
+        hash<DataProviderActionInfo> modify = getAction("modify-message-labels");
+        assertEq("/modify-message-labels", modify.path);
+        assertEq(DPAT_API, modify.action_code);
+        assertEq(("id", "addLabelIds", "removeLabelIds"), keys modify.options);
+        assertTrue(modify.options.id.required);
+        foreach string opt in (("addLabelIds", "removeLabelIds")) {
+            assertFalse(modify.options{opt}.required, opt);
+            assertEq("*softlist<string>", modify.options{opt}.type.getName(), opt);
+            assertEq("labels", modify.options{opt}.element_ref_data,
+                sprintf("each element of %s can be chosen from a dropdown", opt));
+        }
+        assertTrue(hasOutputType(modify));
+        assertTrue(DataProviderActionCatalog::actionMutatesState(modify));
+
+        hash<DataProviderActionInfo> list = getAction("list-labels");
+        assertEq("/labels/list", list.path);
+        assertEq(DPAT_API, list.action_code);
+        assertEq({}, list.options, "listing labels takes no options");
+        assertEq(False, list.mutates_state);
+        assertTrue(hasOutputType(list));
+
+        hash<DataProviderActionInfo> create = getAction("create-label");
+        assertEq("/labels/create", create.path);
+        assertEq(DPAT_API, create.action_code);
+        assertEq(("name", "labelListVisibility", "messageListVisibility"), keys create.options);
+        assertTrue(create.options.name.required);
+        assertEq(("labelShow", "labelShowIfUnread", "labelHide"),
+            (map $1.value, create.options.labelListVisibility.allowed_values));
+        assertEq(("show", "hide"), (map $1.value, create.options.messageListVisibility.allowed_values));
+        assertTrue(hasOutputType(create));
+        assertTrue(DataProviderActionCatalog::actionMutatesState(create));
+
+        hash<DataProviderActionInfo> untrash = getAction("untrash-message");
+        assertEq("/messages/untrash", untrash.path);
+        assertEq(DPAT_API, untrash.action_code);
+        assertEq(("id",), keys untrash.options);
+        assertTrue(untrash.options.id.required);
+        assertTrue(hasOutputType(untrash));
+        assertTrue(DataProviderActionCatalog::actionMutatesState(untrash));
+    }
+
+    #! A consumer must be able to get matching messages with their headers in one action
+    gmailListWithMetadataActionTest() {
+        hash<DataProviderActionInfo> action = getAction("list-with-metadata");
+        assertEq("/list-with-metadata", action.path);
+        assertEq(DPAT_API, action.action_code);
+        assertEq(("q", "maxResults", "includeSpamTrash", "labelIds", "pageToken", "format", "metadata_headers"),
+            keys action.options);
+        assertTrue(action.options.q.required);
+        assertTrue(action.options.q.preselected);
+        assertEq("labels", action.options.labelIds.element_ref_data);
+        assertEq(("metadata", "full"), (map $1.value, action.options.format.allowed_values));
+        assertEq("metadata", action.options.format.default_value);
+        assertEq(("Subject", "From", "To", "Date"), action.options.metadata_headers.default_value);
+        assertEq("*softlist<string>", action.options.metadata_headers.type.getName());
+        assertEq(False, action.mutates_state);
+        assertTrue(hasOutputType(action));
+
+        # the existing list action is untouched
+        hash<DataProviderActionInfo> list = getAction("list");
+        assertEq("/messages/list", list.path);
+        assertEq(("q", "maxResults", "includeSpamTrash", "labelIds", "pageToken"), keys list.options);
+    }
+
+    #! Actions that only read must say so, because an unannotated API action counts as mutating
+    gmailReadOnlyActionTest() {
+        foreach string name in (("list", "get", "get-attachment", "list-labels", "list-drafts", "get-draft",
+                "list-with-metadata")) {
+            hash<DataProviderActionInfo> action = getAction(name);
+            assertEq(False, action.mutates_state, sprintf("%s declares that it is read-only", name));
+            assertFalse(DataProviderActionCatalog::actionMutatesState(action), name);
+        }
+        foreach string name in (("send-message", "create-draft", "send-draft", "delete-draft", "create-label",
+                "modify-message-labels", "untrash-message", "trash-message", "delete-message")) {
+            assertTrue(DataProviderActionCatalog::actionMutatesState(getAction(name)),
+                sprintf("%s is classified as mutating", name));
+        }
+    }
+
+    #! A consumer must be able to answer a message in its thread from the data a watch event carries
+    gmailThreadingTest() {
+        foreach string name in (("send-message", "create-draft")) {
+            hash<string, hash<ActionOptionInfo>> options = getAction(name).options;
+            foreach string opt in (("thread_id", "in_reply_to", "references")) {
+                assertTrue(options.hasKey(opt), sprintf("%s takes %s", name, opt));
+                assertFalse(options{opt}.required, sprintf("%s: %s is optional", name, opt));
+                assertEq("*string", options{opt}.type.getName(), sprintf("%s: %s", name, opt));
+            }
+            assertTrue(options.in_reply_to.example_value =~ /^<.*>$/,
+                sprintf("%s: the In-Reply-To example includes the angle brackets", name));
+        }
+
+        # the watch events carry what the reply needs
+        assertTrue(GmailMessageEventDataType::Fields.hasKey("In-Reply-To"),
+            "message events declare the In-Reply-To header");
+        assertEq("*string", GmailMessageEventDataType::Fields."In-Reply-To".type.getName());
+        assertTrue(GmailAttachmentEventDataType.getFields().hasKey("thread_id"),
+            "attachment events declare the source message's thread");
+        assertEq("*string", GmailAttachmentEventDataType.getFields().thread_id.getType().getName());
+        assertEq({"message_id": "m1", "thread_id": "t1"},
+            GmailAttachmentWatchDataProvider::getSourceInfo({"id": "m1", "threadId": "t1"}));
+    }
+
     #! Every attachment event must identify the message it came from
     gmailAttachmentEventSourceMessageTest() {
         assertTrue(GmailAttachmentEventDataType.getFields().hasKey("message_id"),
@@ -234,6 +408,160 @@ public class GmailDataProviderTest inherits QUnit::Test {
         assertThrows("WATCH-CHECKPOINT-ERROR", sub () {
             provider.advance(102, "");
         });
+    }
+
+    #! Drafts must be creatable in a thread, listable, retrievable, and deletable without anything being sent
+    gmailDraftLiveTest() {
+        if (!gdp) {
+            testSkip("no connection");
+        }
+
+        # draft the reply in the thread of any message in the inbox; Gmail honors the thread only when the
+        # subject matches, so the draft reuses that message's subject
+        hash<auto> listed = gdp.getChildProviderPath("list-with-metadata").doRequest({
+            "q": "in:inbox",
+            "maxResults": 1,
+            "metadata_headers": ("Subject", "Message-ID"),
+        });
+        *hash<auto> original = listed.messages[0];
+        hash<auto> req = {
+            "to": "draft-test@example.invalid",
+            "subject": original ? getHeaderValue(original, "Subject") ?? "GmailDataProvider test draft"
+                : sprintf("GmailDataProvider test draft %s", get_random_string(12)),
+            "body": sprintf("created by GmailDataProvider.qtest %s; safe to delete", get_random_string(12)),
+        };
+        if (original) {
+            req += {
+                "thread_id": original.threadId,
+                "in_reply_to": getHeaderValue(original, "Message-ID"),
+            };
+        }
+
+        hash<auto> draft = gdp.getChildProviderPath("create-draft").doRequest(req);
+        string draft_id = draft.id;
+        assertTrue(draft_id.val(), "the draft was created");
+        bool deleted;
+        on_exit if (!deleted) {
+            gdp.getChildProviderPath("delete-draft").doRequest({"id": draft_id});
+        }
+        if (original) {
+            assertEq(original.threadId, draft.message.threadId, "the draft was created in the requested thread");
+        }
+
+        # the draft is listed
+        AbstractDataProvider list_drafts = gdp.getChildProviderPath("drafts/list");
+        bool found;
+        *string page_token;
+        do {
+            hash<auto> page = list_drafts.doRequest({"maxResults": 500}
+                + (page_token.val() ? {"pageToken": page_token} : {}));
+            found = (select page.drafts, $1.id == draft_id).size() > 0;
+            page_token = page.nextPageToken;
+        } while (!found && page_token.val());
+        assertTrue(found, "the new draft is listed");
+
+        # and offered as reference data
+        AbstractDataProvider get_draft = gdp.getChildProviderPath("get-draft");
+        assertEq(1, (select get_draft.getReferenceData("drafts"), $1.value == draft_id).size(),
+            "the new draft is offered as a dropdown value");
+
+        # the stored draft has the requested content
+        hash<auto> got = gdp.getChildProviderPath("get-draft").doRequest({"id": draft_id, "format": "metadata"});
+        assertEq(draft_id, got.id);
+        assertEq(draft.message.id, got.message.id);
+        assertEq(req.subject, getHeaderValue(got.message, "Subject"), "the stored draft carries the subject");
+        if (original) {
+            assertEq(original.threadId, got.message.threadId, "the stored draft is in the thread");
+            assertEq(req.in_reply_to, getHeaderValue(got.message, "In-Reply-To"),
+                "the stored draft carries the In-Reply-To header");
+            assertEq(req.in_reply_to, getHeaderValue(got.message, "References"),
+                "and the References header derived from it");
+        }
+
+        # deleting it makes it unretrievable
+        gdp.getChildProviderPath("delete-draft").doRequest({"id": draft_id});
+        deleted = True;
+        try {
+            gdp.getChildProviderPath("get-draft").doRequest({"id": draft_id, "format": "minimal"});
+            fail("a deleted draft can still be retrieved");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq(404, ex.arg."response-code", "the deleted draft is gone");
+        }
+    }
+
+    #! Labels must be listable and creatable, and a message must be relabelable with a created label
+    gmailLabelLiveTest() {
+        if (!gdp) {
+            testSkip("no connection");
+        }
+        hash<auto> listed = gdp.getChildProviderPath("messages/list").doRequest({"q": "in:inbox", "maxResults": 1});
+        if (!listed.messages) {
+            testSkip("no messages in the inbox to relabel");
+        }
+        string message_id = listed.messages[0].id;
+
+        hash<auto> labels = gdp.getChildProviderPath("labels/list").doRequest({});
+        assertEq(1, (select labels.labels, $1.id == "INBOX").size(), "the system labels are listed");
+
+        string name = sprintf("qore-test-%s", get_random_string(12));
+        hash<auto> label = gdp.getChildProviderPath("labels/create").doRequest({
+            "name": name,
+            "labelListVisibility": "labelHide",
+            "messageListVisibility": "hide",
+        });
+        string label_id = label.id;
+        assertTrue(label_id.val(), "the label was created");
+        on_exit gdp.getChildProviderPath("labels/delete").doRequest({"id": label_id});
+        assertEq(name, label.name);
+        assertEq("labelHide", label.labelListVisibility, "the visibility options were stored");
+        assertEq("hide", label.messageListVisibility);
+
+        # the new label is offered as a dropdown value for the label options
+        AbstractDataProvider modify = gdp.getChildProviderPath("modify-message-labels");
+        assertEq(1, (select modify.getElementReferenceData("labels"), $1.value == label_id).size());
+        assertEq(1, (select modify.getReferenceData("labels"), $1.value == label_id).size());
+
+        # add the label, then check what Gmail stored, not only what it returned
+        hash<auto> modified = modify.doRequest({"id": message_id, "addLabelIds": (label_id,)});
+        assertTrue(inlist(label_id, modified.labelIds), "the label was added");
+        AbstractDataProvider get = gdp.getChildProviderPath("messages/get");
+        assertTrue(inlist(label_id, get.doRequest({"id": message_id, "format": "minimal"}).labelIds),
+            "the added label is stored");
+
+        modified = modify.doRequest({"id": message_id, "removeLabelIds": label_id});
+        assertFalse(inlist(label_id, modified.labelIds), "the label was removed");
+        assertFalse(inlist(label_id, get.doRequest({"id": message_id, "format": "minimal"}).labelIds),
+            "the removal is stored");
+    }
+
+    #! A search with metadata must return each match with the requested headers
+    gmailListWithMetadataLiveTest() {
+        if (!gdp) {
+            testSkip("no connection");
+        }
+        hash<auto> res = gdp.getChildProviderPath("list-with-metadata").doRequest({
+            "q": "in:inbox",
+            "maxResults": 2,
+        });
+        if (!res.messages) {
+            testSkip("no messages in the inbox");
+        }
+        assertTrue(res.messages.size() <= 2, "maxResults bounds the page");
+        foreach hash<auto> msg in (res.messages) {
+            assertTrue(msg.id.val());
+            assertTrue(msg.threadId.val());
+            assertTrue(getHeaderValue(msg, "From").val(), "the From header was retrieved");
+            assertNothing(msg.payload.body."data", "the metadata format carries no body");
+        }
+    }
+
+    #! Returns the value of the given header of a Gmail message, if present
+    private static *string getHeaderValue(hash<auto> msg, string name) {
+        foreach hash<auto> hdr in (msg.payload.headers) {
+            if (hdr.name.lwr() == name.lwr()) {
+                return hdr.value;
+            }
+        }
     }
 
     private usageIntern() {

--- a/examples/test/qlib/GoogleCalendarDataProvider/GoogleCalendarDataProvider.qtest
+++ b/examples/test/qlib/GoogleCalendarDataProvider/GoogleCalendarDataProvider.qtest
@@ -64,6 +64,7 @@ public class GoogleDataProviderTest inherits QUnit::Test {
     constructor() : Test("GoogleDataProviderTest Test", "1.0", \ARGV, MyOpts) {
         addTestCase("Discovery query value encoding", \queryValueEncodingTest());
         addTestCase("Discovery request target encoding", \requestTargetEncodingTest());
+        addTestCase("action catalog", \googleCalendarActionCatalogTest());
         addTestCase("test", \googleDataProviderTest());
         addTestCase("calendar test", \googleCalendarTest());
 
@@ -105,6 +106,14 @@ public class GoogleDataProviderTest inherits QUnit::Test {
             "a boolean-like string is rendered as the Discovery boolean string");
         assertEq("true", encoder.encode("singleEvents", string_type, bool_string_type.acceptsValue(True)),
             "the rendered Discovery boolean survives query encoding unchanged");
+        # Google APIs take timestamps as RFC 3339 strings (ex: timeMin / timeMax in events.list)
+        AbstractDataProviderType date_type = AbstractDataProviderTypeMap."date";
+        assertEq("2026-09-02T10%3A00%3A00%2B02%3A00",
+            encoder.encode("timeMin", date_type, 2026-09-02T10:00:00+02:00),
+            "date query values are serialized as RFC 3339 with the UTC offset");
+        assertEq("2026-09-02T08%3A00%3A00%2B00%3A00",
+            encoder.encode("timeMin", AbstractDataProviderTypeMap."*softdate", 2026-09-02T08:00:00Z),
+            "UTC dates carry an explicit zero offset, which RFC 3339 permits");
         assertEq(("first%20value", "second%26value"),
             map encoder.encode("items", string_type, $1),
                 ("first value", "second&value"),
@@ -170,6 +179,77 @@ public class GoogleDataProviderTest inherits QUnit::Test {
         return rv;
     }
 
+    #! The read-only calendar actions must be usable from the catalog alone
+    /** A consumer reading events or calendars needs first-class read actions with the filters the Google
+        Calendar API offers; each must be classified as read-only so the platform can offer it where mutating
+        actions are not allowed.
+    */
+    googleCalendarActionCatalogTest() {
+        hash<DataProviderActionInfo> list_events = DataProviderActionCatalog::getAppAction(
+            GoogleCalendarDataProvider::CalendarAppName, "list-events"
+        );
+        assertEq("/calendars/{calendar}/events/list", list_events.path);
+        assertEq("primary", list_events.path_vars.calendar.example_value, "the calendar path var has an example");
+        assertEq(DPAT_API, list_events.action_code);
+        assertEq(False, list_events.mutates_state, "listing events is read-only");
+        assertFalse(DataProviderActionCatalog::actionMutatesState(list_events),
+            "the catalog classifies listing events as read-only");
+        assertEq(("timeMin", "timeMax", "maxResults", "singleEvents", "orderBy", "q", "pageToken", "showDeleted"),
+            keys list_events.options, "the list action exposes the Google Calendar events.list filters");
+        assertTrue(list_events.options.timeMin.preselected, "the time window lower bound is offered upfront");
+        assertEq("*date", list_events.options.timeMin.type.getName(), "the time window is entered as dates");
+        assertEq("*date", list_events.options.timeMax.type.getName());
+        assertTrue(list_events.options.maxResults.preselected, "the page size is offered upfront");
+        assertEq("*int", list_events.options.maxResults.type.getName());
+        assertEq(20, list_events.options.maxResults.example_value);
+        assertEq(True, list_events.options.singleEvents.default_value,
+            "recurring events are expanded into instances by default");
+        assertEq("*bool", list_events.options.singleEvents.type.getName());
+        assertEq(("startTime", "updated"), map $1.value, list_events.options.orderBy.allowed_values,
+            "the ordering is offered as a dropdown");
+        assertTrue(list_events.options.orderBy.allowed_values[0].desc.find("`singleEvents`") >= 0,
+            "ordering by start time documents its dependency on expanded recurring events");
+        assertEq("*bool", list_events.options.showDeleted.type.getName());
+        map assertFalse(list_events.options{$1}.required, $1 + " is optional"), keys list_events.options;
+        assertOutputType(list_events, "Events");
+
+        hash<DataProviderActionInfo> get_event = DataProviderActionCatalog::getAppAction(
+            GoogleCalendarDataProvider::CalendarAppName, "get-event"
+        );
+        assertEq("/calendars/{calendar}/events/get", get_event.path);
+        assertEq("primary", get_event.path_vars.calendar.example_value);
+        assertEq(DPAT_API, get_event.action_code);
+        assertEq(False, get_event.mutates_state, "retrieving an event is read-only");
+        assertFalse(DataProviderActionCatalog::actionMutatesState(get_event));
+        assertEq(("eventId",), keys get_event.options, "the get action takes the event ID");
+        assertTrue(get_event.options.eventId.required, "the event ID is required");
+        assertTrue(get_event.options.eventId.preselected);
+        assertEq("string", get_event.options.eventId.type.getName());
+        assertOutputType(get_event, "Event");
+
+        hash<DataProviderActionInfo> list_calendars = DataProviderActionCatalog::getAppAction(
+            GoogleCalendarDataProvider::CalendarAppName, "list-calendars"
+        );
+        assertEq("/calendarList/list", list_calendars.path);
+        assertNothing(list_calendars.path_vars, "the calendar list is a root path");
+        assertEq(DPAT_API, list_calendars.action_code);
+        assertEq(False, list_calendars.mutates_state, "listing calendars is read-only");
+        assertFalse(DataProviderActionCatalog::actionMutatesState(list_calendars));
+        assertEq(("maxResults", "pageToken", "showHidden"), keys list_calendars.options,
+            "the calendar list action exposes the Google Calendar calendarList.list options");
+        assertEq("*int", list_calendars.options.maxResults.type.getName());
+        assertEq("*bool", list_calendars.options.showHidden.type.getName());
+        map assertFalse(list_calendars.options{$1}.required, $1 + " is optional"), keys list_calendars.options;
+        assertTrue(list_calendars.options.maxResults.preselected || list_calendars.options.showHidden.preselected,
+            "an action without required options still offers something upfront");
+        assertOutputType(list_calendars, "CalendarList");
+
+        # the mutating actions keep their classification
+        map assertTrue(DataProviderActionCatalog::actionMutatesState(
+            DataProviderActionCatalog::getAppAction(GoogleCalendarDataProvider::CalendarAppName, $1)),
+            $1 + " mutates state"), ("quick-add-event", "create-event", "update-event", "delete-event");
+    }
+
     googleDataProviderTest() {
         if (!gdp) {
             testSkip("no connection");
@@ -187,8 +267,10 @@ public class GoogleDataProviderTest inherits QUnit::Test {
         assertEq("calendarList", prov.getName());
         prov = prov.getChildProviderEx("list");
         assertEq("list", prov.getName());
-        hash<auto> h = prov.doRequest();
+        hash<auto> h = prov.doRequest({"maxResults": 250, "showHidden": True});
         assertEq(Type::String, h.etag.type());
+        assertEq("calendar#calendarList", h.kind);
+        assertTrue(exists (select h."items", $1.primary)[0], "the calendar list carries the primary calendar");
 
         # create, update and delete calendar events
         prov = gdp.getChildProviderPath("calendars/primary/events/quickAdd");
@@ -236,6 +318,38 @@ public class GoogleDataProviderTest inherits QUnit::Test {
             string desc = "today's lunch appointment";
             h = prov.doRequest({"eventId": h.id, "description": desc});
             assertEq(desc, h.description);
+
+            # the event must be listed in a time window around it (the "list-events" action path)
+            string event_id = h.id;
+            prov = gdp.getChildProviderPath("calendars/primary/events/list");
+            h = prov.doRequest({
+                "timeMin": start - 1h,
+                "timeMax": end + 1h,
+                "singleEvents": True,
+                "orderBy": "startTime",
+                "maxResults": 250,
+            });
+            assertEq("calendar#events", h.kind);
+            assertEq(Type::List, h."items".type());
+            assertTrue(exists (select h."items", $1.id == event_id)[0],
+                "the inserted event is listed in the time window around it");
+            # the search terms must find the event as well
+            h = prov.doRequest({
+                "timeMin": start - 1h,
+                "timeMax": end + 1h,
+                "singleEvents": True,
+                "q": "Burger Bar",
+            });
+            assertTrue(exists (select h."items", $1.id == event_id)[0],
+                "the inserted event is found by free-text search");
+
+            # the event must be retrievable by ID (the "get-event" action path)
+            prov = gdp.getChildProviderPath("calendars/primary/events/get");
+            h = prov.doRequest({"eventId": event_id});
+            assertEq("calendar#event", h.kind);
+            assertEq(event_id, h.id);
+            assertEq("Lunch at Burger Bar", h.summary);
+            assertEq(desc, h.description);
         }
 
         # test the free/busy calendar API
@@ -269,6 +383,18 @@ public class GoogleDataProviderTest inherits QUnit::Test {
             assertEq("calendar#calendar", h.kind);
             assertEq(summary, h.summary);
             assertEq("Europe/Prague", h.timeZone);
+        }
+    }
+
+    #! Asserts that an action declares its output type from the Discovery schema
+    /** The catalog resolves \c get_output_type callbacks lazily; the callback fetches the Discovery document,
+        so with network access the resolved type is checked, and without it the callback must still be present.
+    */
+    private assertOutputType(hash<DataProviderActionInfo> action, string type_name) {
+        if (action.output_type) {
+            assertEq(type_name, action.output_type.getName(), action.action + " resolves its output type");
+        } else {
+            assertEq(Type::Closure, action.get_output_type.type(), action.action + " declares its output type");
         }
     }
 

--- a/examples/test/qlib/OpenAiDataProvider/OpenAiDataProvider.qtest
+++ b/examples/test/qlib/OpenAiDataProvider/OpenAiDataProvider.qtest
@@ -25,6 +25,10 @@ class FakeOpenAiRestClient inherits OpenAiRestClient::OpenAiRestClientIo {
         hash<auto> response_body;
         hash<auto> last_stream_request;
         list<hash<SseMessageInfo>> stream_events;
+        # raw (pre-serialized) requests: multipart uploads
+        *data last_raw_body;
+        # raw response body; a string for text response formats
+        auto raw_response_body;
     }
 
     constructor() : OpenAiRestClientIo({"token": "x"}) {
@@ -53,6 +57,17 @@ class FakeOpenAiRestClient inherits OpenAiRestClient::OpenAiRestClientIo {
         return <RestClient::RestResponseInfo>{
             "status_code": 200,
             "body": response_body,
+        };
+    }
+
+    hash<RestClient::RestResponseInfo> restDoRawRequest(string method, string path, *data body, *hash<auto> hdr) {
+        last_method = method;
+        last_path = path;
+        last_raw_body = body;
+        last_hdr = hdr;
+        return <RestClient::RestResponseInfo>{
+            "status_code": 200,
+            "body": raw_response_body ?? response_body,
         };
     }
 
@@ -178,6 +193,8 @@ public class OpenAiDataProviderTest inherits QUnit::Test {
         addTestCase("assistants API still functional", \assistantsApiStillFunctionalTest());
         addTestCase("function call output input", \functionCallOutputInputTest());
         addTestCase("conversation reference data", \conversationReferenceDataTest());
+        addTestCase("transcribe audio", \transcribeAudioTest());
+        addTestCase("transcribe audio action catalog", \transcribeAudioActionCatalogTest());
 
         try {
             setupConnection();
@@ -225,7 +242,7 @@ public class OpenAiDataProviderTest inherits QUnit::Test {
         }
         foreach string read_only_action in (("multi-chat", "simple-chat", "get-conversation",
                 "list-conversation-items", "get-conversation-item", "list-response-input-items",
-                "create-image")) {
+                "create-image", "transcribe-audio")) {
             assertFalse(DataProviderActionCatalog::actionMutatesState(
                     DataProviderActionCatalog::getAppActionEx(OpenAiDataProvider::AppName, read_only_action)),
                 read_only_action + " is read-only by its producer contract");
@@ -1532,6 +1549,158 @@ public class OpenAiDataProviderTest inherits QUnit::Test {
         assertThrows("RUNTIME-TYPE-ERROR", "call_id", \prov.doRequest(), ({
             "input": ({"function_call_output": {"output": "x"}},),
         },));
+    }
+
+    transcribeAudioTest() {
+        checkModule();
+        FakeOpenAiRestClient rest();
+        OpenAiDataProvider root(rest);
+        AbstractDataProvider prov = root.getChildProvider("transcribe-audio");
+        assertEq("transcribe-audio", prov.getName());
+        assertEq(OpenAiTranscribeAudioRequestType, prov.getRequestType());
+        assertEq(OpenAiTranscriptionDataType, prov.getResponseType());
+
+        # binary audio content; must survive the base64 round trip and the multipart encoding byte for byte
+        binary audio = <52494646000000005741564500ff01fe>;
+
+        # JSON response format: the file, the model, and every optional field with a value are sent as parts
+        rest.raw_response_body = {
+            "text": "hello world",
+            "usage": {
+                "type": "tokens",
+                "input_tokens": 14,
+                "output_tokens": 3,
+                "total_tokens": 17,
+            },
+        };
+        hash<auto> resp = prov.doRequest({
+            "file": {
+                "name": "greeting.mp3",
+                "content": audio,
+            },
+            "model": "gpt-4o-transcribe",
+            "language": "en",
+            "prompt": "A short greeting",
+            "temperature": 0.2,
+        });
+        assertEq("POST", rest.last_method);
+        assertEq("audio/transcriptions", rest.last_path);
+        # no JSON request must have been made
+        assertNothing(rest.last_request);
+        assertRegex("^multipart/form-data; boundary=", rest.last_hdr."Content-Type");
+        hash<string, hash<FormDataMessageInfo>> parts = MultiPartFormDataMessage::parseMessage(
+            rest.last_hdr."Content-Type", rest.last_raw_body.toString());
+        assertEq(("file", "language", "model", "prompt", "response_format", "temperature"), sort(keys parts));
+        assertEq("greeting.mp3", parts.file.filename);
+        assertEq("audio/mpeg", parts.file.hdr."content-type");
+        assertEq(audio, binary(parts.file.body));
+        assertEq("gpt-4o-transcribe", parts.model.body.toString());
+        assertEq("en", parts.language.body.toString());
+        assertEq("A short greeting", parts.prompt.body.toString());
+        # the default response format is sent explicitly
+        assertEq("json", parts.response_format.body.toString());
+        assertEq("0.2", parts.temperature.body.toString());
+        assertEq("hello world", resp.text);
+        assertEq("tokens", resp.usage.type);
+        assertEq(17, resp.usage.total_tokens);
+
+        # verbose JSON response: the parsed body is returned as-is
+        rest.raw_response_body = {
+            "task": "transcribe",
+            "language": "english",
+            "duration": 1.5,
+            "text": "hello world",
+            "words": (
+                {"word": "hello", "start": 0.0, "end": 0.7},
+                {"word": "world", "start": 0.8, "end": 1.5},
+            ),
+        };
+        resp = prov.doRequest({
+            "file": {
+                "name": "greeting.wav",
+                "content": audio,
+            },
+            "model": "whisper-1",
+            "response_format": "verbose_json",
+        });
+        parts = MultiPartFormDataMessage::parseMessage(rest.last_hdr."Content-Type", rest.last_raw_body.toString());
+        assertEq(("file", "model", "response_format"), keys parts);
+        assertEq("greeting.wav", parts.file.filename);
+        assertEq("audio/x-wav", parts.file.hdr."content-type");
+        assertEq("whisper-1", parts.model.body.toString());
+        assertEq("verbose_json", parts.response_format.body.toString());
+        assertEq("english", resp.language);
+        assertEq(2, resp.words.lsize());
+        assertEq("world", resp.words[1].word);
+
+        # text response format: the raw body is returned in the "text" key; the MIME type given is used
+        rest.raw_response_body = "hello world\n";
+        resp = prov.doRequest({
+            "file": {
+                "name": "greeting.ogg",
+                "content": make_base64_string(audio),
+                "mime_type": "audio/ogg",
+            },
+            "model": "whisper-1",
+            "response_format": "text",
+        });
+        parts = MultiPartFormDataMessage::parseMessage(rest.last_hdr."Content-Type", rest.last_raw_body.toString());
+        assertEq("greeting.ogg", parts.file.filename);
+        assertEq("audio/ogg", parts.file.hdr."content-type");
+        assertEq(audio, binary(parts.file.body));
+        assertEq("text", parts.response_format.body.toString());
+        assertEq({"text": "hello world\n"}, resp);
+
+        # a missing file is rejected by the request type before any request is made
+        rest.last_method = "";
+        assertThrows("INVALID-REQUEST", "mandatory hash field \"file\"", \prov.doRequest(), ({"model": "whisper-1"},));
+        # the file name must have a supported audio extension
+        assertThrows("TRANSCRIBE-AUDIO-ERROR", "notes.txt", \prov.doRequest(), ({
+            "file": {
+                "name": "notes.txt",
+                "content": "not audio",
+            },
+            "model": "whisper-1",
+        },));
+        # the file content is mandatory
+        assertThrows("RUNTIME-TYPE-ERROR", "content", \prov.doRequest(), ({
+            "file": {
+                "name": "greeting.mp3",
+            },
+            "model": "whisper-1",
+        },));
+        assertEq("", rest.last_method);
+    }
+
+    transcribeAudioActionCatalogTest() {
+        hash<DataProviderActionInfo> action = DataProviderActionCatalog::getAppAction(
+            OpenAiDataProvider::AppName, "transcribe-audio"
+        );
+        assertEq("/transcribe-audio", action.path);
+        assertEq(DPAT_API, action.action_code);
+        assertEq("Transcribe Audio", action.display_name);
+        assertFalse(action.mutates_state);
+        assertEq(OpenAiTranscribeAudioDataProvider::ResponseType, action.output_type);
+        # every request field is exposed as an action option; required and preselected options come first
+        assertEq(sort(keys OpenAiTranscribeAudioRequestType::Fields), sort(keys action.options));
+        assertEq(("file", "model", "language", "response_format"), (keys action.options)[0..3]);
+        assertTrue(action.options.file.required);
+        assertEq(FileDataType, action.options.file.type);
+        assertTrue(action.options.model.required);
+        assertEq("gpt-4o-transcribe", action.options.model.default_value);
+        assertEq(("gpt-4o-transcribe", "gpt-4o-mini-transcribe", "whisper-1"),
+            map $1.value, action.options.model.allowed_values);
+        assertFalse(action.options.language.required ?? False);
+        assertTrue(action.options.language.preselected);
+        assertEq(("json", "text", "srt", "verbose_json", "vtt"),
+            map $1.value, action.options.response_format.allowed_values);
+        assertFalse(action.options.temperature.required ?? False);
+
+        # the action path must resolve in the root provider's child tree
+        FakeOpenAiRestClient rest();
+        OpenAiDataProvider root(rest);
+        assertEq("OpenAiTranscribeAudioDataProvider", root.getChildProviderPath("transcribe-audio").className());
+        assertTrue(inlist("transcribe-audio", root.getChildProviderNames()));
     }
 
     private usageIntern() {

--- a/examples/test/qlib/OpenAiDataProvider/OpenAiDataProvider.qtest
+++ b/examples/test/qlib/OpenAiDataProvider/OpenAiDataProvider.qtest
@@ -27,6 +27,8 @@ class FakeOpenAiRestClient inherits OpenAiRestClient::OpenAiRestClientIo {
         list<hash<SseMessageInfo>> stream_events;
         # raw (pre-serialized) requests: multipart uploads
         *data last_raw_body;
+        #! when set, restDoRawRequest() throws this exception instead of answering
+        *hash<auto> raw_error;
         # raw response body; a string for text response formats
         auto raw_response_body;
     }
@@ -61,6 +63,9 @@ class FakeOpenAiRestClient inherits OpenAiRestClient::OpenAiRestClientIo {
     }
 
     hash<RestClient::RestResponseInfo> restDoRawRequest(string method, string path, *data body, *hash<auto> hdr) {
+        if (raw_error) {
+            throw raw_error.err, raw_error.desc, raw_error.arg;
+        }
         last_method = method;
         last_path = path;
         last_raw_body = body;
@@ -1602,6 +1607,53 @@ public class OpenAiDataProviderTest inherits QUnit::Test {
         assertEq("0.2", parts.temperature.body.toString());
         assertEq("hello world", resp.text);
         assertEq("tokens", resp.usage.type);
+
+        # the FileDataType placeholder "auto" must never be sent as the part's Content-Type; the MIME type is
+        # taken from the file name instead
+        rest.raw_response_body = {"text": "wav"};
+        prov.doRequest({
+            "file": {
+                "name": "note.wav",
+                "mime_type": "auto",
+                "content": audio,
+            },
+            "model": "whisper-1",
+        });
+        parts = MultiPartFormDataMessage::parseMessage(rest.last_hdr."Content-Type", rest.last_raw_body.toString());
+        # the MIME type the framework derives for .wav
+        assertEq("audio/x-wav", parts.file.hdr."content-type");
+        assertEq("note.wav", parts.file.filename);
+
+        # an HTTP error keeps its status in the message and its argument (status, body) for the caller
+        rest.raw_error = {
+            "err": "REST-RESPONSE-ERROR",
+            "desc": "HTTP 400 response received",
+            "arg": {"status_code": 400, "body": {"error": {"message": "Unrecognized file format"}}},
+        };
+        try {
+            prov.doRequest({"file": {"name": "note.wav", "content": audio}, "model": "whisper-1"});
+            fail("an HTTP error must be raised");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("REST-RESPONSE-ERROR", ex.err);
+            assertRegex("HTTP response code: 400", ex.desc);
+            assertEq(400, ex.arg.status_code);
+            assertEq("Unrecognized file format", ex.arg.body.error.message, "the response body is preserved");
+        }
+        # a transport error without an HTTP status is rethrown unchanged instead of failing while formatting
+        rest.raw_error = {
+            "err": "TEST-TRANSPORT-ERROR",
+            "desc": "connection reset by peer",
+            "arg": {"detail": "no status here"},
+        };
+        try {
+            prov.doRequest({"file": {"name": "note.wav", "content": audio}, "model": "whisper-1"});
+            fail("a transport error must be raised");
+        } catch (hash<ExceptionInfo> ex) {
+            assertEq("TEST-TRANSPORT-ERROR", ex.err);
+            assertEq("connection reset by peer", ex.desc);
+            assertEq({"detail": "no status here"}, ex.arg);
+        }
+        rest.raw_error = NOTHING;
         assertEq(17, resp.usage.total_tokens);
 
         # verbose JSON response: the parsed body is returned as-is

--- a/examples/test/qlib/OpenAiDataProvider/OpenAiDataProvider.qtest
+++ b/examples/test/qlib/OpenAiDataProvider/OpenAiDataProvider.qtest
@@ -1705,7 +1705,7 @@ public class OpenAiDataProviderTest inherits QUnit::Test {
 
         # a missing file is rejected by the request type before any request is made
         rest.last_method = "";
-        assertThrows("INVALID-REQUEST", "mandatory hash field \"file\"", \prov.doRequest(), ({"model": "whisper-1"},));
+        assertThrows("INVALID-REQUEST", "field \"file\"", \prov.doRequest(), ({"model": "whisper-1"},));
         # the file name must have a supported audio extension
         assertThrows("TRANSCRIBE-AUDIO-ERROR", "notes.txt", \prov.doRequest(), ({
             "file": {

--- a/qlib/DeepgramDataProvider/DeepgramDataProvider.qm
+++ b/qlib/DeepgramDataProvider/DeepgramDataProvider.qm
@@ -30,7 +30,7 @@
 %requires RestClientIo
 
 module DeepgramDataProvider {
-    version = "1.0";
+    version = "1.1";
     desc = "user module providing a data provider API for Deepgram speech services";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -70,30 +70,24 @@ module DeepgramDataProvider {
             "path": "/transcribe-file",
             "action": "transcribe-file",
             "display_name": "Transcribe File",
-            "short_desc": "Transcribe an audio file by URL via Deepgram ASR",
-            "desc": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint "
-                "and returns the JSON transcript.  Supports the Nova model family "
-                "with smart formatting, diarization, summarization, and "
-                "language detection.\n\n"
-                "**Note**: this action submits via URL only.  For raw-audio uploads "
-                "and realtime WebSocket streaming, use "
-                "@ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" "
-                "directly.",
+            "short_desc": "Transcribe an audio file by URL or upload via Deepgram ASR",
+            "desc": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the "
+                "JSON transcript.  The audio is given either as a public `url` that "
+                "Deepgram fetches or as an `audio` file whose bytes are uploaded as "
+                "the request body; exactly one of the two must be provided.  Supports "
+                "the Nova model family with smart formatting, diarization, "
+                "summarization, and language detection.",
             "action_code": DPAT_API,
             "groups": ("Speech Recognition",),
             "options": DataProviderActionCatalog::getActionOptionFromFields(
-                DeepgramTranscribeFileRequestDataType::Fields{"url",}, {
-                    "preselected": True, "required": True,
-                }
-            ) + DataProviderActionCatalog::getActionOptionFromFields(
                 DeepgramTranscribeFileRequestDataType::Fields{
-                    "model", "language", "smart_format", "diarize",
+                    "url", "audio", "model", "language", "smart_format", "diarize",
                 }, {
                     "preselected": True,
                 }
             ) + DataProviderActionCatalog::getActionOptionFromFields(
                 DeepgramTranscribeFileRequestDataType::Fields - (
-                    "url", "model", "language", "smart_format", "diarize",
+                    "url", "audio", "model", "language", "smart_format", "diarize",
                 )
             ),
             "output_type": DeepgramTranscribeFileDataProvider::ResponseType,
@@ -140,9 +134,9 @@ module DeepgramDataProvider {
     [Deepgram](https://deepgram.com) speech services.
 
     Two DPAT_API actions are registered:
-    - `transcribe-file` — submit an audio URL to `/v1/listen` and receive
-      a JSON transcript (Nova model family, smart format, diarization,
-      summarization, language detection)
+    - `transcribe-file` — submit an audio URL, or upload the audio bytes
+      directly, to `/v1/listen` and receive a JSON transcript (Nova model
+      family, smart format, diarization, summarization, language detection)
     - `synthesize-speech` — submit text to `/v1/speak` and receive audio
       bytes (Aura voice models, MP3/WAV/Opus/FLAC encodings)
 
@@ -154,6 +148,13 @@ module DeepgramDataProvider {
     @ref deepgramrestclientintro "DeepgramRestClient" for direct API access.
 
     @section DeepgramDataProviderRelnotes Release Notes
+
+    @subsection DeepgramDataProviderv1_1 DeepgramDataProvider v1.1
+    - the `transcribe-file` action accepts the audio to transcribe as a new
+      `audio` input option — a file value (or raw audio bytes) uploaded as the
+      request body with its MIME type sent as the `Content-Type` — as an
+      alternative to the `url` option, which is now optional; exactly one of
+      the two must be given
 
     @subsection DeepgramDataProviderv1_0 DeepgramDataProvider v1.0
     - the initial version of the %DeepgramDataProvider module

--- a/qlib/DeepgramDataProvider/DeepgramDataProviderCommon.qc
+++ b/qlib/DeepgramDataProvider/DeepgramDataProviderCommon.qc
@@ -123,9 +123,39 @@ public class DeepgramDataProviderCommon inherits DataProvider::AbstractDataProvi
     }
 
     private hash<auto> doRestCommand(string method, string path, auto body, *hash<auto> hdr) {
+        return doRestCommandIntern(method, path, body, hdr, False);
+    }
+
+    #! Sends a request whose body is sent verbatim with the given \c Content-Type
+    /** The REST client's configured serialization (JSON) is bypassed by using its raw request
+        path, so a @ref binary body reaches the server byte-for-byte instead of being serialized
+        as a JSON string; the caller owns the body and its \c Content-Type.  Used by the
+        \c transcribe-file action to upload audio bytes to \c /v1/listen.
+
+        @param method the HTTP method
+        @param path the URI path
+        @param body the request body, sent unchanged
+        @param content_type the MIME type of \a body, sent as the \c Content-Type header
+        @param hdr any additional request headers
+
+        @return the REST response
+
+        @since DeepgramDataProvider 1.1
+    */
+    private hash<auto> doRawRestCommand(string method, string path, data body, string content_type,
+            *hash<auto> hdr) {
+        return doRestCommandIntern(method, path, body, (hdr ?? {}) + {"Content-Type": content_type}, True);
+    }
+
+    #! Common request path for doRestCommand() and doRawRestCommand()
+    private hash<auto> doRestCommandIntern(string method, string path, auto body, *hash<auto> hdr,
+            bool raw) {
         int retries = 0;
         while (True) {
             try {
+                if (raw) {
+                    return rest.restDoRawRequest(method.upr(), path, body, hdr);
+                }
                 switch (method.upr()) {
                     case "GET":
                         return rest.restGet(path, hdr);

--- a/qlib/DeepgramDataProvider/DeepgramDataTypes.qc
+++ b/qlib/DeepgramDataProvider/DeepgramDataTypes.qc
@@ -23,19 +23,84 @@
 */
 
 public namespace DeepgramDataProvider {
-#! Transcribe-file request: URL submission with model + ASR options
+#! File type for the transcribe-file \c audio input that also accepts raw audio bytes
+/** Upstream steps commonly produce raw @ref binary audio (the output of a recording or
+    download step, for example); wrapping it in a @ref DataProvider::FileDataType "file"
+    hash by hand would be needless friction, so a bare @ref binary value is accepted and
+    treated as the \c content of a file named
+    @ref DeepgramAudioFileDataType::RawAudioName "RawAudioName"; as that name has no
+    extension, the MIME type falls back to \c application/octet-stream
+
+    @since DeepgramDataProvider 1.1
+*/
+public class DeepgramAudioFileDataType inherits DataProvider::FileOrNothingDataType {
+    public {
+        #! Placeholder file name given to raw audio bytes (a file value requires a name)
+        const RawAudioName = "audio";
+    }
+
+    #! Creates the type
+    constructor() : FileOrNothingDataType() {}
+
+    #! Returns a hash of types accepted by this type; keys are type names
+    hash<string, bool> getAcceptTypeHash(*bool simple) {
+        return FileOrNothingDataType::getAcceptTypeHash(simple) + {
+            Type::Binary: True,
+        };
+    }
+
+    #! Returns the value if the value can be assigned to the type
+    /** @param value a @ref DataProvider::FileDataType "file" hash or raw @ref binary audio
+
+        @return the file hash; raw binary is wrapped as \c {"name": RawAudioName, "content": value}
+        before the file validation runs (which base64-encodes the content)
+
+        @throw RUNTIME-TYPE-ERROR value cannot be assigned to type
+    */
+    auto acceptsValue(auto value) {
+        if (value.typeCode() == NT_BINARY) {
+            # the file validation replaces the content with its base64 encoding, so the wrapper must
+            # be a hash<auto>, not the hash<string, binary> a bare literal would create
+            return FileOrNothingDataType::acceptsValue({} + {"name": RawAudioName, "content": value});
+        }
+        return FileOrNothingDataType::acceptsValue(value);
+    }
+}
+
+#! Transcribe-file request: URL or uploaded audio with model + ASR options
 public class DeepgramTranscribeFileRequestDataType inherits HashDataType {
     public {
         const Fields = {
             "url": {
                 "display_name": "Audio URL",
                 "short_desc": "Public URL of the audio file to transcribe",
-                "type": AbstractDataProviderTypeMap."string",
+                "type": AbstractDataProviderTypeMap."*string",
                 "desc": "Public URL of the audio file to transcribe.  Deepgram fetches "
                     "the file from this URL; it must be reachable from the public "
-                    "internet.",
-                "required": True,
+                    "internet.\n\n"
+                    "Exactly one of `url` or `audio` must be provided.",
                 "example_value": "https://example.com/audio.wav",
+                "attr": {
+                    "required_groups": ("audio_source",),
+                    "exclusive_with": "audio",
+                },
+            },
+            "audio": {
+                "display_name": "Audio File",
+                "short_desc": "Audio file to upload for transcription",
+                "type": new DeepgramAudioFileDataType(),
+                "desc": "The audio file to transcribe, uploaded as the request body; used "
+                    "when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, "
+                    "`audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; "
+                    "when it is `auto`, it is derived from the file `name`, falling back "
+                    "to `application/octet-stream`.  Upstream steps can pass either a "
+                    "file hash (`name`, `content`, `mime_type`) or the raw audio bytes "
+                    "as a `binary` value.\n\n"
+                    "Exactly one of `url` or `audio` must be provided.",
+                "attr": {
+                    "required_groups": ("audio_source",),
+                    "exclusive_with": "url",
+                },
             },
             "model": {
                 "display_name": "Model",

--- a/qlib/DeepgramDataProvider/DeepgramTranscribeFileDataProvider.qc
+++ b/qlib/DeepgramDataProvider/DeepgramTranscribeFileDataProvider.qc
@@ -50,12 +50,58 @@ public class DeepgramTranscribeFileDataProvider inherits DeepgramDataProviderCom
     private hash<DataProviderInfo> getStaticInfoImpl() { return ProviderInfo; }
 
     private auto doRequestImpl(auto req, *hash<auto> request_options) {
-        # URL goes in JSON body; all other parameters go in the query string
-        hash<auto> query_params = req - "url";
+        bool has_url = req.url.val();
+        bool has_audio = exists req.audio;
+        if (has_url == has_audio) {
+            throw "DEEPGRAM-TRANSCRIBE-ERROR", sprintf("exactly one of \"url\" or \"audio\" must be "
+                "provided; got %s", has_url ? "both" : "neither");
+        }
+        # The audio source goes in the request body; all other parameters go in the query string
+        hash<auto> query_params = req - ("url", "audio");
         string path = "/v1/listen"
             + DeepgramDataProviderCommon::buildQueryString(query_params);
+        if (has_audio) {
+            # the audio bytes are the body; Deepgram reads the container format from the Content-Type
+            return doRawRestCommand("POST", path, getAudioContent(req.audio),
+                getAudioMimeType(req.audio)).body;
+        }
         hash<auto> body = {"url": req.url};
         return doRestCommand("POST", path, body).body;
+    }
+
+    #! Returns the binary content of a file value
+    /** The content is declared as base64 but may already have been decoded upstream, so both forms are
+        accepted
+
+        @param file the file value
+
+        @return the content as binary
+
+        @since DeepgramDataProvider 1.1
+    */
+    static binary getAudioContent(hash<auto> file) {
+        if (file.content.typeCode() == NT_BINARY) {
+            return file.content;
+        }
+        return parse_base64_string(file.content.toString());
+    }
+
+    #! Returns the MIME type to send as the \c Content-Type for a file value
+    /** @param file the file value
+
+        @return the MIME type carried by the file, or one inferred from its name, or
+        \c application/octet-stream
+
+        @note \c "auto" is the @ref DataProvider::FileDataType "FileDataType" placeholder meaning "work it
+        out from the name", so it is treated as absent rather than sent literally
+
+        @since DeepgramDataProvider 1.1
+    */
+    static string getAudioMimeType(hash<auto> file) {
+        if (file.mime_type.val() && file.mime_type != "auto") {
+            return file.mime_type;
+        }
+        return file.name.val() ? get_mime_type_from_ext(file.name) : MimeTypeOctetStream;
     }
 }
 }

--- a/qlib/DeepgramDataProvider/DeepgramTranscribeFileDataProvider.qc
+++ b/qlib/DeepgramDataProvider/DeepgramTranscribeFileDataProvider.qc
@@ -50,8 +50,9 @@ public class DeepgramTranscribeFileDataProvider inherits DeepgramDataProviderCom
     private hash<DataProviderInfo> getStaticInfoImpl() { return ProviderInfo; }
 
     private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        # value presence, not key presence: an unset option can arrive as a key with no value
         bool has_url = req.url.val();
-        bool has_audio = exists req.audio;
+        bool has_audio = req.audio.val();
         if (has_url == has_audio) {
             throw "DEEPGRAM-TRANSCRIBE-ERROR", sprintf("exactly one of \"url\" or \"audio\" must be "
                 "provided; got %s", has_url ? "both" : "neither");

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/cs.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/cs.json
@@ -344,12 +344,12 @@
           "message": "Přepsat soubor"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Přepsat zvukový soubor z URL pomocí Deepgram ASR"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Přepsat zvukový soubor z URL nebo nahráním pomocí Deepgram ASR"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "Odešle veřejnou URL adresu zvuku do koncového bodu Deepgram `/v1/listen` a vrátí přepis ve formátu JSON. Podporuje rodinu modelů Nova s inteligentním formátováním, diarizací, sumarizací a detekcí jazyka.\n\n**Poznámka**: tato akce odesílá pouze prostřednictvím URL. Pro nahrávání nezpracovaného zvuku a streamování v reálném čase přes WebSocket použijte přímo @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "Odešle zvuk do koncového bodu Deepgram `/v1/listen` a vrátí přepis ve formátu JSON. Zvuk se zadává buď jako veřejná `url`, kterou Deepgram stáhne, nebo jako soubor `audio`, jehož bajty se nahrají jako tělo požadavku; musí být zadán právě jeden z nich. Podporuje rodinu modelů Nova s inteligentním formátováním, diarizací, sumarizací a detekcí jazyka."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "Veřejná URL adresa zvukového souboru k přepisu"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "Veřejná URL adresa zvukového souboru k přepisu. Deepgram stáhne soubor z této URL adresy; musí být dostupná z veřejného internetu."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Veřejná URL adresa zvukového souboru k přepisu. Deepgram stáhne soubor z této URL adresy; musí být dostupná z veřejného internetu.\n\nMusí být zadán právě jeden z parametrů `url` nebo `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "Zvukový soubor"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "Zvukový soubor k nahrání pro přepis"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Zvukový soubor k přepisu, nahraný jako tělo požadavku; použije se, když není zadána `url`. Hodnota `mime_type` souboru (např. `audio/wav`, `audio/mpeg`, `audio/flac`) se odešle jako `Content-Type` požadavku; pokud je `auto`, odvodí se z názvu souboru `name`, jinak se použije `application/octet-stream`. Předchozí kroky mohou předat buď hash souboru (`name`, `content`, `mime_type`), nebo nezpracované bajty zvuku jako hodnotu typu `binary`.\n\nMusí být zadán právě jeden z parametrů `url` nebo `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Data souboru"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 kódovaná data souboru nebo surová data k zakódování pomocí base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 kódovaná data souboru nebo surová data k zakódování pomocí base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME typ"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Řetězec MIME typu pro soubor"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Řetězec MIME typu pro soubor"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Automatické rozpoznání"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické rozpoznání z názvu souboru; platné jen pro vstup"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické rozpoznání z názvu souboru; platné jen pro vstup"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Prostý text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Prostý text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Soubor PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Soubor PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Soubor MS Word docx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Soubor MS Word `docx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Soubor MS PowerPoint pptx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Soubor MS PowerPoint `pptx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Soubor MS Excel xlsx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Soubor MS Excel `xlsx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Název souboru"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Název souboru"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Název souboru"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/de.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/de.json
@@ -344,12 +344,12 @@
           "message": "Datei transkribieren"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Eine Audiodatei per URL über Deepgram ASR transkribieren"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Eine Audiodatei per URL oder Upload über Deepgram ASR transkribieren"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "Übermittelt eine öffentliche Audio-URL an den `/v1/listen`-Endpunkt von Deepgram und gibt das JSON-Transkript zurück. Unterstützt die Nova-Modellfamilie mit intelligenter Formatierung, Diarisierung, Zusammenfassung und Spracherkennung.\n\n**Hinweis**: Diese Aktion übermittelt nur per URL. Für Roh-Audio-Uploads und Echtzeit-WebSocket-Streaming verwenden Sie direkt @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "Übermittelt Audio an den `/v1/listen`-Endpunkt von Deepgram und gibt das JSON-Transkript zurück. Das Audio wird entweder als öffentliche `url`, die Deepgram abruft, oder als `audio`-Datei angegeben, deren Bytes als Anfragetext hochgeladen werden; genau eines von beiden muss angegeben werden. Unterstützt die Nova-Modellfamilie mit intelligenter Formatierung, Diarisierung, Zusammenfassung und Spracherkennung."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "Öffentliche URL der zu transkribierenden Audiodatei"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "Öffentliche URL der zu transkribierenden Audiodatei. Deepgram ruft die Datei von dieser URL ab; sie muss über das öffentliche Internet erreichbar sein."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Öffentliche URL der zu transkribierenden Audiodatei. Deepgram ruft die Datei von dieser URL ab; sie muss über das öffentliche Internet erreichbar sein.\n\nGenau eines von `url` oder `audio` muss angegeben werden."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "Audiodatei"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "Für die Transkription hochzuladende Audiodatei"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Die zu transkribierende Audiodatei, hochgeladen als Anfragetext; wird verwendet, wenn keine `url` angegeben ist. Der `mime_type` der Datei (z. B. `audio/wav`, `audio/mpeg`, `audio/flac`) wird als `Content-Type` der Anfrage gesendet; bei `auto` wird er aus dem Dateinamen `name` abgeleitet, andernfalls wird `application/octet-stream` verwendet. Vorgelagerte Schritte können entweder einen Datei-Hash (`name`, `content`, `mime_type`) oder die rohen Audio-Bytes als `binary`-Wert übergeben.\n\nGenau eines von `url` oder `audio` muss angegeben werden."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dateidaten"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-codierte Dateidaten oder Rohdaten, die mit Base64 kodiert werden sollen"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-codierte Dateidaten oder Rohdaten, die mit Base64 kodiert werden sollen"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME-Typ"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Die MIME-Typ-Zeichenkette für die Datei"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Die MIME-Typ-Zeichenkette für die Datei"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Automatische Erkennung"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatische Erkennung aus dem Dateinamen; nur für Eingaben gültig"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatische Erkennung aus dem Dateinamen; nur für Eingaben gültig"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Klartext"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Klartext"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML-Text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML-Text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF-Datei"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF-Datei"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx-Dokument"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx`-Dokument"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx-Dokument"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx`-Dokument"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx-Dokument"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx`-Dokument"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Dateiname"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Der Dateiname"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Der Dateiname"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/es.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/es.json
@@ -344,12 +344,12 @@
           "message": "Transcribir archivo"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Transcribir un archivo de audio por URL mediante Deepgram ASR"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Transcribir un archivo de audio por URL o mediante carga con Deepgram ASR"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "Envía una URL pública de audio al endpoint `/v1/listen` de Deepgram y devuelve la transcripción en JSON. Es compatible con la familia de modelos Nova con formato inteligente, diarización, generación de resúmenes y detección de idioma.\n\n**Nota**: esta acción solo realiza envíos mediante URL. Para cargas de audio sin procesar y transmisión WebSocket en tiempo real, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directamente."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "Envía audio al endpoint `/v1/listen` de Deepgram y devuelve la transcripción en JSON. El audio se indica como una `url` pública que Deepgram obtiene o como un archivo `audio` cuyos bytes se cargan como cuerpo de la solicitud; debe proporcionarse exactamente uno de los dos. Es compatible con la familia de modelos Nova con formato inteligente, diarización, generación de resúmenes y detección de idioma."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "URL pública del archivo de audio para transcribir"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "URL pública del archivo de audio para transcribir. Deepgram obtiene el archivo desde esta URL; debe ser accesible desde la red pública de Internet."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "URL pública del archivo de audio para transcribir. Deepgram obtiene el archivo desde esta URL; debe ser accesible desde la red pública de Internet.\n\nDebe proporcionarse exactamente uno de `url` o `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "Archivo de audio"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "Archivo de audio para cargar y transcribir"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "El archivo de audio para transcribir, cargado como cuerpo de la solicitud; se usa cuando no se indica `url`. El `mime_type` del archivo (p. ej. `audio/wav`, `audio/mpeg`, `audio/flac`) se envía como `Content-Type` de la solicitud; cuando es `auto`, se deriva del nombre de archivo `name`, y en su defecto se usa `application/octet-stream`. Los pasos anteriores pueden pasar un hash de archivo (`name`, `content`, `mime_type`) o los bytes de audio sin procesar como un valor `binary`.\n\nDebe proporcionarse exactamente uno de `url` o `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Datos del archivo"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Datos de archivo codificados en Base64 o datos brutos para codificar con codificación Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Datos de archivo codificados en Base64 o datos brutos para codificar con codificación Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Tipo MIME"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "La cadena MIME para el archivo"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "La cadena MIME para el archivo"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Detección automática"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Detectar automáticamente del nombre de archivo; válido solo en entrada"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Detectar automáticamente del nombre de archivo; válido solo en entrada"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Texto sin formato"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Texto sin formato"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Texto HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Texto HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Archivo PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Archivo PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Documento MS Word docx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Documento de MS Word `docx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Documento MS PowerPoint pptx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Documento de MS PowerPoint `pptx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Documento MS Excel xlsx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Documento de MS Excel `xlsx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nombre de archivo"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "El nombre del archivo"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "El nombre del archivo"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/fr.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/fr.json
@@ -344,12 +344,12 @@
           "message": "Transcrire un fichier"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Transcrire un fichier audio par URL via Deepgram ASR"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Transcrire un fichier audio par URL ou par téléversement via Deepgram ASR"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "Soumet une URL audio publique au point de terminaison `/v1/listen` de Deepgram et renvoie la transcription JSON. Prend en charge la famille de modèles Nova avec le formatage intelligent, la diarisation, le résumé et la détection de la langue.\n\n**Remarque** : cette action s'effectue uniquement via une URL. Pour les téléversements d'audio brut et le streaming WebSocket en temps réel, utilisez directement @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "Soumet l'audio au point de terminaison `/v1/listen` de Deepgram et renvoie la transcription JSON. L'audio est fourni soit sous forme d'`url` publique que Deepgram récupère, soit sous forme de fichier `audio` dont les octets sont téléversés comme corps de la requête ; exactement l'un des deux doit être fourni. Prend en charge la famille de modèles Nova avec le formatage intelligent, la diarisation, le résumé et la détection de la langue."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "URL publique du fichier audio à transcrire"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "URL publique du fichier audio à transcrire. Deepgram récupère le fichier à partir de cette URL ; elle doit être accessible depuis l'Internet public."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "URL publique du fichier audio à transcrire. Deepgram récupère le fichier à partir de cette URL ; elle doit être accessible depuis l'Internet public.\n\nExactement l'un des paramètres `url` ou `audio` doit être fourni."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "Fichier audio"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "Fichier audio à téléverser pour la transcription"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Le fichier audio à transcrire, téléversé comme corps de la requête ; utilisé lorsque `url` n'est pas fourni. Le `mime_type` du fichier (par ex. `audio/wav`, `audio/mpeg`, `audio/flac`) est envoyé comme `Content-Type` de la requête ; s'il vaut `auto`, il est déduit du nom de fichier `name`, avec `application/octet-stream` par défaut. Les étapes en amont peuvent transmettre soit un hachage de fichier (`name`, `content`, `mime_type`), soit les octets audio bruts sous forme de valeur `binary`.\n\nExactement l'un des paramètres `url` ou `audio` doit être fourni."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Données du fichier"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Données de fichier encodées en Base64 ou données brutes à encoder en Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Données de fichier encodées en Base64 ou données brutes à encoder en Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Type MIME"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "La chaîne de type MIME pour le fichier"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "La chaîne de type MIME pour le fichier"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Détection automatique"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Détection automatique à partir du nom de fichier ; valable uniquement en entrée"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Détection automatique à partir du nom de fichier ; valable uniquement en entrée"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Texte brut"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Texte brut"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Texte HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Texte HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Fichier PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Fichier PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Document Word docx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Document Word `docx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Document PowerPoint pptx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Document PowerPoint `pptx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Document Excel xlsx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Document Excel `xlsx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nom de fichier"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Le nom du fichier"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Le nom du fichier"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/it.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/it.json
@@ -344,12 +344,12 @@
           "message": "Trascrivi file"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Trascrivi un file audio da URL tramite Deepgram ASR"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Trascrivi un file audio da URL o tramite caricamento con Deepgram ASR"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "Invia un URL audio pubblico all'endpoint `/v1/listen` di Deepgram e restituisce la trascrizione JSON. Supporta la famiglia di modelli Nova con formattazione intelligente, diarizzazione, riassunto e rilevamento della lingua.\n\n**Nota**: questa azione invia solo tramite URL. Per i caricamenti di audio non elaborato e lo streaming WebSocket in tempo reale, usa direttamente @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "Invia l'audio all'endpoint `/v1/listen` di Deepgram e restituisce la trascrizione JSON. L'audio viene fornito come `url` pubblico che Deepgram recupera oppure come file `audio` i cui byte vengono caricati come corpo della richiesta; deve essere fornito esattamente uno dei due. Supporta la famiglia di modelli Nova con formattazione intelligente, diarizzazione, riassunto e rilevamento della lingua."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "URL pubblico del file audio da trascrivere"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "URL pubblico del file audio da trascrivere. Deepgram recupera il file da questo URL; deve essere raggiungibile da Internet pubblico."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "URL pubblico del file audio da trascrivere. Deepgram recupera il file da questo URL; deve essere raggiungibile da Internet pubblico.\n\nDeve essere fornito esattamente uno tra `url` e `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "File audio"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "File audio da caricare per la trascrizione"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Il file audio da trascrivere, caricato come corpo della richiesta; usato quando `url` non è specificato. Il `mime_type` del file (ad es. `audio/wav`, `audio/mpeg`, `audio/flac`) viene inviato come `Content-Type` della richiesta; se è `auto`, viene ricavato dal nome del file `name`, altrimenti viene usato `application/octet-stream`. I passaggi a monte possono passare un hash di file (`name`, `content`, `mime_type`) oppure i byte audio grezzi come valore `binary`.\n\nDeve essere fornito esattamente uno tra `url` e `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dati File"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dati file codificati in Base64 o dati grezzi da codificare con l'encoding Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dati file codificati in Base64 o dati grezzi da codificare con l'encoding Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Tipo MIME"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Stringa tipo MIME del file"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Stringa tipo MIME del file"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Rilevamento automatico"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Rilevamento automatico dal nome del file; valido solo in input"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Rilevamento automatico dal nome del file; valido solo in input"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Testo normale"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Testo normale"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Testo HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Testo HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "File PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "File PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Documento MS Word docx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Documento MS Word `docx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Documento MS PowerPoint pptx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Documento MS PowerPoint `pptx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Documento MS Excel xlsx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Documento MS Excel `xlsx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nome file"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Il nome del file"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Il nome del file"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/ja.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/ja.json
@@ -344,12 +344,12 @@
           "message": "ファイルの文字起こし"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Deepgram ASRを介してURLから音声ファイルを文字起こし"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Deepgram ASRを介してURLまたはアップロードから音声ファイルを文字起こし"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "公開音声URLをDeepgramの`/v1/listen`エンドポイントに送信し、JSON文字起こし結果を返します。スマートフォーマット、話者分離、要約、言語検出を備えたNovaモデルファミリーをサポートしています。\n\n**注意**: このアクションはURL経由での送信のみ行います。RAW音声のアップロードやリアルタイムWebSocketストリーミングには、@ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"を直接使用してください。"
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "音声をDeepgramの`/v1/listen`エンドポイントに送信し、JSON文字起こし結果を返します。音声は、Deepgramが取得する公開`url`として、またはバイト列をリクエストボディとしてアップロードする`audio`ファイルとして指定します。どちらか一方のみを指定する必要があります。スマートフォーマット、話者分離、要約、言語検出を備えたNovaモデルファミリーをサポートしています。"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "文字起こしを行う音声ファイルのパブリックURL"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "文字起こしする音声ファイルの公開URL。DeepgramはこのURLからファイルを取得します。パブリックインターネットからアクセス可能である必要があります。"
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "文字起こしする音声ファイルの公開URL。DeepgramはこのURLからファイルを取得します。パブリックインターネットからアクセス可能である必要があります。\n\n`url`と`audio`のどちらか一方のみを指定する必要があります。"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "音声ファイル"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "文字起こしのためにアップロードする音声ファイル"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "文字起こしする音声ファイル。リクエストボディとしてアップロードされ、`url`が指定されていない場合に使用されます。ファイルの`mime_type`（例: `audio/wav`、`audio/mpeg`、`audio/flac`）がリクエストの`Content-Type`として送信されます。`auto`の場合はファイル名`name`から導出され、導出できない場合は`application/octet-stream`が使用されます。上流のステップは、ファイルハッシュ（`name`、`content`、`mime_type`）またはRAW音声バイト列を`binary`値として渡すことができます。\n\n`url`と`audio`のどちらか一方のみを指定する必要があります。"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "ファイルデータ"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64でエンコードされたファイルデータまたは、Base64エンコードでエンコードされるべき生データ"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64でエンコードされたファイルデータまたは、Base64エンコードでエンコードされるべき生データ"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME タイプ"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "ファイルのMIMEタイプ文字列"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "ファイルのMIMEタイプ文字列"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "自動検出"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "ファイル名から自動検出；入力時のみ有効"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "ファイル名から自動検出；入力時のみ有効"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "プレーンテキスト"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "プレーンテキスト"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTMLテキスト"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTMLテキスト"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF ファイル"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF ファイル"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx ドキュメント"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` ドキュメント"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx ドキュメント"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` ドキュメント"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx ドキュメント"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` ドキュメント"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "ファイル名"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "ファイル名"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "ファイル名"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/ko.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/ko.json
@@ -344,12 +344,12 @@
           "message": "파일 텍스트 변환"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Deepgram ASR을 통해 URL로 오디오 파일 텍스트 변환"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Deepgram ASR을 통해 URL 또는 업로드로 오디오 파일 텍스트 변환"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "공개 오디오 URL을 Deepgram의 `/v1/listen` 엔드포인트에 제출하고 JSON 트랜스크립트를 반환합니다. 스마트 포맷팅, 화자 분리(diarization), 요약 및 언어 감지 기능을 갖춘 Nova 모델 제품군을 지원합니다.\n\n**참고**: 이 작업은 URL을 통해서만 제출합니다. 원시 오디오 업로드 및 실시간 WebSocket 스트리밍의 경우 @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"를 직접 사용하세요."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "오디오를 Deepgram의 `/v1/listen` 엔드포인트에 제출하고 JSON 트랜스크립트를 반환합니다. 오디오는 Deepgram이 가져오는 공개 `url` 또는 바이트가 요청 본문으로 업로드되는 `audio` 파일 중 하나로 지정하며, 둘 중 정확히 하나만 제공해야 합니다. 스마트 포맷팅, 화자 분리(diarization), 요약 및 언어 감지 기능을 갖춘 Nova 모델 제품군을 지원합니다."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "텍스트로 변환할 오디오 파일의 공개 URL"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "텍스트로 변환할 오디오 파일의 공개 URL입니다. Deepgram이 이 URL에서 파일을 가져오므로 공용 인터넷에서 접근할 수 있어야 합니다."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "텍스트로 변환할 오디오 파일의 공개 URL입니다. Deepgram이 이 URL에서 파일을 가져오므로 공용 인터넷에서 접근할 수 있어야 합니다.\n\n`url` 또는 `audio` 중 정확히 하나만 제공해야 합니다."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "오디오 파일"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "텍스트 변환을 위해 업로드할 오디오 파일"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "텍스트로 변환할 오디오 파일로, 요청 본문으로 업로드되며 `url`이 지정되지 않은 경우에 사용됩니다. 파일의 `mime_type`(예: `audio/wav`, `audio/mpeg`, `audio/flac`)이 요청의 `Content-Type`으로 전송되며, `auto`인 경우 파일 이름 `name`에서 유추하고 그렇지 않으면 `application/octet-stream`을 사용합니다. 업스트림 단계에서는 파일 해시(`name`, `content`, `mime_type`) 또는 원시 오디오 바이트를 `binary` 값으로 전달할 수 있습니다.\n\n`url` 또는 `audio` 중 정확히 하나만 제공해야 합니다."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "파일 데이터"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 인코딩된 파일 데이터 또는 Base64로 인코딩할 원시 데이터"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 인코딩된 파일 데이터 또는 Base64로 인코딩할 원시 데이터"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME 유형"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "파일에 대한 MIME 유형 문자열"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "파일에 대한 MIME 유형 문자열"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "자동 감지"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "파일 이름에서 자동 감지; 입력 시에만 유효"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "파일 이름에서 자동 감지; 입력 시에만 유효"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "일반 텍스트"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "일반 텍스트"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 텍스트"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 텍스트"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF 파일"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF 파일"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx 문서"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` 문서"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx 문서"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` 문서"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx 문서"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` 문서"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "파일 이름"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "파일 이름"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "파일 이름"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/pl.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/pl.json
@@ -344,12 +344,12 @@
           "message": "Transkrybuj plik"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Transkrybuj plik audio z adresu URL za pomocą Deepgram ASR"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Transkrybuj plik audio z adresu URL lub przez przesłanie za pomocą Deepgram ASR"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "Przesyła publiczny adres URL audio do punktu końcowego `/v1/listen` usługi Deepgram i zwraca transkrypcję JSON. Obsługuje rodzinę modeli Nova z inteligentnym formatowaniem, diaryzacją, podsumowywaniem i wykrywaniem języka.\n\n**Uwaga**: to działanie przesyła dane tylko za pośrednictwem adresu URL. W przypadku przesyłania surowego dźwięku i strumieniowania WebSocket w czasie rzeczywistym użyj bezpośrednio @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "Przesyła dźwięk do punktu końcowego `/v1/listen` usługi Deepgram i zwraca transkrypcję JSON. Dźwięk podaje się jako publiczny `url`, który Deepgram pobiera, albo jako plik `audio`, którego bajty są przesyłane jako treść żądania; należy podać dokładnie jedno z nich. Obsługuje rodzinę modeli Nova z inteligentnym formatowaniem, diaryzacją, podsumowywaniem i wykrywaniem języka."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "Publiczny adres URL pliku audio do transkrypcji"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "Publiczny adres URL pliku audio do transkrypcji. Deepgram pobiera plik z tego adresu URL; musi być on dostępny z publicznego internetu."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Publiczny adres URL pliku audio do transkrypcji. Deepgram pobiera plik z tego adresu URL; musi być on dostępny z publicznego internetu.\n\nNależy podać dokładnie jedno z: `url` lub `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "Plik audio"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "Plik audio do przesłania w celu transkrypcji"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Plik audio do transkrypcji, przesyłany jako treść żądania; używany, gdy nie podano `url`. Wartość `mime_type` pliku (np. `audio/wav`, `audio/mpeg`, `audio/flac`) jest wysyłana jako `Content-Type` żądania; gdy ma wartość `auto`, jest wyprowadzana z nazwy pliku `name`, a w przeciwnym razie używana jest wartość `application/octet-stream`. Poprzednie kroki mogą przekazać hash pliku (`name`, `content`, `mime_type`) albo surowe bajty dźwięku jako wartość `binary`.\n\nNależy podać dokładnie jedno z: `url` lub `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dane pliku"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dane pliku zakodowane w formacie Base64 lub dane surowe do zakodowania w formacie Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dane pliku zakodowane w formacie Base64 lub dane surowe do zakodowania w formacie Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Typ MIME"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Ciąg typu MIME pliku"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Ciąg typu MIME pliku"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Wykrywanie automatyczne"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Wykrywanie automatyczne na podstawie nazwy pliku; ważne tylko dla danych wejściowych"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Wykrywanie automatyczne na podstawie nazwy pliku; ważne tylko dla danych wejściowych"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Zwykły tekst"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Zwykły tekst"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Tekst HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Tekst HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Plik PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Plik PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Dokument MS Word docx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Dokument MS Word `docx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Dokument MS PowerPoint pptx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Dokument MS PowerPoint `pptx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Dokument MS Excel xlsx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Dokument MS Excel `xlsx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nazwa pliku"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Nazwa pliku"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Nazwa pliku"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/root.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/root.json
@@ -344,12 +344,12 @@
           "message": "Transcribe File"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Transcribe an audio file by URL via Deepgram ASR"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Transcribe an audio file by URL or upload via Deepgram ASR"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "Public URL of the audio file to transcribe"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "Audio File"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "Audio file to upload for transcription"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "File Data"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-encoded file data or raw data to be encoded with base64 encoding"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-encoded file data or raw data to be encoded with base64 encoding"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME Type"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "The MIME type string for the file"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "The MIME type string for the file"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Autodetect"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Autodetect from the file name; valid only on input"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Autodetect from the file name; valid only on input"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Plain text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Plain text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF file"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF file"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Filename"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "The filename"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "The filename"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/sk.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/sk.json
@@ -344,12 +344,12 @@
           "message": "Prepísať súbor"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Prepísať zvukový súbor z URL adresy cez Deepgram ASR"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Prepísať zvukový súbor z URL adresy alebo nahraním cez Deepgram ASR"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "Odošle verejnú URL adresu zvuku na koncový bod `/v1/listen` služby Deepgram a vráti prepis vo formáte JSON. Podporuje rodinu modelov Nova s inteligentným formátovaním, diarizáciou, sumarizáciou a detekciou jazyka.\n\n**Poznámka**: táto akcia odosiela údaje iba cez URL adresu. Pre nahrávanie nespracovaného zvuku a streamovanie cez WebSocket v reálnom čase použite priamo @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "Odošle zvuk na koncový bod `/v1/listen` služby Deepgram a vráti prepis vo formáte JSON. Zvuk sa zadáva buď ako verejná `url`, ktorú Deepgram stiahne, alebo ako súbor `audio`, ktorého bajty sa nahrajú ako telo požiadavky; musí byť zadaný práve jeden z nich. Podporuje rodinu modelov Nova s inteligentným formátovaním, diarizáciou, sumarizáciou a detekciou jazyka."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "Verejná URL adresa zvukového súboru na prepis"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "Verejná URL adresa zvukového súboru na prepis. Deepgram získa súbor z tejto URL adresy; musí byť dostupná z verejného internetu."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Verejná URL adresa zvukového súboru na prepis. Deepgram získa súbor z tejto URL adresy; musí byť dostupná z verejného internetu.\n\nMusí byť zadaný práve jeden z parametrov `url` alebo `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "Zvukový súbor"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "Zvukový súbor na nahranie na prepis"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Zvukový súbor na prepis, nahraný ako telo požiadavky; použije sa, keď nie je zadaná `url`. Hodnota `mime_type` súboru (napr. `audio/wav`, `audio/mpeg`, `audio/flac`) sa odošle ako `Content-Type` požiadavky; ak je `auto`, odvodí sa z názvu súboru `name`, inak sa použije `application/octet-stream`. Predchádzajúce kroky môžu odovzdať buď hash súboru (`name`, `content`, `mime_type`), alebo nespracované bajty zvuku ako hodnotu typu `binary`.\n\nMusí byť zadaný práve jeden z parametrov `url` alebo `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dáta súboru"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dáta súboru zakódované v Base64 alebo nezakódované dáta, ktoré sa majú zakódovať pomocou Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dáta súboru zakódované v Base64 alebo nezakódované dáta, ktoré sa majú zakódovať pomocou Base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Typ MIME"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Reťazec MIME typu súboru"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Reťazec MIME typu súboru"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Automatické detekovanie"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické detekovanie z názvu súboru; platné iba pri vstupe"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické detekovanie z názvu súboru; platné iba pri vstupe"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Obyčajný text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Obyčajný text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF súbor"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF súbor"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Dokument MS Word docx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Dokument MS Word `docx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Dokument MS PowerPoint pptx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Dokument MS PowerPoint `pptx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Dokument MS Excel xlsx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Dokument MS Excel `xlsx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Názov súboru"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Názov súboru"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Názov súboru"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/uk.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/uk.json
@@ -344,12 +344,12 @@
           "message": "Транскрибувати файл"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "Транскрибувати аудіофайл за URL-адресою через Deepgram ASR"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "Транскрибувати аудіофайл за URL-адресою або через завантаження за допомогою Deepgram ASR"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "Надсилає публічну URL-адресу аудіо до кінцевої точки Deepgram `/v1/listen` і повертає транскрипт JSON. Підтримує сімейство моделей Nova з розумним форматуванням, діарізацією, узагальненням та визначенням мови.\n\n**Примітка**: ця дія надсилає дані лише через URL-адресу. Для завантаження необробленого аудіо та потокової передачі через WebSocket у реальному часі використовуйте безпосередньо @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"."
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "Надсилає аудіо до кінцевої точки Deepgram `/v1/listen` і повертає транскрипт JSON. Аудіо задається або як публічна `url`, яку завантажує Deepgram, або як файл `audio`, байти якого надсилаються як тіло запиту; потрібно вказати рівно один із них. Підтримує сімейство моделей Nova з розумним форматуванням, діарізацією, узагальненням та визначенням мови."
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "Публічна URL-адреса аудіофайлу для транскрибування"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "Публічна URL-адреса аудіофайлу для транскрибування. Deepgram завантажує файл за цією URL-адресою; вона має бути доступна з публічного інтернету."
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Публічна URL-адреса аудіофайлу для транскрибування. Deepgram завантажує файл за цією URL-адресою; вона має бути доступна з публічного інтернету.\n\nПотрібно вказати рівно один із параметрів: `url` або `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "Аудіофайл"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "Аудіофайл для завантаження на транскрибування"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "Аудіофайл для транскрибування, що надсилається як тіло запиту; використовується, якщо `url` не вказано. Значення `mime_type` файлу (наприклад, `audio/wav`, `audio/mpeg`, `audio/flac`) надсилається як `Content-Type` запиту; якщо воно дорівнює `auto`, його буде визначено з імені файлу `name`, інакше використовується `application/octet-stream`. Попередні кроки можуть передати або хеш файлу (`name`, `content`, `mime_type`), або необроблені байти аудіо як значення `binary`.\n\nПотрібно вказати рівно один із параметрів: `url` або `audio`."
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Дані файлу"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Дані файлу у форматі base64 або сирові дані, що кодуються за допомогою base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Дані файлу у форматі base64 або сирові дані, що кодуються за допомогою base64"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME-тип"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Строка MIME-типу файлу"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Строка MIME-типу файлу"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Автоматичне визначення"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Автоматичне визначення за назвою файлу; дійсно лише для вхідних даних"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Автоматичне визначення за назвою файлу; дійсно лише для вхідних даних"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Звичайний текст"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Звичайний текст"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Текст HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Текст HTML"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Файл PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Файл PDF"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Документ MS Word docx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Документ MS Word `docx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Документ MS PowerPoint pptx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Документ MS PowerPoint `pptx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Документ MS Excel xlsx"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Документ MS Excel `xlsx`"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Назва файлу"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Ім’я файлу"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Ім’я файлу"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/zh-Hant.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/zh-Hant.json
@@ -344,12 +344,12 @@
           "message": "轉錄檔案"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "透過 Deepgram ASR 根據 URL 轉錄音訊檔案"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "透過 Deepgram ASR 根據 URL 或上傳轉錄音訊檔案"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "提交公開音訊 URL 至 Deepgram 的 `/v1/listen` 端點並傳回 JSON 逐字稿。支援具備智慧格式化、說話者辨識 (Diarization)、摘要和語言偵測功能的 Nova 模型系列。\n\n**注意**：此動作僅支援透過 URL 提交。如需原始音訊上傳和即時 WebSocket 串流，請直接使用 @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"。"
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "將音訊提交至 Deepgram 的 `/v1/listen` 端點並傳回 JSON 逐字稿。音訊可以是由 Deepgram 擷取的公開 `url`，或是以位元組作為請求主體上傳的 `audio` 檔案；兩者必須恰好提供其中之一。支援具備智慧格式化、說話者辨識 (Diarization)、摘要和語言偵測功能的 Nova 模型系列。"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "要轉錄的音訊檔案之公開 URL"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "要轉錄之音訊檔案的公開 URL。Deepgram 會從此 URL 擷取檔案；該 URL 必須可從公開網際網路連線。"
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "要轉錄之音訊檔案的公開 URL。Deepgram 會從此 URL 擷取檔案；該 URL 必須可從公開網際網路連線。\n\n`url` 與 `audio` 必須恰好提供其中之一。"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "音訊檔案"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "要上傳以進行轉錄的音訊檔案"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "要轉錄的音訊檔案，以請求主體上傳；在未提供 `url` 時使用。檔案的 `mime_type`（例如 `audio/wav`、`audio/mpeg`、`audio/flac`）會作為請求的 `Content-Type` 傳送；若為 `auto`，則會從檔案名稱 `name` 推斷，否則使用 `application/octet-stream`。上游步驟可以傳入檔案雜湊（`name`、`content`、`mime_type`）或以 `binary` 值傳入原始音訊位元組。\n\n`url` 與 `audio` 必須恰好提供其中之一。"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "檔案資料"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料，將以 Base64 編碼"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料，將以 Base64 編碼"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME 類型"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "自動偵測"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "根據檔案名稱自動偵測；僅在輸入時有效"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "根據檔案名稱自動偵測；僅在輸入時有效"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF檔案"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF檔案"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "檔案名稱"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "檔案名稱"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "檔案名稱"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/zh-TW.json
+++ b/qlib/DeepgramDataProvider/i18n/data-provider.RGVlcGdyYW0/zh-TW.json
@@ -344,12 +344,12 @@
           "message": "轉錄檔案"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.short_desc": {
-          "source": "Transcribe an audio file by URL via Deepgram ASR",
-          "message": "透過 Deepgram ASR 依 URL 轉錄音訊檔案"
+          "source": "Transcribe an audio file by URL or upload via Deepgram ASR",
+          "message": "透過 Deepgram ASR 依 URL 或上傳轉錄音訊檔案"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.desc": {
-          "source": "Submits a public audio URL to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.\n\n**Note**: this action submits via URL only.  For raw-audio uploads and realtime WebSocket streaming, use @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\" directly.",
-          "message": "將公開音訊 URL 提交至 Deepgram 的 `/v1/listen` 端點並傳回 JSON 逐字稿。支援具備智慧格式化、說話者辨識、摘要與語言偵測功能的 Nova 模型系列。\n\n**注意**：此動作僅支援透過 URL 提交。如需原始音訊上傳與即時 WebSocket 串流，請直接使用 @ref DeepgramRestClient::DeepgramRestClientIo \"DeepgramRestClientIo\"。"
+          "source": "Submits audio to Deepgram's `/v1/listen` endpoint and returns the JSON transcript.  The audio is given either as a public `url` that Deepgram fetches or as an `audio` file whose bytes are uploaded as the request body; exactly one of the two must be provided.  Supports the Nova model family with smart formatting, diarization, summarization, and language detection.",
+          "message": "將音訊提交至 Deepgram 的 `/v1/listen` 端點並傳回 JSON 逐字稿。音訊可以是由 Deepgram 擷取的公開 `url`，或是以位元組作為請求主體上傳的 `audio` 檔案；兩者必須恰好提供其中一個。支援具備智慧格式化、說話者辨識、摘要與語言偵測功能的 Nova 模型系列。"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.display_name": {
           "source": "Audio URL",
@@ -360,8 +360,140 @@
           "message": "要轉錄的音訊檔案公開 URL"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.dXJs.desc": {
-          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.",
-          "message": "要轉錄之音訊檔案的公開 URL。Deepgram 會從此 URL 擷取檔案；該 URL 必須可從公開網際網路存取。"
+          "source": "Public URL of the audio file to transcribe.  Deepgram fetches the file from this URL; it must be reachable from the public internet.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "要轉錄之音訊檔案的公開 URL。Deepgram 會從此 URL 擷取檔案；該 URL 必須可從公開網際網路存取。\n\n`url` 與 `audio` 必須恰好提供其中一個。"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.display_name": {
+          "source": "Audio File",
+          "message": "音訊檔案"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.short_desc": {
+          "source": "Audio file to upload for transcription",
+          "message": "要上傳以進行轉錄的音訊檔案"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.desc": {
+          "source": "The audio file to transcribe, uploaded as the request body; used when `url` is not given.  The file's `mime_type` (e.g. `audio/wav`, `audio/mpeg`, `audio/flac`) is sent as the request `Content-Type`; when it is `auto`, it is derived from the file `name`, falling back to `application/octet-stream`.  Upstream steps can pass either a file hash (`name`, `content`, `mime_type`) or the raw audio bytes as a `binary` value.\n\nExactly one of `url` or `audio` must be provided.",
+          "message": "要轉錄的音訊檔案，以請求主體上傳；在未提供 `url` 時使用。檔案的 `mime_type`（例如 `audio/wav`、`audio/mpeg`、`audio/flac`）會作為請求的 `Content-Type` 傳送；若為 `auto`，則從檔案名稱 `name` 推斷，否則使用 `application/octet-stream`。上游步驟可傳入檔案雜湊（`name`、`content`、`mime_type`），或以 `binary` 值傳入原始音訊位元組。\n\n`url` 與 `audio` 必須恰好提供其中一個。"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "檔案資料"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME 類型"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "自動偵測"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "從檔名自動偵測；僅適用於輸入"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "從檔名自動偵測；僅適用於輸入"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF 檔案"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF 檔案"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` 文件"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "檔案名稱"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "檔案名"
+        },
+        "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.YXVkaW8.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "檔案名"
         },
         "app.RGVlcGdyYW0.action.dHJhbnNjcmliZS1maWxl.option.bW9kZWw.display_name": {
           "source": "Model",

--- a/qlib/DeepgramRestClient.qm
+++ b/qlib/DeepgramRestClient.qm
@@ -32,7 +32,7 @@
 %requires QoreSpeechUtils
 
 module DeepgramRestClient {
-    version = "1.0";
+    version = "1.1";
     desc = "user module for calling Deepgram speech (ASR + TTS) REST services";
     author = "Qore Technologies <info@qoretechnologies.com>";
     url = "https://qore.org";
@@ -73,8 +73,8 @@ module DeepgramRestClient {
     Deepgram uses a non-standard auth header format —
     \c "Authorization: Token <api_key>" rather than the more common
     \c "Authorization: Bearer <api_key>".  The module handles this by
-    injecting the right header via the \c headers connection
-    option; callers just supply \c apikey.
+    injecting the right header via the \c headers option of the REST
+    clients; callers just supply \c apikey.
 
     @par Example: file transcription (URL-based)
     @code{.py}
@@ -101,6 +101,12 @@ f.write(resp.body);
 
     @section DeepgramRestClientRelnotes Release Notes
 
+    @subsection DeepgramRestClientv1_1 DeepgramRestClient v1.1
+    - the `Authorization: Token <key>` header built from the `apikey` option is now placed in the `headers`
+      option read by the REST clients; it was previously put in an unread `default_headers` option, so
+      requests and the connection ping were sent without authentication and failed with HTTP 401
+      (<a href="https://github.com/qoretechnologies/qorus/issues/523">qorus#523</a>)
+
     @subsection DeepgramRestClientv1_0 DeepgramRestClient v1.0
     - the initial version of the %DeepgramRestClient module
 */
@@ -122,20 +128,21 @@ public class DeepgramRestClientBase {
     }
 
     #! Returns options for the DeepgramRestClient constructors
-    /** Maps the \c apikey option into a \c headers entry that
-        sends \c "Authorization: Token <key>" on every request — Deepgram's
-        non-Bearer auth format.
+    /** Maps the \c apikey option into an \c "Authorization: Token <key>" entry in the \c headers option,
+        which both the sync and the async REST clients send on every request — Deepgram's non-Bearer auth
+        format.  Any \c default_headers entries supplied by the caller are folded into \c headers as well.
+
+        @note before DeepgramRestClient 1.1 the header was placed in a \c default_headers option that no REST
+        client reads, so requests were sent without authentication
     */
     static hash<auto> getOptions(hash<auto> opts) {
         hash<auto!> rv;
         rv += DefaultOptions + opts;
+        if (rv.default_headers) {
+            rv.headers = (rv.headers ?? {}) + remove rv.default_headers;
+        }
         if (rv.apikey) {
-            hash<auto!> dh;
-            if (rv.headers) {
-                dh += rv.headers;
-            }
-            dh.Authorization = "Token " + rv.apikey;
-            rv.headers = dh;
+            rv.headers = (rv.headers ?? {}) + {"Authorization": "Token " + rv.apikey};
             delete rv.apikey;
         }
         return rv;

--- a/qlib/DeepgramRestClient.qm
+++ b/qlib/DeepgramRestClient.qm
@@ -139,7 +139,8 @@ public class DeepgramRestClientBase {
         hash<auto!> rv;
         rv += DefaultOptions + opts;
         if (rv.default_headers) {
-            rv.headers = (rv.headers ?? {}) + remove rv.default_headers;
+            # explicit headers win over the legacy option on key collisions
+            rv.headers = (remove rv.default_headers) + (rv.headers ?? {});
         }
         if (rv.apikey) {
             rv.headers = (rv.headers ?? {}) + {"Authorization": "Token " + rv.apikey};

--- a/qlib/GmailDataProvider/GmailApiDataProviderBase.qc
+++ b/qlib/GmailDataProvider/GmailApiDataProviderBase.qc
@@ -1,0 +1,151 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GmailDataProvider module definition
+
+/** GmailApiDataProviderBase.qc Copyright 2023 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GmailDataProvider module
+public namespace GmailDataProvider {
+#! Base class for hand-written Gmail action providers that wrap one Gmail Discovery API method
+/** The Discovery API child providers under \c drafts, \c labels, and \c messages already execute every Gmail
+    method; this class exists so that an action can offer dropdowns for its arguments, which a generated
+    provider cannot do.  It supplies the reference data shared by the draft and label actions:
+    - \c drafts: the account's drafts, from \c users/drafts/list
+    - \c labels: the account's labels, from \c users/labels/list; also available as element reference data
+      for list-typed options such as the label IDs to add to or remove from a message
+
+    @since GmailDataProvider 1.2
+*/
+public class GmailApiDataProviderBase inherits GoogleDataProvider::GoogleApiDataProvider {
+    public {
+        #! Reference data type for the account's drafts
+        const ReferenceDataDrafts = "drafts";
+
+        #! Reference data type for the account's labels
+        const ReferenceDataLabels = "labels";
+
+        #! The maximum number of drafts returned as reference data
+        const MaxReferenceDrafts = 500;
+
+        #! The page size used when listing drafts for reference data
+        const ReferenceDraftPageSize = 100;
+    }
+
+    #! Creates the object from a REST connection
+    /** @param rest the Gmail REST connection
+        @param resource_action the Gmail Discovery API method to wrap (ex: \c "users/drafts/get")
+    */
+    constructor(GoogleRestClient::GoogleRestClientIo rest, string resource_action)
+            : GoogleApiDataProvider(rest, GoogleDiscoveryGmailApiName, resource_action, {"userId": "me"}) {
+    }
+
+    #! Returns information on supported reference data
+    /** @return a hash of supported reference data; keys in the hash returned are supported in calls to
+        @ref getReferenceData()
+    */
+    *hash<string, bool> getSupportedReferenceData() {
+        return {
+            ReferenceDataDrafts: True,
+            ReferenceDataLabels: True,
+        };
+    }
+
+    #! Returns information on supported element reference data
+    /** @return a hash of supported element reference data; keys in the hash returned are supported in calls to
+        @ref getElementReferenceData()
+    */
+    *hash<string, bool> getSupportedElementReferenceData() {
+        return {
+            ReferenceDataLabels: True,
+        };
+    }
+
+    #! Returns reference data of the given kind if available
+    /** @param type the unique type name of the reference data
+        @param action_opts an optional hash of action options when called when working with an app action
+
+        @return a list of allowed values for this data
+    */
+    private *list<hash<AllowedValueInfo>> getReferenceDataImpl(string type, *hash<auto> action_opts) {
+        switch (type) {
+            case ReferenceDataDrafts: return getReferenceDrafts();
+            case ReferenceDataLabels: return getReferenceLabels();
+        }
+    }
+
+    #! Returns element reference data of the given kind if available
+    /** @param type the unique type name of the element reference data
+        @param action_opts an optional hash of action options when called when working with an app action
+
+        @return a list of allowed values for this data
+    */
+    private *list<hash<AllowedValueInfo>> getElementReferenceDataImpl(string type, *hash<auto> action_opts) {
+        if (type == ReferenceDataLabels) {
+            return getReferenceLabels();
+        }
+    }
+
+    #! Returns the account's drafts as reference data
+    /** Gmail's draft listing carries only the draft ID and the ID and thread ID of the message it holds, so
+        each draft is labelled by its ID and described by its message and thread; showing subjects instead
+        would cost one further request per draft
+    */
+    private list<hash<AllowedValueInfo>> getReferenceDrafts() {
+        list<hash<AllowedValueInfo>> rv = ();
+        *string page_token;
+        do {
+            string uri = sprintf("gmail/v1/users/me/drafts?maxResults=%d", ReferenceDraftPageSize);
+            if (page_token.val()) {
+                uri += "&pageToken=" + encode_url(page_token);
+            }
+            hash<auto> res = rest.restGet(uri).body;
+            foreach hash<auto> draft in (res.drafts) {
+                rv += <AllowedValueInfo>{
+                    "value": draft.id,
+                    "display_name": draft.id,
+                    "short_desc": sprintf("Draft of message %s in thread %s", draft.message.id,
+                        draft.message.threadId),
+                    "desc": sprintf("Draft `%s` of message `%s` in thread `%s`", draft.id, draft.message.id,
+                        draft.message.threadId),
+                };
+            }
+            page_token = res.nextPageToken;
+        } while (page_token.val() && rv.size() < MaxReferenceDrafts);
+        return rv;
+    }
+
+    #! Returns the account's labels as reference data
+    private list<hash<AllowedValueInfo>> getReferenceLabels() {
+        list<hash<AllowedValueInfo>> rv = ();
+        hash<auto> res = rest.restGet("gmail/v1/users/me/labels").body;
+        foreach hash<auto> label in (res.labels) {
+            string kind = label.type == "system" ? "System" : "User";
+            rv += <AllowedValueInfo>{
+                "value": label.id,
+                "display_name": label.name,
+                "short_desc": sprintf("%s label %s", kind, label.id),
+                "desc": sprintf("%s label `%s`", kind, label.id),
+            };
+        }
+        return rv;
+    }
+}
+}

--- a/qlib/GmailDataProvider/GmailApiDataProviderBase.qc
+++ b/qlib/GmailDataProvider/GmailApiDataProviderBase.qc
@@ -112,12 +112,17 @@ public class GmailApiDataProviderBase inherits GoogleDataProvider::GoogleApiData
         list<hash<AllowedValueInfo>> rv = ();
         *string page_token;
         do {
-            string uri = sprintf("gmail/v1/users/me/drafts?maxResults=%d", ReferenceDraftPageSize);
+            # never ask for, or keep, more than the advertised maximum
+            int page_size = min(ReferenceDraftPageSize, MaxReferenceDrafts - rv.size());
+            string uri = sprintf("gmail/v1/users/me/drafts?maxResults=%d", page_size);
             if (page_token.val()) {
                 uri += "&pageToken=" + encode_url(page_token);
             }
             hash<auto> res = rest.restGet(uri).body;
             foreach hash<auto> draft in (res.drafts) {
+                if (rv.size() >= MaxReferenceDrafts) {
+                    break;
+                }
                 rv += <AllowedValueInfo>{
                     "value": draft.id,
                     "display_name": draft.id,

--- a/qlib/GmailDataProvider/GmailAttachmentWatchDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailAttachmentWatchDataProvider.qc
@@ -137,9 +137,10 @@ public class GmailAttachmentWatchDataProvider inherits GmailMessageWatchDataProv
 
     #! Raise events
     /** @note the ID of the message carrying the attachment is added to each event as
-        \c message_id; without it an event consumer has no way to refer back to the source message
-        (to delete or label it after successful processing, for example), because the event
-        otherwise carries attachment data only
+        \c message_id, and the ID of its thread as \c thread_id; without them an event consumer has
+        no way to refer back to the source message (to delete or label it after successful
+        processing, or to reply in its thread, for example), because the event otherwise carries
+        attachment data only
     */
     private messageReceived(hash<auto> msg) {
         int matches;
@@ -149,7 +150,7 @@ public class GmailAttachmentWatchDataProvider inherits GmailMessageWatchDataProv
                     att.filename, attachment_glob);
                 continue;
             }
-            notifyObservers(EVENT_ATTACHMENT_MATCHED, att + {"message_id": msg.id});
+            notifyObservers(EVENT_ATTACHMENT_MATCHED, att + GmailAttachmentWatchDataProvider::getSourceInfo(msg));
             ++matches;
         }
         LoggerWrapper::info("Gmail: message %y matched attachments: %d/%d", msg.id, matches, msg.attachments.size());
@@ -168,10 +169,24 @@ public class GmailAttachmentWatchDataProvider inherits GmailMessageWatchDataProv
     private auto getExampleEventDataImpl(string event_id) {
         *hash<auto> msg = getExampleMessage();
         if (msg.attachments) {
-            # must match the shape raised by messageReceived(), including the source message ID
-            return msg.attachments[0] + {"message_id": msg.id};
+            # must match the shape raised by messageReceived(), including the source message and thread IDs
+            return msg.attachments[0] + GmailAttachmentWatchDataProvider::getSourceInfo(msg);
         }
         return AbstractDataProvider::getExampleEventDataImpl(event_id);
+    }
+
+    #! Returns the source message fields carried by every attachment event
+    /** @param msg the Gmail message carrying the attachment
+
+        @return a hash with \c message_id and \c thread_id
+
+        @since GmailDataProvider 1.2
+    */
+    static hash<auto> getSourceInfo(hash<auto> msg) {
+        return {
+            "message_id": msg.id,
+            "thread_id": msg.threadId,
+        };
     }
 }
 
@@ -185,6 +200,14 @@ public class GmailAttachmentEventDataType inherits HashDataType {
                 "desc": "The ID of the Gmail message carrying the attachment; use this to refer back to the "
                     "source message after processing the attachment - to delete or label it, for example - "
                     "with the `make-api-call` action.  Always set on events raised by this provider",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "thread_id": {
+                "display_name": "Thread ID",
+                "short_desc": "The ID of the Gmail thread of the message carrying the attachment",
+                "desc": "The ID of the Gmail thread of the message carrying the attachment; pass it as "
+                    "`thread_id` to the `send-message` or `create-draft` action to answer in the same "
+                    "conversation. Always set on events raised by this provider",
                 "type": AbstractDataProviderTypeMap."*string",
             },
             "hdr": {

--- a/qlib/GmailDataProvider/GmailAttachmentWatchDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailAttachmentWatchDataProvider.qc
@@ -144,13 +144,15 @@ public class GmailAttachmentWatchDataProvider inherits GmailMessageWatchDataProv
     */
     private messageReceived(hash<auto> msg) {
         int matches;
+        # the same for every attachment of the message
+        hash<auto> source_info = GmailAttachmentWatchDataProvider::getSourceInfo(msg);
         foreach hash<auto> att in (msg.attachments) {
             if (attachment_regex && (!att.filename.val() || !regex(att.filename, attachment_regex, re_flags))) {
                 LoggerWrapper::debug("Gmail: skipping attachment with filename %y; does not match glob: %y",
                     att.filename, attachment_glob);
                 continue;
             }
-            notifyObservers(EVENT_ATTACHMENT_MATCHED, att + GmailAttachmentWatchDataProvider::getSourceInfo(msg));
+            notifyObservers(EVENT_ATTACHMENT_MATCHED, att + source_info);
             ++matches;
         }
         LoggerWrapper::info("Gmail: message %y matched attachments: %d/%d", msg.id, matches, msg.attachments.size());

--- a/qlib/GmailDataProvider/GmailBaseDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailBaseDataProvider.qc
@@ -45,7 +45,14 @@ public class GmailBaseDataProvider inherits GoogleDataProvider::GoogleApiParentD
     }
 
     private {
+        #! Hand-written child providers; every other child is generated from the Discovery API document
         const ChildMap = {
+            "create-draft": Class::forName("GmailDataProvider::GmailCreateDraftDataProvider"),
+            "delete-draft": Class::forName("GmailDataProvider::GmailDeleteDraftDataProvider"),
+            "get-draft": Class::forName("GmailDataProvider::GmailGetDraftDataProvider"),
+            "list-with-metadata": Class::forName("GmailDataProvider::GmailListWithMetadataDataProvider"),
+            "modify-message-labels": Class::forName("GmailDataProvider::GmailModifyMessageLabelsDataProvider"),
+            "send-draft": Class::forName("GmailDataProvider::GmailSendDraftDataProvider"),
             "send-message": Class::forName("GmailDataProvider::GmailMessageSendDataProvider"),
             "watch": Class::forName("GmailDataProvider::GmailMessageWatchDataProvider"),
             "watch-attachment": Class::forName("GmailDataProvider::GmailAttachmentWatchDataProvider"),

--- a/qlib/GmailDataProvider/GmailCreateDraftDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailCreateDraftDataProvider.qc
@@ -1,0 +1,108 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GmailDataProvider module definition
+
+/** GmailCreateDraftDataProvider.qc Copyright 2023 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GmailDataProvider module
+public namespace GmailDataProvider {
+#! Data provider for creating Gmail drafts
+/** Takes the same request as @ref GmailMessageSendDataProvider "send-message" and stores the message as a
+    draft instead of transmitting it
+
+    @since GmailDataProvider 1.2
+*/
+public class GmailCreateDraftDataProvider inherits GmailApiDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "create-draft",
+            "desc": "Gmail create draft data provider",
+            "type": "GmailCreateDraftDataProvider",
+            "supports_request": True,
+            "mutates_state": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = GmailSendMessageRequestDataType;
+
+        #! Gmail draft create resource action
+        const ResourceAction = "users/drafts/create";
+    }
+
+    #! Creates the object from a REST connection
+    constructor(GoogleRestClient::GoogleRestClientIo rest) : GmailApiDataProviderBase(rest, ResourceAction) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google data %s provider for `%s`", ProviderInfo.name, rest.getSafeUrl());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request info
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        hash<auto> greq = {
+            "userId": "me",
+            "message": GmailMessageSendDataProvider::makeMessageBody(req),
+        };
+        return GoogleApiDataProvider::doRequestImpl(greq, request_options);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the Google request type for the operation
+    private AbstractDataProviderType getGoogleRequestType() {
+        return GoogleDataProviderBase::getRequestTypeForSchema(GoogleDiscoveryGmailApiName, ResourceAction);
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *AbstractDataProviderType getResponseTypeImpl() {
+        return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName, ResourceAction);
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/GmailDataProvider/GmailDataProvider.qm
+++ b/qlib/GmailDataProvider/GmailDataProvider.qm
@@ -36,7 +36,7 @@
 %requires MailMessage
 
 module GmailDataProvider {
-    version = "1.1";
+    version = "1.2";
     desc = "User module providing a data provider API for Gmail REST cloud services";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -67,6 +67,7 @@ module GmailDataProvider {
             "short_desc": "Search for messages",
             "desc": "Search for messages in the account",
             "action_code": DPAT_API,
+            "mutates_state": False,
             "options": {
                 "q": <ActionOptionInfo>{
                     "display_name": "Search Criteria",
@@ -121,6 +122,7 @@ module GmailDataProvider {
             "short_desc": "Retrieve a message",
             "desc": "Retrieve a message",
             "action_code": DPAT_API,
+            "mutates_state": False,
             "options": {
                 "id": <ActionOptionInfo>{
                     "display_name": "Message ID",
@@ -145,6 +147,7 @@ module GmailDataProvider {
             "short_desc": "Retrieve an attachment",
             "desc": "Retrieve an attachment",
             "action_code": DPAT_API,
+            "mutates_state": False,
             "options": {
                 "messageId": <ActionOptionInfo>{
                     "display_name": "Message ID",
@@ -369,12 +372,312 @@ module GmailDataProvider {
             "display_name": "Send a Message",
             "short_desc": "Create and transmit a new outgoing email through Gmail",
             "desc": "Creates a new outgoing email from the supplied recipient addresses, subject, body, "
-                "and attachments, and transmits that new email through Gmail.",
+                "and attachments, and transmits that new email through Gmail. Set `thread_id` and "
+                "`in_reply_to` to send the email as a reply within an existing conversation",
             "action_code": DPAT_API,
             "options": DataProviderActionCatalog::getActionOptionFromFields(GmailSendMessageRequestDataType::Fields),
             "get_output_type": AbstractDataProviderType sub () {
                 return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
                     GmailMessageSendDataProvider::ResourceAction);
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/list-with-metadata",
+            "action": "list-with-metadata",
+            "display_name": "Search for Messages with Metadata",
+            "short_desc": "Search for messages and return each match with its headers",
+            "desc": "Search for messages in the account and return each matching message with its metadata, "
+                "instead of the bare message and thread IDs that `list` returns. Each match is retrieved "
+                "separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` "
+                "+ 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+            "action_code": DPAT_API,
+            "mutates_state": False,
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                GmailListWithMetadataRequestDataType::Fields),
+            "get_output_type": AbstractDataProviderType sub () {
+                return GmailListWithMetadataDataProvider::getResponseType();
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/messages/untrash",
+            "action": "untrash-message",
+            "display_name": "Restore a Message from the Trash",
+            "short_desc": "Move a message from the trash back into the mailbox",
+            "desc": "Moves the message identified by `id` out of Gmail's trash folder and back into the "
+                "mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash "
+                "cannot be restored",
+            "action_code": DPAT_API,
+            "options": {
+                "id": <ActionOptionInfo>{
+                    "display_name": "Message ID",
+                    "short_desc": "The ID of the message to restore from the trash",
+                    "desc": "The ID of the message to restore from the trash; watch events carry this value "
+                        "as `message_id`",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "example_value": "18c6b13f059fc0bd",
+                    "required": True,
+                    "preselected": True,
+                },
+            },
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
+                    "users/messages/untrash");
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/modify-message-labels",
+            "action": "modify-message-labels",
+            "display_name": "Change a Message's Labels",
+            "short_desc": "Add labels to and remove labels from a message",
+            "desc": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the "
+                "message identified by `id` in one call. Gmail's system labels are changed the same way: "
+                "remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to "
+                "star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+            "action_code": DPAT_API,
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                GmailModifyMessageLabelsRequestDataType::Fields),
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
+                    GmailModifyMessageLabelsDataProvider::ResourceAction);
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/labels/list",
+            "action": "list-labels",
+            "display_name": "List Labels",
+            "short_desc": "List all labels in the account",
+            "desc": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, "
+                "and so on) and user-created labels, each with the ID that `modify-message-labels` and the "
+                "`labelIds` search option take",
+            "action_code": DPAT_API,
+            "mutates_state": False,
+            "options": {},
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
+                    "users/labels/list");
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/labels/create",
+            "action": "create-label",
+            "display_name": "Create a Label",
+            "short_desc": "Create a new user label in the account",
+            "desc": "Creates a new user label in the account and returns it with the ID that "
+                "`modify-message-labels` takes",
+            "action_code": DPAT_API,
+            "options": {
+                "name": <ActionOptionInfo>{
+                    "display_name": "Label Name",
+                    "short_desc": "The display name of the label",
+                    "desc": "The display name of the label; use `/` to nest a label under another, ex: "
+                        "`Projects/Alpha`",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "example_value": "Projects/Alpha",
+                    "required": True,
+                    "preselected": True,
+                },
+                "labelListVisibility": <ActionOptionInfo>{
+                    "display_name": "Label List Visibility",
+                    "short_desc": "Whether the label is shown in the label list",
+                    "desc": "Whether the label is shown in the label list of the Gmail web interface",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "allowed_values": (
+                        <AllowedValueInfo>{
+                            "value": "labelShow",
+                            "display_name": "Show",
+                            "desc": "Show the label in the label list",
+                        },
+                        <AllowedValueInfo>{
+                            "value": "labelShowIfUnread",
+                            "display_name": "Show If Unread",
+                            "desc": "Show the label in the label list only while it has unread messages",
+                        },
+                        <AllowedValueInfo>{
+                            "value": "labelHide",
+                            "display_name": "Hide",
+                            "desc": "Do not show the label in the label list",
+                        },
+                    ),
+                },
+                "messageListVisibility": <ActionOptionInfo>{
+                    "display_name": "Message List Visibility",
+                    "short_desc": "Whether messages with the label are shown in the message list",
+                    "desc": "Whether messages with the label are shown in the message list of the Gmail web "
+                        "interface",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "allowed_values": (
+                        <AllowedValueInfo>{
+                            "value": "show",
+                            "display_name": "Show",
+                            "desc": "Show messages with the label in the message list",
+                        },
+                        <AllowedValueInfo>{
+                            "value": "hide",
+                            "display_name": "Hide",
+                            "desc": "Do not show messages with the label in the message list",
+                        },
+                    ),
+                },
+            },
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
+                    "users/labels/create");
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/create-draft",
+            "action": "create-draft",
+            "display_name": "Create a Draft",
+            "short_desc": "Create a new draft email in Gmail without sending it",
+            "desc": "Creates a new draft email from the supplied recipient addresses, subject, body, and "
+                "attachments, and stores it in Gmail's drafts folder without sending it, so that a person can "
+                "review and send it, or so that `send-draft` can send it later. Set `thread_id` and "
+                "`in_reply_to` to draft a reply within an existing conversation",
+            "action_code": DPAT_API,
+            "options": DataProviderActionCatalog::getActionOptionFromFields(GmailSendMessageRequestDataType::Fields),
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
+                    GmailCreateDraftDataProvider::ResourceAction);
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/drafts/list",
+            "action": "list-drafts",
+            "display_name": "Search for Drafts",
+            "short_desc": "Search for drafts",
+            "desc": "Search for drafts in the account; each draft is returned with its ID and the ID and thread "
+                "ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+            "action_code": DPAT_API,
+            "mutates_state": False,
+            "options": {
+                "q": <ActionOptionInfo>{
+                    "display_name": "Search Criteria",
+                    "short_desc": "The gmail search criteria for retrieving the drafts",
+                    "desc": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com "
+                        "subject:hello`; if not set, all drafts are returned",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "example_value": "to:me@gmail.com subject:hello",
+                    "preselected": True,
+                },
+                "maxResults": <ActionOptionInfo>{
+                    "display_name": "Max Results",
+                    "short_desc": "The maximum number of results to return",
+                    "desc": "The maximum number of results to return",
+                    "type": AbstractDataProviderTypeMap."int",
+                    "example_value": 20,
+                },
+                "includeSpamTrash": <ActionOptionInfo>{
+                    "display_name": "Include Spam and Trash?",
+                    "short_desc": "Include the spam and trash folders in the search?",
+                    "desc": "Include the spam and trash folders in the search?",
+                    "type": AbstractDataProviderTypeMap."bool",
+                    "example_value": False,
+                },
+                "pageToken": <ActionOptionInfo>{
+                    "display_name": "Page Token",
+                    "short_desc": "Page token to retrieve a specific page of results in the list",
+                    "desc": "Page token to retrieve a specific page of results in the list",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "example_value": "07142542234962330268",
+                },
+            },
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
+                    "users/drafts/list");
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/get-draft",
+            "action": "get-draft",
+            "display_name": "Retrieve a Draft",
+            "short_desc": "Retrieve a draft",
+            "desc": "Retrieves a draft and the message it holds in the requested `format`",
+            "action_code": DPAT_API,
+            "mutates_state": False,
+            "options": {
+                "id": <ActionOptionInfo>{
+                    "display_name": "Draft ID",
+                    "short_desc": "The ID of the draft to retrieve",
+                    "desc": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this "
+                        "value as `id`",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "example_value": "r-1234567890123456789",
+                    "required": True,
+                    "preselected": True,
+                    "ref_data": GmailApiDataProviderBase::ReferenceDataDrafts,
+                },
+                "format": <ActionOptionInfo>{
+                    "display_name": "Message Format",
+                    "short_desc": "How much of the draft's message to retrieve",
+                    "desc": "How much of the draft's message to retrieve; if not set, the complete message is "
+                        "returned",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "example_value": "metadata",
+                    "allowed_values": GmailMessageFormatList,
+                },
+            },
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
+                    GmailGetDraftDataProvider::ResourceAction);
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/send-draft",
+            "action": "send-draft",
+            "display_name": "Send a Draft",
+            "short_desc": "Send an existing draft as it is",
+            "desc": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the "
+                "draft and returns the sent message. Use `get-draft` first to review what will be sent",
+            "action_code": DPAT_API,
+            "options": {
+                "id": <ActionOptionInfo>{
+                    "display_name": "Draft ID",
+                    "short_desc": "The ID of the draft to send",
+                    "desc": "The ID of the draft to send; `list-drafts` and `create-draft` return this value "
+                        "as `id`",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "example_value": "r-1234567890123456789",
+                    "required": True,
+                    "preselected": True,
+                    "ref_data": GmailApiDataProviderBase::ReferenceDataDrafts,
+                },
+            },
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
+                    GmailSendDraftDataProvider::ResourceAction);
+            },
+        });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GmailDataProvider::AppName,
+            "path": "/delete-draft",
+            "action": "delete-draft",
+            "display_name": "Delete a Draft",
+            "short_desc": "Permanently delete a draft; this cannot be undone",
+            "desc": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash "
+                "and no copy remains.\n\n"
+                "The Gmail API returns no content for this call",
+            "action_code": DPAT_API,
+            "options": {
+                "id": <ActionOptionInfo>{
+                    "display_name": "Draft ID",
+                    "short_desc": "The ID of the draft to delete permanently",
+                    "desc": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return "
+                        "this value as `id`",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "example_value": "r-1234567890123456789",
+                    "required": True,
+                    "preselected": True,
+                    "ref_data": GmailApiDataProviderBase::ReferenceDataDrafts,
+                },
             },
         });
     };
@@ -390,10 +693,37 @@ module GmailDataProvider {
     services.
 
     This data provider provides Google API access to the Gmail API as defined by Google's Discovery
-    API; some example data providers are listed below:
+    API.
 
     To use this data provider, you will need a connection that has already executed the OAuth2 authorization code flow
     and acquired a token to communicate with the Google API.
+
+    @section gmaildataprovider_actions Gmail Actions
+
+    The \c Gmail app registers the following actions; the path in the second column names the child of the
+    root data provider that backs the action.  Children with a single-segment path are hand-written classes in
+    this module; every other child is generated from the Gmail Discovery API document and executes one Gmail
+    API method.
+
+    |!Action|!Path|!Description
+    |\c list|\c /messages/list|Searches for messages and returns their message and thread IDs
+    |\c list-with-metadata|\c /list-with-metadata|Searches for messages and returns each match with its headers
+    |\c get|\c /messages/get|Retrieves a message
+    |\c get-attachment|\c /messages/attachments/get|Retrieves an attachment
+    |\c send-message|\c /send-message|Creates and sends a message, optionally as a reply in an existing thread
+    |\c create-draft|\c /create-draft|Creates a draft without sending it
+    |\c list-drafts|\c /drafts/list|Searches for drafts
+    |\c get-draft|\c /get-draft|Retrieves a draft
+    |\c send-draft|\c /send-draft|Sends an existing draft
+    |\c delete-draft|\c /delete-draft|Permanently deletes a draft
+    |\c list-labels|\c /labels/list|Lists all labels in the account
+    |\c create-label|\c /labels/create|Creates a user label
+    |\c modify-message-labels|\c /modify-message-labels|Adds labels to and removes labels from a message
+    |\c trash-message|\c /messages/trash|Moves a message to the trash
+    |\c untrash-message|\c /messages/untrash|Restores a message from the trash
+    |\c delete-message|\c /messages/delete|Permanently deletes a message
+    |\c watch|\c /watch|Raises an event for each new matching message
+    |\c watch-attachment|\c /watch-attachment|Raises an event for each new matching attachment
 
     @section gmaildataprovider_factory Gmail Data Provider Factory
 
@@ -405,6 +735,22 @@ module GmailDataProvider {
 
 
     @section gmaildataprovider_relnotes Release Notes
+
+    @subsection gmaildataprovider_v1_2 GmailDataProvider v1.2
+    - added the \c create-draft, \c list-drafts, \c get-draft, \c send-draft, and \c delete-draft actions for
+      working with drafts; \c get-draft, \c send-draft, and \c delete-draft offer the account's drafts as
+      reference data
+    - added the \c list-labels, \c create-label, and \c modify-message-labels actions for working with labels,
+      and the \c untrash-message action to restore a message from the trash; the label options of
+      \c modify-message-labels and the \c labelIds option of \c list-with-metadata offer the account's labels as
+      element reference data
+    - added the \c list-with-metadata action, which returns each matching message with its headers in one call
+      instead of the bare IDs that \c list returns
+    - added the \c thread_id, \c in_reply_to, and \c references options to \c send-message and \c create-draft,
+      so a message can be sent or drafted as a reply within an existing conversation
+    - message watch events carry the \c In-Reply-To header, and attachment watch events carry the \c thread_id
+      of the source message
+    - the \c list, \c get, and \c get-attachment actions are declared read-only
 
     @subsection gmaildataprovider_v1_1 GmailDataProvider v1.1
     - added the \c trash-message and \c delete-message actions, so a consumer can clear a source message
@@ -450,6 +796,37 @@ public const GoogleDiscoveryGmailApiName = "gmail";
 
 #! used in accordance with: https://about.google/brand-resource-center/brand-elements/
 public const GmailLogo = File::readTextFile(get_script_dir() + "/gmail-logo.svg");
+
+#! Message formats supported when retrieving a message or draft
+/** @since GmailDataProvider 1.2
+*/
+public const GmailMessageFormatList = (
+    <AllowedValueInfo>{
+        "display_name": "Full",
+        "short_desc": "The complete message including all headers and the body",
+        "desc": "The complete message including all headers and the MIME body parts; attachment data is not "
+            "included and must be retrieved with `get-attachment`",
+        "value": "full",
+    },
+    <AllowedValueInfo>{
+        "display_name": "Metadata",
+        "short_desc": "Message IDs, labels, snippet, and headers only",
+        "desc": "Message IDs, labels, snippet, and headers only; no body",
+        "value": "metadata",
+    },
+    <AllowedValueInfo>{
+        "display_name": "Minimal",
+        "short_desc": "Message IDs and labels only",
+        "desc": "Message IDs and labels only; no headers and no body",
+        "value": "minimal",
+    },
+    <AllowedValueInfo>{
+        "display_name": "Raw",
+        "short_desc": "The complete message as base64url-encoded MIME data",
+        "desc": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+        "value": "raw",
+    },
+);
 
 #! Backlog-handling options shared by the Gmail watch actions
 /** @since GmailDataProvider 1.1

--- a/qlib/GmailDataProvider/GmailDeleteDraftDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailDeleteDraftDataProvider.qc
@@ -1,0 +1,71 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GmailDataProvider module definition
+
+/** GmailDeleteDraftDataProvider.qc Copyright 2023 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GmailDataProvider module
+public namespace GmailDataProvider {
+#! Data provider for permanently deleting a Gmail draft
+/** Wraps the Discovery API \c users/drafts/delete method so that the draft can be chosen from reference data
+
+    @since GmailDataProvider 1.2
+*/
+public class GmailDeleteDraftDataProvider inherits GmailApiDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "delete-draft",
+            "desc": "Gmail delete draft data provider",
+            "type": "GmailDeleteDraftDataProvider",
+            "supports_request": True,
+            "mutates_state": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Gmail draft delete resource action
+        const ResourceAction = "users/drafts/delete";
+    }
+
+    #! Creates the object from a REST connection
+    constructor(GoogleRestClient::GoogleRestClientIo rest) : GmailApiDataProviderBase(rest, ResourceAction) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google data %s provider for `%s`", ProviderInfo.name, rest.getSafeUrl());
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/GmailDataProvider/GmailGetDraftDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailGetDraftDataProvider.qc
@@ -1,0 +1,71 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GmailDataProvider module definition
+
+/** GmailGetDraftDataProvider.qc Copyright 2023 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GmailDataProvider module
+public namespace GmailDataProvider {
+#! Data provider for retrieving a Gmail draft
+/** Wraps the Discovery API \c users/drafts/get method so that the draft can be chosen from reference data
+
+    @since GmailDataProvider 1.2
+*/
+public class GmailGetDraftDataProvider inherits GmailApiDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "get-draft",
+            "desc": "Gmail retrieve draft data provider",
+            "type": "GmailGetDraftDataProvider",
+            "supports_request": True,
+            "mutates_state": False,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Gmail draft get resource action
+        const ResourceAction = "users/drafts/get";
+    }
+
+    #! Creates the object from a REST connection
+    constructor(GoogleRestClient::GoogleRestClientIo rest) : GmailApiDataProviderBase(rest, ResourceAction) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google data %s provider for `%s`", ProviderInfo.name, rest.getSafeUrl());
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/GmailDataProvider/GmailListWithMetadataDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailListWithMetadataDataProvider.qc
@@ -1,0 +1,333 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GmailDataProvider module definition
+
+/** GmailListWithMetadataDataProvider.qc Copyright 2023 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GmailDataProvider module
+public namespace GmailDataProvider {
+#! Data provider for searching for Gmail messages and returning each match with its metadata
+/** Gmail's \c users/messages/list method returns only message and thread IDs, so a consumer that needs the
+    subject or sender of each match has to retrieve every message separately.  This provider does that in one
+    action: it lists the matching messages and then retrieves each one with \c users/messages/get in the
+    requested \c format, returning the retrieved messages in place of the bare IDs
+
+    @since GmailDataProvider 1.2
+*/
+public class GmailListWithMetadataDataProvider inherits GmailApiDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list-with-metadata",
+            "desc": "Gmail search with metadata data provider",
+            "type": "GmailListWithMetadataDataProvider",
+            "supports_request": True,
+            "mutates_state": False,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = GmailListWithMetadataRequestDataType;
+
+        #! Gmail message list resource action
+        const ResourceAction = "users/messages/list";
+
+        #! Gmail message get resource action used to retrieve each listed message
+        const GetResourceAction = "users/messages/get";
+
+        #! The message format retrieved when the request does not name one
+        const DefaultFormat = "metadata";
+
+        #! The headers retrieved when the request does not name any
+        const DefaultMetadataHeaders = ("Subject", "From", "To", "Date");
+
+        #! The request keys that are not part of the Gmail list request
+        const RetrievalKeys = ("format", "metadata_headers");
+
+        #! The URI of the account's messages resource
+        const MessagesUri = "gmail/v1/users/me/messages";
+    }
+
+    private {
+        #! The response type; created on demand because it is built from the Discovery API document
+        static GmailListWithMetadataResponseDataType response_type;
+
+        #! The type of each retrieved message
+        AbstractDataProviderType message_type;
+    }
+
+    #! Creates the object from a REST connection
+    constructor(GoogleRestClient::GoogleRestClientIo rest) : GmailApiDataProviderBase(rest, ResourceAction) {
+        message_type = GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName,
+            GetResourceAction);
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google data %s provider for `%s`", ProviderInfo.name, rest.getSafeUrl());
+    }
+
+    #! Returns the response type
+    /** @return the response type: the Gmail list response with each listed message replaced by the retrieved
+        message
+    */
+    static AbstractDataProviderType getResponseType() {
+        return response_type ?? (response_type = new GmailListWithMetadataResponseDataType());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request info
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+
+        @note one \c users/messages/list request is made, and then one \c users/messages/get request per
+        listed message; a page of \c maxResults messages therefore costs \c maxResults + 1 requests.  The
+        request URIs are built here rather than from the Discovery API request types, because those types
+        describe Gmail's repeated query parameters (\c labelIds, \c metadataHeaders) as single strings
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        string format = req.format ?? DefaultFormat;
+        softlist<string> metadata_headers = req.metadata_headers ?? DefaultMetadataHeaders;
+
+        hash<auto> rv = restGet(MessagesUri + GmailListWithMetadataDataProvider::getQuery(req - RetrievalKeys))
+            ?? {};
+        list<hash<auto>> messages = ();
+        foreach hash<auto> minfo in (rv.messages) {
+            # "auto!" so that the string-only literal is not narrowed to hash<string, string>, which would
+            # reject the header list
+            hash<auto!> get_args = {
+                "format": format,
+            };
+            # Gmail ignores the header list unless the metadata format is requested
+            if (format == DefaultFormat) {
+                get_args.metadataHeaders = metadata_headers;
+            }
+            string uri = sprintf("%s/%s%s", MessagesUri, encode_url(minfo.id, True),
+                GmailListWithMetadataDataProvider::getQuery(get_args));
+            messages += message_type.acceptsValue(restGet(uri));
+        }
+        # "+" rather than a key assignment, so a response hash narrowed to another value type is not an error
+        return getResponseTypeImpl().acceptsValue(rv + {"messages": messages});
+    }
+
+    #! Makes a GET request and returns the response body
+    /** @param uri the request URI
+
+        @return the response body
+
+        @note any error response is included in the exception as with @ref GoogleApiDataProvider requests
+    */
+    private auto restGet(string uri) {
+        try {
+            return rest.restGet(uri).body;
+        } catch (hash<ExceptionInfo> ex) {
+            rethrow ex.err, ex.desc, ex.arg + {
+                "request-uri": ex.arg.request_path,
+                "response-code": ex.arg.status_code,
+                "response-body": ex.arg.response_body_raw,
+            };
+        }
+    }
+
+    #! Returns the query string for the given arguments
+    /** @param args the query arguments; a list value is repeated once per element, as Gmail expects for
+        \c labelIds and \c metadataHeaders, and a boolean is sent as \c true or \c false
+
+        @return the query string with a leading \c "?", or an empty string if there are no arguments
+    */
+    private static string getQuery(hash<auto> args) {
+        list<string> query = ();
+        foreach hash<auto> i in (args.pairIterator()) {
+            foreach auto val in (i.value) {
+                string str = val.typeCode() == NT_BOOLEAN ? (val ? "true" : "false") : val.toString();
+                query += sprintf("%s=%s", i.key, encode_url(str, True));
+            }
+        }
+        return query ? "?" + query.join("&") : "";
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *AbstractDataProviderType getResponseTypeImpl() {
+        return GmailListWithMetadataDataProvider::getResponseType();
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Message formats supported when retrieving listed messages
+/** @since GmailDataProvider 1.2
+*/
+public const GmailListWithMetadataFormatList = (
+    <AllowedValueInfo>{
+        "display_name": "Metadata",
+        "short_desc": "Message IDs, labels, snippet, and the requested headers only",
+        "desc": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+        "value": "metadata",
+    },
+    <AllowedValueInfo>{
+        "display_name": "Full",
+        "short_desc": "The complete message including all headers and the body",
+        "desc": "The complete message including all headers and the MIME body parts; attachment data is not "
+            "included and must be retrieved with `get-attachment`",
+        "value": "full",
+    },
+);
+
+#! Gmail search with metadata request type
+/** @since GmailDataProvider 1.2
+*/
+public class GmailListWithMetadataRequestDataType inherits HashDataType {
+    public {
+        #! Field descriptions
+        const Fields = {
+            "q": {
+                "display_name": "Search Criteria",
+                "type": StringType,
+                "short_desc": "The gmail search criteria for retrieving the messages",
+                "desc": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com "
+                    "subject:hello is:unread`",
+                "example_value": "in:inbox to:me@gmail.com subject:hello is:unread",
+                "required": True,
+                "preselected": True,
+            },
+            "maxResults": {
+                "display_name": "Max Results",
+                "type": IntOrNothingType,
+                "short_desc": "The maximum number of results to return",
+                "desc": "The maximum number of results to return; each message returned costs one additional "
+                    "API request",
+                "example_value": 20,
+                "preselected": True,
+            },
+            "includeSpamTrash": {
+                "display_name": "Include Spam and Trash?",
+                "type": BoolOrNothingType,
+                "short_desc": "Include the spam and trash folders in the search?",
+                "desc": "Include the spam and trash folders in the search?",
+                "example_value": False,
+            },
+            "labelIds": {
+                "display_name": "Labels",
+                "type": new SoftListDataType(StringType, True),
+                "short_desc": "Only return messages with labels that match all of the specified label IDs",
+                "desc": "Only return messages with labels that match all of the specified label IDs. Messages in "
+                    "a thread might have labels that other messages in the same thread don't have",
+                "example_value": ("INBOX", "UNREAD"),
+                "element_ref_data": GmailApiDataProviderBase::ReferenceDataLabels,
+            },
+            "pageToken": {
+                "display_name": "Page Token",
+                "type": StringOrNothingType,
+                "short_desc": "Page token to retrieve a specific page of results in the list",
+                "desc": "Page token to retrieve a specific page of results in the list",
+                "example_value": "07142542234962330268",
+            },
+            "format": {
+                "display_name": "Message Format",
+                "type": StringType,
+                "short_desc": "How much of each matching message to retrieve",
+                "desc": "How much of each matching message to retrieve",
+                "default_value": GmailListWithMetadataDataProvider::DefaultFormat,
+                "allowed_values": GmailListWithMetadataFormatList,
+            },
+            "metadata_headers": {
+                "display_name": "Metadata Headers",
+                "type": new SoftListDataType(StringType, True),
+                "short_desc": "The message headers to retrieve for each matching message",
+                "desc": "The message headers to retrieve for each matching message; ignored unless `format` is "
+                    "`metadata`",
+                "default_value": GmailListWithMetadataDataProvider::DefaultMetadataHeaders,
+                "example_value": ("Subject", "From", "To", "Date", "Message-ID"),
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Gmail search with metadata request type
+/** @since GmailDataProvider 1.2
+*/
+public const GmailListWithMetadataRequestDataType = new GmailListWithMetadataRequestDataType();
+
+#! Gmail search with metadata response type
+/** The Gmail \c users/messages/list response with each listed message replaced by the message retrieved with
+    \c users/messages/get
+
+    @note Built from the Discovery API document, so it cannot be created before the document is available
+
+    @since GmailDataProvider 1.2
+*/
+public class GmailListWithMetadataResponseDataType inherits HashDataType {
+    #! Creates the object
+    constructor() : HashDataType("GmailListWithMetadataResponse") {
+        addField(new QoreDataField({
+            "name": "messages",
+            "display_name": "Messages",
+            "short_desc": "The matching messages, each retrieved in the requested format",
+            "desc": "The matching messages, each retrieved in the requested format; with the `metadata` format, "
+                "the requested headers are in `payload.headers`",
+            "type": new ListDataType("GmailMessageList", GoogleDataProviderBase::getResponseTypeForSchema(
+                GoogleDiscoveryGmailApiName, GmailListWithMetadataDataProvider::GetResourceAction), True),
+        }));
+        addField(new QoreDataField({
+            "name": "nextPageToken",
+            "display_name": "Next Page Token",
+            "short_desc": "Token to retrieve the next page of results in the list",
+            "desc": "Token to retrieve the next page of results in the list; pass it as `pageToken` to retrieve "
+                "the next page",
+            "type": AbstractDataProviderTypeMap."*string",
+        }));
+        addField(new QoreDataField({
+            "name": "resultSizeEstimate",
+            "display_name": "Result Size Estimate",
+            "short_desc": "Estimated total number of results",
+            "desc": "Estimated total number of results",
+            "type": AbstractDataProviderTypeMap."*int",
+        }));
+    }
+}
+}

--- a/qlib/GmailDataProvider/GmailMessageWatchDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailMessageWatchDataProvider.qc
@@ -169,6 +169,14 @@ public class GmailMessageEventDataType inherits HashDataType {
                 "desc": "A unique ID for this email",
                 "type": AbstractDataProviderTypeMap."*string",
             },
+            "In-Reply-To": {
+                "display_name": "In Reply To",
+                "short_desc": "The Message-ID of the email this email replies to",
+                "desc": "The `Message-ID` of the email this email replies to, including the angle brackets; to "
+                    "answer this email in its thread, pass its own `Message-ID` as `in_reply_to` and its "
+                    "`threadId` as `thread_id` to the `send-message` or `create-draft` action",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
             "References": {
                 "display_name": "Email Reference ID",
                 "short_desc": "A unique ID for any email this email is in reply to",

--- a/qlib/GmailDataProvider/GmailModifyMessageLabelsDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailModifyMessageLabelsDataProvider.qc
@@ -1,0 +1,157 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GmailDataProvider module definition
+
+/** GmailModifyMessageLabelsDataProvider.qc Copyright 2023 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GmailDataProvider module
+public namespace GmailDataProvider {
+#! Data provider for adding labels to and removing labels from a Gmail message
+/** Wraps the Discovery API \c users/messages/modify method so that the labels can be chosen from reference
+    data
+
+    @since GmailDataProvider 1.2
+*/
+public class GmailModifyMessageLabelsDataProvider inherits GmailApiDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "modify-message-labels",
+            "desc": "Gmail modify message labels data provider",
+            "type": "GmailModifyMessageLabelsDataProvider",
+            "supports_request": True,
+            "mutates_state": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = GmailModifyMessageLabelsRequestDataType;
+
+        #! Gmail message modify resource action
+        const ResourceAction = "users/messages/modify";
+    }
+
+    #! Creates the object from a REST connection
+    constructor(GoogleRestClient::GoogleRestClientIo rest) : GmailApiDataProviderBase(rest, ResourceAction) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google data %s provider for `%s`", ProviderInfo.name, rest.getSafeUrl());
+    }
+
+    #! Makes a request and returns the response
+    /** @param req the request info
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        hash<auto> greq = {
+            "userId": "me",
+        } + req;
+        return GoogleApiDataProvider::doRequestImpl(greq, request_options);
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the Google request type for the operation
+    private AbstractDataProviderType getGoogleRequestType() {
+        return GoogleDataProviderBase::getRequestTypeForSchema(GoogleDiscoveryGmailApiName, ResourceAction);
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *AbstractDataProviderType getResponseTypeImpl() {
+        return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryGmailApiName, ResourceAction);
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! Gmail modify message labels request type
+/** @since GmailDataProvider 1.2
+*/
+public class GmailModifyMessageLabelsRequestDataType inherits HashDataType {
+    public {
+        #! Field descriptions
+        const Fields = {
+            "id": {
+                "display_name": "Message ID",
+                "type": StringType,
+                "short_desc": "The ID of the message to relabel",
+                "desc": "The ID of the message to relabel; watch events carry this value as `message_id`",
+                "example_value": "18c6b13f059fc0bd",
+                "required": True,
+                "preselected": True,
+            },
+            "addLabelIds": {
+                "display_name": "Labels to Add",
+                "type": new SoftListDataType(StringType, True),
+                "short_desc": "The IDs of the labels to add to the message",
+                "desc": "The IDs of the labels to add to the message; a label is identified by its ID (ex: "
+                    "`INBOX`, `STARRED`, `Label_12`), not its name",
+                "example_value": ("STARRED",),
+                "element_ref_data": GmailApiDataProviderBase::ReferenceDataLabels,
+                "preselected": True,
+            },
+            "removeLabelIds": {
+                "display_name": "Labels to Remove",
+                "type": new SoftListDataType(StringType, True),
+                "short_desc": "The IDs of the labels to remove from the message",
+                "desc": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: "
+                    "`INBOX`, `UNREAD`, `Label_12`), not its name",
+                "example_value": ("UNREAD",),
+                "element_ref_data": GmailApiDataProviderBase::ReferenceDataLabels,
+                "preselected": True,
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! Gmail modify message labels request type
+/** @since GmailDataProvider 1.2
+*/
+public const GmailModifyMessageLabelsRequestDataType = new GmailModifyMessageLabelsRequestDataType();
+}

--- a/qlib/GmailDataProvider/GmailSendDraftDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailSendDraftDataProvider.qc
@@ -1,0 +1,71 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore GmailDataProvider module definition
+
+/** GmailSendDraftDataProvider.qc Copyright 2023 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! Contains all public definitions in the GmailDataProvider module
+public namespace GmailDataProvider {
+#! Data provider for sending an existing Gmail draft
+/** Wraps the Discovery API \c users/drafts/send method so that the draft can be chosen from reference data
+
+    @since GmailDataProvider 1.2
+*/
+public class GmailSendDraftDataProvider inherits GmailApiDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "send-draft",
+            "desc": "Gmail send draft data provider",
+            "type": "GmailSendDraftDataProvider",
+            "supports_request": True,
+            "mutates_state": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Gmail draft send resource action
+        const ResourceAction = "users/drafts/send";
+    }
+
+    #! Creates the object from a REST connection
+    constructor(GoogleRestClient::GoogleRestClientIo rest) : GmailApiDataProviderBase(rest, ResourceAction) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("Google data %s provider for `%s`", ProviderInfo.name, rest.getSafeUrl());
+    }
+
+    #! Returns data provider static info
+    hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/GmailDataProvider/GmailSendMessageDataProvider.qc
+++ b/qlib/GmailDataProvider/GmailSendMessageDataProvider.qc
@@ -69,6 +69,27 @@ public class GmailMessageSendDataProvider inherits GoogleDataProvider::GoogleApi
         @return the response to the request
     */
     private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        hash<auto> greq = {
+            "userId": "me",
+        } + GmailMessageSendDataProvider::makeMessageBody(req);
+        return GoogleApiDataProvider::doRequestImpl(greq, request_options);
+    }
+
+    #! Returns the MIME message for a send or draft request, base64url-encoded as Gmail's API expects
+    /** @param req the request; see @ref GmailSendMessageRequestDataType for the keys
+
+        @return the serialized MIME message encoded with @ref Qore::make_base64_url_string()
+
+        @throw MESSAGE-ERROR the message cannot be serialized (ex: no recipients)
+
+        @note The threading headers follow RFC 5322 section 3.6.4: a reply carries the original's \c Message-ID
+        in \c In-Reply-To and the conversation's IDs in \c References; when only \c in_reply_to is given, it
+        also serves as \c References, because Gmail threads a message under the original only when both
+        headers refer to it
+
+        @since GmailDataProvider 1.2
+    */
+    static string makeRawMessage(hash<auto> req) {
         Message msg(req.sender ?? "me@gmail.com", req.subject);
         map msg.addTO($1), req.to;
         map msg.addCC($1), req.cc;
@@ -76,14 +97,35 @@ public class GmailMessageSendDataProvider inherits GoogleDataProvider::GoogleApi
         msg.setBody(req.body, req."body-encoding", req."body-mime-type");
         map msg.attach($1."data".name, $1."data".mime_type, parse_base64_string($1."data".content), $1.encoding,
             $1.hdr), req.attachments;
+        if (req.in_reply_to.val()) {
+            msg.addHeader({"In-Reply-To": req.in_reply_to});
+        }
+        if (*string references = req.references ?? req.in_reply_to) {
+            msg.addHeader({"References": references});
+        }
 
         # throws a MESSAGE-ERROR exception if the message cannot be sent
-        string mstr = make_base64_url_string(msg.serialize());
-        hash<auto> greq = {
-            "userId": "me",
-            "raw": mstr,
+        return make_base64_url_string(msg.serialize());
+    }
+
+    #! Returns the Gmail API \c Message body for a send or draft request
+    /** @param req the request; see @ref GmailSendMessageRequestDataType for the keys
+
+        @return a hash with the \c raw MIME message (see makeRawMessage()) and, when the request names a thread
+        in \c thread_id, the \c threadId the message belongs to
+
+        @throw MESSAGE-ERROR the message cannot be serialized (ex: no recipients)
+
+        @since GmailDataProvider 1.2
+    */
+    static hash<auto> makeMessageBody(hash<auto> req) {
+        hash<auto> rv = {
+            "raw": GmailMessageSendDataProvider::makeRawMessage(req),
         };
-        return GoogleApiDataProvider::doRequestImpl(greq, request_options);
+        if (req.thread_id.val()) {
+            rv.threadId = req.thread_id;
+        }
+        return rv;
     }
 
     #! Returns the description of a successful request message, if any
@@ -264,6 +306,36 @@ public class GmailSendMessageRequestDataType inherits HashDataType {
                 "type": StringOrNothingType,
                 "short_desc": "The sender's address for the email",
                 "desc": "The sender's address for the email",
+            },
+            "thread_id": {
+                "display_name": "Thread ID",
+                "type": StringOrNothingType,
+                "short_desc": "The ID of the Gmail thread to add the message to",
+                "desc": "The ID of the Gmail thread to add the message to; set this to reply within an existing "
+                    "conversation. Gmail only honors it when `subject` matches the thread's subject and "
+                    "`in_reply_to` (or `references`) names a message in the thread. Watch events carry this "
+                    "value as `threadId`",
+                "example_value": "18c6b13f059fc0bd",
+            },
+            "in_reply_to": {
+                "display_name": "In Reply To",
+                "type": StringOrNothingType,
+                "short_desc": "The Message-ID header value of the message being answered",
+                "desc": "The `Message-ID` header value of the message being answered, including the angle "
+                    "brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the "
+                    "`References` header, so that mail clients and Gmail thread the reply under the original "
+                    "message. Watch events carry this value as `Message-ID`",
+                "example_value": "<CAF1mXwUPjLb-Q3P2Ee5Ax9U1YrMU=ZxWq7MdX0KE_4Y5N6uD5Q@mail.gmail.com>",
+            },
+            "references": {
+                "display_name": "References",
+                "type": StringOrNothingType,
+                "short_desc": "The Message-ID header values of the conversation being answered",
+                "desc": "The `References` header value: the `Message-ID` values of the messages in the "
+                    "conversation being answered, oldest first, separated by spaces and including the angle "
+                    "brackets. If not set, `in_reply_to` is used. Watch events carry the original message's "
+                    "`References` header",
+                "example_value": "<original@mail.example.com> <first-reply@mail.example.com>",
             },
         };
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/cs.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/cs.json
@@ -860,8 +860,8 @@
           "message": "Vytvořit a odeslat nový odchozí e-mail přes Gmail"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "Vytvoří nový odchozí e-mail ze zadaných adres příjemců, předmětu, těla a příloh a odešle jej přes Gmail."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "Vytvoří nový odchozí e-mail ze zadaných adres příjemců, předmětu, těla a příloh a odešle jej přes Gmail. Nastavením `thread_id` a `in_reply_to` odešlete e-mail jako odpověď v rámci existující konverzace"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "Adresa odesílatele e-mailu"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID vlákna"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "ID vlákna Gmailu, do kterého se má zpráva přidat"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "ID vlákna Gmailu, do kterého se má zpráva přidat; nastavte tuto hodnotu, chcete-li odpovědět v rámci existující konverzace. Gmail ji respektuje pouze tehdy, když `subject` odpovídá předmětu vlákna a `in_reply_to` (nebo `references`) uvádí zprávu z tohoto vlákna. Události sledování nesou tuto hodnotu jako `threadId`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "Odpověď na"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Hodnota hlavičky Message-ID zprávy, na kterou se odpovídá"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Hodnota hlavičky `Message-ID` zprávy, na kterou se odpovídá, včetně lomených závorek; odesílá se jako hlavička `In-Reply-To` a, pokud není nastaveno `references`, také jako hlavička `References`, aby poštovní klienti i Gmail zařadili odpověď pod původní zprávu. Události sledování nesou tuto hodnotu jako `Message-ID`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Reference"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Hodnoty hlaviček Message-ID konverzace, na kterou se odpovídá"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Hodnota hlavičky `References`: hodnoty `Message-ID` zpráv v konverzaci, na kterou se odpovídá, od nejstarší, oddělené mezerami a včetně lomených závorek. Pokud není nastavena, použije se `in_reply_to`. Události sledování nesou hlavičku `References` původní zprávy"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "Hledat zprávy s metadaty"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "Hledat zprávy a vrátit každou nalezenou zprávu s jejími hlavičkami"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "Hledá zprávy v účtu a vrací každou odpovídající zprávu s jejími metadaty namísto pouhých ID zpráv a vláken, která vrací `list`. Každá nalezená zpráva se načítá samostatně v požadovaném `format`, takže stránka s `maxResults` zprávami stojí `maxResults` + 1 požadavků na API; udržujte `maxResults` malé a k procházení dalších stránek použijte `pageToken`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Kritéria vyhledávání"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "Vyhledávací kritéria Gmailu pro načtení zpráv"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "Vyhledávací kritéria Gmailu pro načtení zpráv; např.: `in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Maximální počet výsledků"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Maximální počet vrácených výsledků"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "Maximální počet výsledků, které se mají vrátit; každá vrácená zpráva stojí jeden další požadavek na API"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Zahrnout spam a koš?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Zahrnout do vyhledávání složky spam a koš?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Zahrnout do vyhledávání složky spam a koš?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "Štítky"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "Vrátit pouze zprávy se štítky, které odpovídají všem zadaným ID štítků"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "Vrátit pouze zprávy se štítky, které odpovídají všem zadaným ID štítků. Zprávy ve vlákně mohou mít štítky, které jiné zprávy ve stejném vlákně nemají"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token stránky"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token stránky pro načtení konkrétní stránky výsledků v seznamu"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token stránky pro načtení konkrétní stránky výsledků v seznamu"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Formát zprávy"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Kolik z každé odpovídající zprávy se má načíst"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Kolik z každé odpovídající zprávy se má načíst"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadata"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "Pouze ID zpráv, štítky, úryvek a požadované hlavičky"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "Pouze ID zpráv, štítky, úryvek a hlavičky uvedené v `metadata_headers`; bez těla"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Úplný"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Celá zpráva včetně všech hlaviček a těla"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Celá zpráva včetně všech hlaviček a částí těla MIME; data příloh nejsou zahrnuta a je nutné je načíst pomocí `get-attachment`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "Hlavičky metadat"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "Hlavičky zprávy, které se mají načíst pro každou odpovídající zprávu"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "Hlavičky zprávy, které se mají načíst pro každou odpovídající zprávu; ignoruje se, pokud `format` není `metadata`"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "Obnovit zprávu z koše"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "Přesunout zprávu z koše zpět do schránky"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "Přesune zprávu identifikovanou pomocí `id` z koše Gmailu zpět do schránky, čímž vrátí zpět akci `trash-message`; zprávu, kterou Gmail již z koše odstranil, obnovit nelze"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID zprávy"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "ID zprávy, která má být obnovena z koše"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "ID zprávy, která má být obnovena z koše; události sledování nesou tuto hodnotu jako `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "Změnit štítky zprávy"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "Přidat štítky ke zprávě a odebrat je z ní"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "Jedním voláním přidá ke zprávě identifikované pomocí `id` štítky uvedené v `addLabelIds` a odebere z ní štítky uvedené v `removeLabelIds`. Systémové štítky Gmailu se mění stejným způsobem: odeberte `UNREAD`, chcete-li zprávu označit jako přečtenou, odeberte `INBOX`, chcete-li ji archivovat, nebo přidejte `STARRED`, chcete-li ji označit hvězdičkou. Pomocí `list-labels` zjistíte ID štítku a pomocí `create-label` vytvoříte nový"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID zprávy"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "ID zprávy, jejíž štítky se mají změnit"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "ID zprávy, jejíž štítky se mají změnit; události sledování nesou tuto hodnotu jako `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "Štítky k přidání"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "ID štítků, které se mají ke zprávě přidat"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "ID štítků, které se mají ke zprávě přidat; štítek je identifikován svým ID (např. `INBOX`, `STARRED`, `Label_12`), nikoli názvem"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "Štítky k odebrání"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "ID štítků, které se mají ze zprávy odebrat"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "ID štítků, které se mají ze zprávy odebrat; štítek je identifikován svým ID (např. `INBOX`, `UNREAD`, `Label_12`), nikoli názvem"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "Vypsat štítky"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "Vypsat všechny štítky v účtu"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "Vypíše všechny štítky v účtu, jak systémové štítky Gmailu (`INBOX`, `UNREAD`, `STARRED` a další), tak štítky vytvořené uživatelem, každý s ID, které přijímají `modify-message-labels` a možnost vyhledávání `labelIds`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "Vytvořit štítek"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "Vytvořit v účtu nový uživatelský štítek"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "Vytvoří v účtu nový uživatelský štítek a vrátí jej s ID, které přijímá `modify-message-labels`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "Název štítku"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "Zobrazovaný název štítku"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "Zobrazovaný název štítku; pomocí `/` lze štítek vnořit pod jiný, např. `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "Viditelnost v seznamu štítků"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "Zda se štítek zobrazuje v seznamu štítků"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Zda se štítek zobrazuje v seznamu štítků webového rozhraní Gmailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "Zobrazit"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "Zobrazit štítek v seznamu štítků"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "Zobrazit, pokud je nepřečteno"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "Zobrazit štítek v seznamu štítků pouze tehdy, když obsahuje nepřečtené zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "Skrýt"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "Nezobrazovat štítek v seznamu štítků"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "Viditelnost v seznamu zpráv"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "Zda se zprávy s tímto štítkem zobrazují v seznamu zpráv"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Zda se zprávy s tímto štítkem zobrazují v seznamu zpráv webového rozhraní Gmailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "Zobrazit"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "Zobrazit zprávy s tímto štítkem v seznamu zpráv"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "Skrýt"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "Nezobrazovat zprávy s tímto štítkem v seznamu zpráv"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "Vytvořit koncept"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "Vytvořit v Gmailu nový koncept e-mailu bez jeho odeslání"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "Vytvoří nový koncept e-mailu ze zadaných adres příjemců, předmětu, těla a příloh a uloží jej do složky konceptů Gmailu bez odeslání, aby jej mohl zkontrolovat a odeslat člověk nebo aby jej mohla později odeslat akce `send-draft`. Nastavením `thread_id` a `in_reply_to` připravíte odpověď v rámci existující konverzace"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "Komu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "Adresy příjemců zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "Jedna nebo více adres `To:` pro e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "Kopie (CC)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "Adresy v kopii"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "Jedna nebo více adres `Cc:` pro e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "Skrytá kopie (BCC)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "Adresy skryté kopie (BCC)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "Jedna nebo více adres `Bcc:` pro e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "Předmět"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "Předmět e-mailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "Předmět e-mailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "Tělo zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "Tělo zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "Tělo zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "Přílohy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "Přílohy zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "Přílohy zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "Data přílohy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Data, název souboru a MIME typ pro přílohu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Data, název souboru a MIME typ pro přílohu"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Data souboru"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 kódovaná data souboru nebo surová data k zakódování pomocí base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 kódovaná data souboru nebo surová data k zakódování pomocí base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME typ"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Řetězec MIME typu pro soubor"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Řetězec MIME typu pro soubor"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Automatické rozpoznání"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické rozpoznání z názvu souboru; platné jen pro vstup"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické rozpoznání z názvu souboru; platné jen pro vstup"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Prostý text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Prostý text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Soubor PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Soubor PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Soubor MS Word docx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Soubor MS Word `docx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Soubor MS PowerPoint pptx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Soubor MS PowerPoint `pptx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Soubor MS Excel xlsx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Soubor MS Excel `xlsx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Název souboru"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Název souboru"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Název souboru"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "Kódování přílohy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Kódování, které se má použít pro přílohu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Kódování, které se má použít pro přílohu:\n- `default`: `quoted-printable` pro textová data, `base64` pro binární data\n- `none`: žádné kódování obsahu (nedoporučuje se)\n- `quoted-printable`: kódování quoted printable\n- `base64`: kódování base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Automaticky"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' pro textová data, 'base64' pro binární data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` pro textová data, `base64` pro binární data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Žádné"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Bez kódování obsahu (nedoporučuje se)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Bez kódování obsahu (nedoporučuje se)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideální pro textová data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideální pro textová data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideální pro binární data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideální pro binární data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "Hlavičky"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Volitelné hlavičky odeslané spolu s přílohou"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Volitelné hlavičky odeslané spolu s přílohou"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "Kódování těla zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Kódování, které se má použít pro přílohu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Kódování, které se má použít pro přílohu:\n- `default`: `quoted-printable` pro textová data, `base64` pro binární data\n- `none`: žádné kódování obsahu (nedoporučuje se)\n- `quoted-printable`: kódování quoted printable\n- `base64`: kódování base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Automaticky"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' pro textová data, 'base64' pro binární data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` pro textová data, `base64` pro binární data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Žádné"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Bez kódování obsahu (nedoporučuje se)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Bez kódování obsahu (nedoporučuje se)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideální pro textová data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideální pro textová data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideální pro binární data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideální pro binární data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "MIME typ těla zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "MIME typ těla zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "MIME typ těla zprávy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Prostý text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Prostý text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "Odesílatel"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "Adresa odesílatele e-mailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "Adresa odesílatele e-mailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID vlákna"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "ID vlákna Gmailu, do kterého se má zpráva přidat"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "ID vlákna Gmailu, do kterého se má zpráva přidat; nastavte tuto hodnotu, chcete-li odpovědět v rámci existující konverzace. Gmail ji respektuje pouze tehdy, když `subject` odpovídá předmětu vlákna a `in_reply_to` (nebo `references`) uvádí zprávu z tohoto vlákna. Události sledování nesou tuto hodnotu jako `threadId`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "Odpověď na"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Hodnota hlavičky Message-ID zprávy, na kterou se odpovídá"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Hodnota hlavičky `Message-ID` zprávy, na kterou se odpovídá, včetně lomených závorek; odesílá se jako hlavička `In-Reply-To` a, pokud není nastaveno `references`, také jako hlavička `References`, aby poštovní klienti i Gmail zařadili odpověď pod původní zprávu. Události sledování nesou tuto hodnotu jako `Message-ID`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Reference"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Hodnoty hlaviček Message-ID konverzace, na kterou se odpovídá"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Hodnota hlavičky `References`: hodnoty `Message-ID` zpráv v konverzaci, na kterou se odpovídá, od nejstarší, oddělené mezerami a včetně lomených závorek. Pokud není nastavena, použije se `in_reply_to`. Události sledování nesou hlavičku `References` původní zprávy"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "Hledat koncepty"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "Hledat koncepty"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "Hledá koncepty v účtu; každý koncept se vrací se svým ID a s ID a ID vlákna zprávy, kterou obsahuje. Obsah konceptu načtete pomocí `get-draft`"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Kritéria vyhledávání"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "Kritéria vyhledávání Gmailu pro načtení konceptů"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "Kritéria vyhledávání Gmailu pro načtení konceptů; např. `to:me@gmail.com subject:hello`; pokud nejsou nastavena, vrátí se všechny koncepty"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Maximální počet výsledků"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Maximální počet vrácených výsledků"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "Maximální počet vrácených výsledků"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Zahrnout spam a koš?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Zahrnout do vyhledávání složky spam a koš?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Zahrnout do vyhledávání složky spam a koš?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token stránky"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token stránky pro načtení konkrétní stránky výsledků v seznamu"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token stránky pro načtení konkrétní stránky výsledků v seznamu"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "Získat koncept"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "Získat koncept"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "Načte koncept a zprávu, kterou obsahuje, v požadovaném `format`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID konceptu"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "ID konceptu, který se má načíst"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "ID konceptu, který se má načíst; `list-drafts` a `create-draft` vracejí tuto hodnotu jako `id`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Formát zprávy"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "Kolik ze zprávy konceptu se má načíst"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "Kolik ze zprávy konceptu se má načíst; pokud není nastaveno, vrátí se celá zpráva"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Úplný"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Celá zpráva včetně všech hlaviček a těla"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Celá zpráva včetně všech hlaviček a částí těla MIME; data příloh nejsou zahrnuta a je nutné je načíst pomocí `get-attachment`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadata"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "Pouze ID zpráv, štítky, úryvek a hlavičky"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "Pouze ID zpráv, štítky, úryvek a hlavičky; bez těla"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "Minimální"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "Pouze ID zpráv a štítky"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "Pouze ID zpráv a štítky; bez hlaviček a bez těla"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "Nezpracovaný"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "Celá zpráva jako data MIME kódovaná pomocí base64url"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "Celá zpráva jako data MIME kódovaná pomocí base64url v `raw`; tělo se neparsuje"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "Odeslat koncept"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "Odeslat existující koncept tak, jak je"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "Odešle koncept identifikovaný pomocí `id` tak, jak je, příjemcům, které uvádí; Gmail koncept odstraní a vrátí odeslanou zprávu. Nejprve pomocí `get-draft` zkontrolujte, co bude odesláno"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID konceptu"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "ID konceptu, který se má odeslat"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "ID konceptu, který se má odeslat; `list-drafts` a `create-draft` vracejí tuto hodnotu jako `id`"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "Smazat koncept"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "Trvale smazat koncept; tuto akci nelze vrátit zpět"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "Trvale smaže koncept. **Tuto akci nelze vrátit zpět**: koncept se nepřesune do koše a nezůstane žádná kopie.\n\nGmail API pro toto volání nevrací žádný obsah"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID konceptu"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "ID konceptu, který se má trvale smazat"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "ID konceptu, který se má trvale smazat; `list-drafts` a `create-draft` vracejí tuto hodnotu jako `id`"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/de.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/de.json
@@ -860,8 +860,8 @@
           "message": "Neue ausgehende E-Mail erstellen und über Gmail senden"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "Erstellt eine neue ausgehende E-Mail aus den angegebenen Empfängeradressen, dem Betreff, dem Text und den Anhängen und überträgt diese neue E-Mail über Gmail."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "Erstellt eine neue ausgehende E-Mail aus den angegebenen Empfängeradressen, dem Betreff, dem Text und den Anhängen und überträgt diese neue E-Mail über Gmail. Setzen Sie `thread_id` und `in_reply_to`, um die E-Mail als Antwort innerhalb einer bestehenden Konversation zu senden"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "Die Absenderadresse der E-Mail"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "Thread-ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "Die ID des Gmail-Threads, dem die Nachricht hinzugefügt werden soll"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "Die ID des Gmail-Threads, dem die Nachricht hinzugefügt werden soll; setzen Sie diesen Wert, um innerhalb einer bestehenden Konversation zu antworten. Gmail berücksichtigt ihn nur, wenn `subject` dem Betreff des Threads entspricht und `in_reply_to` (oder `references`) eine Nachricht im Thread benennt. Überwachungsereignisse übertragen diesen Wert als `threadId`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "Antwort auf"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Der Wert des Message-ID-Headers der Nachricht, die beantwortet wird"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Der Wert des `Message-ID`-Headers der Nachricht, die beantwortet wird, einschließlich der spitzen Klammern; wird als `In-Reply-To`-Header gesendet und, sofern `references` nicht gesetzt ist, auch als `References`-Header, damit E-Mail-Clients und Gmail die Antwort unter der ursprünglichen Nachricht einordnen. Überwachungsereignisse übertragen diesen Wert als `Message-ID`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Referenzen"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Die Werte der Message-ID-Header der Konversation, die beantwortet wird"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Der Wert des `References`-Headers: die `Message-ID`-Werte der Nachrichten in der Konversation, die beantwortet wird, älteste zuerst, durch Leerzeichen getrennt und einschließlich der spitzen Klammern. Wenn nicht gesetzt, wird `in_reply_to` verwendet. Überwachungsereignisse übertragen den `References`-Header der ursprünglichen Nachricht"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "Nach Nachrichten mit Metadaten suchen"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "Nach Nachrichten suchen und jeden Treffer mit seinen Headern zurückgeben"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "Sucht nach Nachrichten im Konto und gibt jede passende Nachricht mit ihren Metadaten zurück, anstelle der bloßen Nachrichten- und Thread-IDs, die `list` zurückgibt. Jeder Treffer wird einzeln im angeforderten `format` abgerufen, sodass eine Seite mit `maxResults` Nachrichten `maxResults` + 1 API-Anfragen kostet; halten Sie `maxResults` klein und verwenden Sie `pageToken`, um weitere Seiten zu durchlaufen"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Suchkriterien"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "Die Gmail-Suchkriterien zum Abrufen der Nachrichten"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "Die Gmail-Suchkriterien zum Abrufen der Nachrichten; z. B.: `in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Max. Ergebnisse"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Die maximale Anzahl der zurückzugebenden Ergebnisse"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "Die maximale Anzahl der zurückzugebenden Ergebnisse; jede zurückgegebene Nachricht kostet eine zusätzliche API-Anfrage"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Spam und Papierkorb einbeziehen?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Spam- und Papierkorbordner in die Suche einbeziehen?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Spam- und Papierkorbordner in die Suche einbeziehen?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "Etiketten"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "Nur Nachrichten zurückgeben, die allen angegebenen Label-IDs entsprechen"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "Nur Nachrichten mit Labels zurückgeben, die mit allen angegebenen Label-IDs übereinstimmen. Nachrichten in einem Thread können Labels haben, die andere Nachrichten im selben Thread nicht haben"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Seiten-Token"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Page-Token zum Abrufen einer bestimmten Ergebnisseite in der Liste"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Page-Token zum Abrufen einer bestimmten Ergebnisseite in der Liste"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Nachrichtenformat"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Wie viel von jeder passenden Nachricht abgerufen werden soll"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Wie viel von jeder passenden Nachricht abgerufen werden soll"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadaten"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "Nur Nachrichten-IDs, Etiketten, Snippet und die angeforderten Header"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "Nur Nachrichten-IDs, Etiketten, Snippet und die in `metadata_headers` genannten Header; kein Text"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Vollständig"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Die vollständige Nachricht einschließlich aller Header und des Texts"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Die vollständige Nachricht einschließlich aller Header und der MIME-Textteile; Anhangsdaten sind nicht enthalten und müssen mit `get-attachment` abgerufen werden"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "Metadaten-Header"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "Die Nachrichten-Header, die für jede passende Nachricht abgerufen werden sollen"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "Die Nachrichten-Header, die für jede passende Nachricht abgerufen werden sollen; wird ignoriert, sofern `format` nicht `metadata` ist"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "Nachricht aus dem Papierkorb wiederherstellen"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "Eine Nachricht aus dem Papierkorb zurück in das Postfach verschieben"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "Verschiebt die durch `id` identifizierte Nachricht aus dem Papierkorb von Gmail zurück in das Postfach und macht damit `trash-message` rückgängig; eine Nachricht, die Gmail bereits aus dem Papierkorb entfernt hat, kann nicht wiederhergestellt werden"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "Nachrichten-ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "Die ID der Nachricht, die aus dem Papierkorb wiederhergestellt werden soll"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "Die ID der Nachricht, die aus dem Papierkorb wiederhergestellt werden soll; Überwachungsereignisse übertragen diesen Wert als `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "Etiketten einer Nachricht ändern"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "Etiketten zu einer Nachricht hinzufügen und von ihr entfernen"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "Fügt der durch `id` identifizierten Nachricht die Etiketten in `addLabelIds` hinzu und entfernt die Etiketten in `removeLabelIds` in einem Aufruf. Die Systemetiketten von Gmail werden auf dieselbe Weise geändert: Entfernen Sie `UNREAD`, um eine Nachricht als gelesen zu markieren, entfernen Sie `INBOX`, um sie zu archivieren, oder fügen Sie `STARRED` hinzu, um sie mit einem Stern zu versehen. Verwenden Sie `list-labels`, um die ID eines Etiketts zu finden, oder `create-label`, um ein neues zu erstellen"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "Nachrichten-ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "Die ID der Nachricht, deren Etiketten geändert werden sollen"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "Die ID der Nachricht, deren Etiketten geändert werden sollen; Überwachungsereignisse übertragen diesen Wert als `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "Hinzuzufügende Etiketten"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "Die IDs der Etiketten, die der Nachricht hinzugefügt werden sollen"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "Die IDs der Etiketten, die der Nachricht hinzugefügt werden sollen; ein Etikett wird durch seine ID (z. B. `INBOX`, `STARRED`, `Label_12`) identifiziert, nicht durch seinen Namen"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "Zu entfernende Etiketten"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "Die IDs der Etiketten, die von der Nachricht entfernt werden sollen"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "Die IDs der Etiketten, die von der Nachricht entfernt werden sollen; ein Etikett wird durch seine ID (z. B. `INBOX`, `UNREAD`, `Label_12`) identifiziert, nicht durch seinen Namen"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "Etiketten auflisten"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "Alle Etiketten im Konto auflisten"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "Listet alle Etiketten im Konto auf, sowohl die Systemetiketten von Gmail (`INBOX`, `UNREAD`, `STARRED` usw.) als auch benutzerdefinierte Etiketten, jeweils mit der ID, die `modify-message-labels` und die Suchoption `labelIds` erwarten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "Etikett erstellen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "Ein neues Benutzeretikett im Konto erstellen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "Erstellt ein neues Benutzeretikett im Konto und gibt es mit der ID zurück, die `modify-message-labels` erwartet"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "Etikettname"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "Der Anzeigename des Etiketts"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "Der Anzeigename des Etiketts; verwenden Sie `/`, um ein Etikett unter einem anderen zu verschachteln, z. B. `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "Sichtbarkeit in der Etikettenliste"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "Ob das Etikett in der Etikettenliste angezeigt wird"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Ob das Etikett in der Etikettenliste der Gmail-Weboberfläche angezeigt wird"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "Anzeigen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "Das Etikett in der Etikettenliste anzeigen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "Anzeigen, wenn ungelesen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "Das Etikett nur dann in der Etikettenliste anzeigen, wenn es ungelesene Nachrichten enthält"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "Ausblenden"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "Das Etikett nicht in der Etikettenliste anzeigen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "Sichtbarkeit in der Nachrichtenliste"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "Ob Nachrichten mit dem Etikett in der Nachrichtenliste angezeigt werden"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Ob Nachrichten mit dem Etikett in der Nachrichtenliste der Gmail-Weboberfläche angezeigt werden"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "Anzeigen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "Nachrichten mit dem Etikett in der Nachrichtenliste anzeigen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "Ausblenden"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "Nachrichten mit dem Etikett nicht in der Nachrichtenliste anzeigen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "Entwurf erstellen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "Einen neuen E-Mail-Entwurf in Gmail erstellen, ohne ihn zu senden"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "Erstellt einen neuen E-Mail-Entwurf aus den angegebenen Empfängeradressen, dem Betreff, dem Text und den Anhängen und speichert ihn im Entwürfe-Ordner von Gmail, ohne ihn zu senden, sodass eine Person ihn prüfen und senden kann oder `send-draft` ihn später senden kann. Setzen Sie `thread_id` und `in_reply_to`, um eine Antwort innerhalb einer bestehenden Konversation zu entwerfen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "An"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "Empfängeradressen der Nachricht"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "Eine oder mehrere `To:`-Adressen für die E-Mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "CC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "Cc-Adressen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "Eine oder mehrere `Cc:`-Adressen für die E-Mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "BCC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "BCC-Adressen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "Eine oder mehrere `Bcc:`-Adressen für die E-Mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "Betreff"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "Der Betreff der E-Mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "Der Betreff der E-Mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "Nachrichtentext"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "Der Nachrichtentext"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "Der Nachrichtentext"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "Anhänge"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "Nachrichtenanhänge"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "Anhänge für die Nachricht"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "Anhangsdaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Die Daten, der Dateiname und der MIME-Typ der Anlage"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Die Daten, der Dateiname und der MIME-Typ der Anlage"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dateidaten"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-codierte Dateidaten oder Rohdaten, die mit Base64 kodiert werden sollen"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-codierte Dateidaten oder Rohdaten, die mit Base64 kodiert werden sollen"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME-Typ"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Die MIME-Typ-Zeichenkette für die Datei"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Die MIME-Typ-Zeichenkette für die Datei"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Automatische Erkennung"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatische Erkennung aus dem Dateinamen; nur für Eingaben gültig"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatische Erkennung aus dem Dateinamen; nur für Eingaben gültig"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Klartext"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Klartext"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML-Text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML-Text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF-Datei"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF-Datei"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx-Dokument"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx`-Dokument"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx-Dokument"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx`-Dokument"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx-Dokument"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx`-Dokument"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Dateiname"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Der Dateiname"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Der Dateiname"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "Anhangskodierung"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Die für den Anhang zu verwendende Codierung"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Die für den Anhang zu verwendende Codierung:\n- `default`: `quoted-printable` für Zeichenkettendaten, `base64` für Binärdaten\n- `none`: keine Inhaltscodierung (nicht empfohlen)\n- `quoted-printable`: Quoted-Printable-Codierung\n- `base64`: Base64-Codierung"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' für Zeichenkettendaten, 'base64' für Binärdaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` für Zeichenkettendaten, `base64` für Binärdaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Keine"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Keine Inhaltscodierung (nicht empfohlen)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Keine Inhaltscodierung (nicht empfohlen)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal für Zeichenkettendaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal für Zeichenkettendaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal für Binärdaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal für Binärdaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "Header"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Optionale Header, die mit der Anlage gesendet werden"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Optionale Header, die mit der Anlage gesendet werden"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "Textcodierung"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Die für den Anhang zu verwendende Codierung"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Die für den Anhang zu verwendende Codierung:\n- `default`: `quoted-printable` für Zeichenkettendaten, `base64` für Binärdaten\n- `none`: keine Inhaltscodierung (nicht empfohlen)\n- `quoted-printable`: Quoted-Printable-Codierung\n- `base64`: Base64-Codierung"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' für Zeichenkettendaten, 'base64' für Binärdaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` für Zeichenkettendaten, `base64` für Binärdaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Keine"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Keine Inhaltscodierung (nicht empfohlen)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Keine Inhaltscodierung (nicht empfohlen)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal für Zeichenkettendaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal für Zeichenkettendaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal für Binärdaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal für Binärdaten"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "Nachrichtentext-MIME-Typ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "Der MIME-Typ des Nachrichtentexts"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "Der MIME-Typ des Nachrichtentexts"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Klartext"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Klartext"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML-Text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML-Text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "Absender"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "Die Absenderadresse der E-Mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "Die Absenderadresse der E-Mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "Thread-ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "Die ID des Gmail-Threads, dem die Nachricht hinzugefügt werden soll"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "Die ID des Gmail-Threads, dem die Nachricht hinzugefügt werden soll; setzen Sie diesen Wert, um innerhalb einer bestehenden Konversation zu antworten. Gmail berücksichtigt ihn nur, wenn `subject` dem Betreff des Threads entspricht und `in_reply_to` (oder `references`) eine Nachricht im Thread benennt. Überwachungsereignisse übertragen diesen Wert als `threadId`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "Antwort auf"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Der Wert des Message-ID-Headers der Nachricht, die beantwortet wird"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Der Wert des `Message-ID`-Headers der Nachricht, die beantwortet wird, einschließlich der spitzen Klammern; wird als `In-Reply-To`-Header gesendet und, sofern `references` nicht gesetzt ist, auch als `References`-Header, damit E-Mail-Clients und Gmail die Antwort unter der ursprünglichen Nachricht einordnen. Überwachungsereignisse übertragen diesen Wert als `Message-ID`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Referenzen"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Die Werte der Message-ID-Header der Konversation, die beantwortet wird"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Der Wert des `References`-Headers: die `Message-ID`-Werte der Nachrichten in der Konversation, die beantwortet wird, älteste zuerst, durch Leerzeichen getrennt und einschließlich der spitzen Klammern. Wenn nicht gesetzt, wird `in_reply_to` verwendet. Überwachungsereignisse übertragen den `References`-Header der ursprünglichen Nachricht"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "Nach Entwürfen suchen"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "Nach Entwürfen suchen"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "Sucht nach Entwürfen im Konto; jeder Entwurf wird mit seiner ID sowie der ID und Thread-ID der Nachricht zurückgegeben, die er enthält. Verwenden Sie `get-draft`, um den Inhalt eines Entwurfs abzurufen"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Suchkriterien"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "Die Gmail-Suchkriterien zum Abrufen der Entwürfe"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "Die Gmail-Suchkriterien zum Abrufen der Entwürfe; z. B. `to:me@gmail.com subject:hello`; wenn nicht gesetzt, werden alle Entwürfe zurückgegeben"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Max. Ergebnisse"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Die maximale Anzahl der zurückzugebenden Ergebnisse"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "Die maximale Anzahl der zurückzugebenden Ergebnisse"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Spam und Papierkorb einbeziehen?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Spam- und Papierkorbordner in die Suche einbeziehen?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Spam- und Papierkorbordner in die Suche einbeziehen?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Seiten-Token"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Page-Token zum Abrufen einer bestimmten Ergebnisseite in der Liste"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Page-Token zum Abrufen einer bestimmten Ergebnisseite in der Liste"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "Entwurf abrufen"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "Einen Entwurf abrufen"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "Ruft einen Entwurf und die darin enthaltene Nachricht im angeforderten `format` ab"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Entwurfs-ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "Die ID des abzurufenden Entwurfs"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "Die ID des abzurufenden Entwurfs; `list-drafts` und `create-draft` geben diesen Wert als `id` zurück"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Nachrichtenformat"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "Wie viel von der Nachricht des Entwurfs abgerufen werden soll"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "Wie viel von der Nachricht des Entwurfs abgerufen werden soll; wenn nicht gesetzt, wird die vollständige Nachricht zurückgegeben"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Vollständig"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Die vollständige Nachricht einschließlich aller Header und des Texts"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Die vollständige Nachricht einschließlich aller Header und der MIME-Textteile; Anhangsdaten sind nicht enthalten und müssen mit `get-attachment` abgerufen werden"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadaten"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "Nur Nachrichten-IDs, Etiketten, Snippet und Header"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "Nur Nachrichten-IDs, Etiketten, Snippet und Header; kein Text"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "Minimal"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "Nur Nachrichten-IDs und Etiketten"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "Nur Nachrichten-IDs und Etiketten; keine Header und kein Text"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "Roh"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "Die vollständige Nachricht als base64url-codierte MIME-Daten"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "Die vollständige Nachricht als base64url-codierte MIME-Daten in `raw`; der Text wird nicht geparst"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "Entwurf senden"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "Einen vorhandenen Entwurf unverändert senden"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "Sendet den durch `id` identifizierten Entwurf unverändert an die darin genannten Empfänger; Gmail entfernt den Entwurf und gibt die gesendete Nachricht zurück. Verwenden Sie zuerst `get-draft`, um zu prüfen, was gesendet wird"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Entwurfs-ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "Die ID des zu sendenden Entwurfs"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "Die ID des zu sendenden Entwurfs; `list-drafts` und `create-draft` geben diesen Wert als `id` zurück"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "Entwurf löschen"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "Einen Entwurf dauerhaft löschen; dies kann nicht rückgängig gemacht werden"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "Löscht einen Entwurf dauerhaft. **Dies kann nicht rückgängig gemacht werden**: Der Entwurf wird nicht in den Papierkorb verschoben und es verbleibt keine Kopie.\n\nDie Gmail-API gibt für diesen Aufruf keinen Inhalt zurück"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Entwurfs-ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "Die ID des dauerhaft zu löschenden Entwurfs"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "Die ID des dauerhaft zu löschenden Entwurfs; `list-drafts` und `create-draft` geben diesen Wert als `id` zurück"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/es.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/es.json
@@ -860,8 +860,8 @@
           "message": "Crear y transmitir un nuevo correo electrónico saliente a través de Gmail"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "Crea un nuevo correo electrónico saliente a partir de las direcciones de destinatarios, asunto, cuerpo y archivos adjuntos suministrados, y transmite ese nuevo correo a través de Gmail."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "Crea un nuevo correo electrónico saliente a partir de las direcciones de destinatarios, asunto, cuerpo y archivos adjuntos suministrados, y transmite ese nuevo correo a través de Gmail. Establezca `thread_id` y `in_reply_to` para enviar el correo como respuesta dentro de una conversación existente"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "La dirección del remitente del correo electrónico"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID del hilo"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "El ID del hilo de Gmail al que añadir el mensaje"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "El ID del hilo de Gmail al que añadir el mensaje; establézcalo para responder dentro de una conversación existente. Gmail solo lo respeta cuando `subject` coincide con el asunto del hilo y `in_reply_to` (o `references`) nombra un mensaje del hilo. Los eventos de observación portan este valor como `threadId`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "En respuesta a"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "El valor de la cabecera Message-ID del mensaje al que se responde"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "El valor de la cabecera `Message-ID` del mensaje al que se responde, incluidos los corchetes angulares; se envía como cabecera `In-Reply-To` y, a menos que se establezca `references`, también como cabecera `References`, para que los clientes de correo y Gmail agrupen la respuesta bajo el mensaje original. Los eventos de observación portan este valor como `Message-ID`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Referencias"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Los valores de la cabecera Message-ID de la conversación a la que se responde"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "El valor de la cabecera `References`: los valores `Message-ID` de los mensajes de la conversación a la que se responde, del más antiguo al más reciente, separados por espacios e incluidos los corchetes angulares. Si no se establece, se usa `in_reply_to`. Los eventos de observación portan la cabecera `References` del mensaje original"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "Buscar mensajes con metadatos"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "Buscar mensajes y devolver cada coincidencia con sus cabeceras"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "Busca mensajes en la cuenta y devuelve cada mensaje coincidente con sus metadatos, en lugar de los simples ID de mensaje y de hilo que devuelve `list`. Cada coincidencia se recupera por separado en el `format` solicitado, por lo que una página de `maxResults` mensajes cuesta `maxResults` + 1 solicitudes a la API; mantenga `maxResults` pequeño y use `pageToken` para recorrer las páginas siguientes"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Criterios de búsqueda"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "El criterio de búsqueda de gmail para recuperar los mensajes"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "El criterio de búsqueda de gmail para recuperar los mensajes; ej.: `in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Resultados máximos"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "El número máximo de resultados a devolver"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "El número máximo de resultados a devolver; cada mensaje devuelto cuesta una solicitud adicional a la API"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "¿Incluir spam y papelera?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "¿Incluir las carpetas de spam y papelera en la búsqueda?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "¿Incluir las carpetas de spam y papelera en la búsqueda?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "Etiquetas"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "Solo devolver mensajes que coincidan con todos los ID de etiqueta indicados"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "Solo devolver mensajes con etiquetas que coincidan con todos los ID de etiqueta especificados. Los mensajes en un hilo pueden tener etiquetas que otros mensajes en el mismo hilo no tienen"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token de página"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token de página para recuperar una página específica de resultados en la lista"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token de página para recuperar una página específica de resultados en la lista"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Formato del mensaje"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Cuánto de cada mensaje coincidente recuperar"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Cuánto de cada mensaje coincidente recuperar"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadatos"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "Solo los ID de mensaje, las etiquetas, el fragmento y las cabeceras solicitadas"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "Solo los ID de mensaje, las etiquetas, el fragmento y las cabeceras indicadas en `metadata_headers`; sin cuerpo"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Completo"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "El mensaje completo, incluidas todas las cabeceras y el cuerpo"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "El mensaje completo, incluidas todas las cabeceras y las partes MIME del cuerpo; los datos de los archivos adjuntos no se incluyen y deben recuperarse con `get-attachment`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "Cabeceras de metadatos"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "Las cabeceras del mensaje a recuperar para cada mensaje coincidente"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "Las cabeceras del mensaje a recuperar para cada mensaje coincidente; se ignora a menos que `format` sea `metadata`"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "Restaurar un mensaje desde la papelera"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "Mover un mensaje de la papelera de vuelta al buzón"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "Mueve el mensaje identificado por `id` fuera de la papelera de Gmail y de vuelta al buzón, deshaciendo `trash-message`; un mensaje que Gmail ya haya purgado de la papelera no se puede restaurar"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID del mensaje"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "El ID del mensaje a restaurar desde la papelera"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "El ID del mensaje a restaurar desde la papelera; los eventos de observación portan este valor como `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "Cambiar las etiquetas de un mensaje"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "Añadir etiquetas a un mensaje y quitárselas"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "Añade las etiquetas de `addLabelIds` al mensaje identificado por `id` y le quita las etiquetas de `removeLabelIds` en una sola llamada. Las etiquetas del sistema de Gmail se cambian de la misma manera: quite `UNREAD` para marcar un mensaje como leído, quite `INBOX` para archivarlo o añada `STARRED` para destacarlo. Use `list-labels` para encontrar el ID de una etiqueta o `create-label` para crear una nueva"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID del mensaje"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "El ID del mensaje cuyas etiquetas cambiar"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "El ID del mensaje cuyas etiquetas cambiar; los eventos de observación portan este valor como `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "Etiquetas a añadir"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "Los ID de las etiquetas a añadir al mensaje"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "Los ID de las etiquetas a añadir al mensaje; una etiqueta se identifica por su ID (p. ej. `INBOX`, `STARRED`, `Label_12`), no por su nombre"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "Etiquetas a quitar"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "Los ID de las etiquetas a quitar del mensaje"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "Los ID de las etiquetas a quitar del mensaje; una etiqueta se identifica por su ID (p. ej. `INBOX`, `UNREAD`, `Label_12`), no por su nombre"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "Listar etiquetas"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "Listar todas las etiquetas de la cuenta"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "Lista todas las etiquetas de la cuenta, tanto las etiquetas del sistema de Gmail (`INBOX`, `UNREAD`, `STARRED`, etc.) como las creadas por el usuario, cada una con el ID que aceptan `modify-message-labels` y la opción de búsqueda `labelIds`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "Crear una etiqueta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "Crear una nueva etiqueta de usuario en la cuenta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "Crea una nueva etiqueta de usuario en la cuenta y la devuelve con el ID que acepta `modify-message-labels`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "Nombre de la etiqueta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "El nombre visible de la etiqueta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "El nombre visible de la etiqueta; use `/` para anidar una etiqueta bajo otra, p. ej. `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "Visibilidad en la lista de etiquetas"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "Si la etiqueta se muestra en la lista de etiquetas"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Si la etiqueta se muestra en la lista de etiquetas de la interfaz web de Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "Mostrar"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "Mostrar la etiqueta en la lista de etiquetas"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "Mostrar si hay no leídos"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "Mostrar la etiqueta en la lista de etiquetas solo mientras tenga mensajes no leídos"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "Ocultar"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "No mostrar la etiqueta en la lista de etiquetas"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "Visibilidad en la lista de mensajes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "Si los mensajes con la etiqueta se muestran en la lista de mensajes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Si los mensajes con la etiqueta se muestran en la lista de mensajes de la interfaz web de Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "Mostrar"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "Mostrar los mensajes con la etiqueta en la lista de mensajes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "Ocultar"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "No mostrar los mensajes con la etiqueta en la lista de mensajes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "Crear un borrador"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "Crear un nuevo borrador de correo en Gmail sin enviarlo"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "Crea un nuevo borrador de correo a partir de las direcciones de destinatarios, asunto, cuerpo y archivos adjuntos suministrados y lo guarda en la carpeta de borradores de Gmail sin enviarlo, para que una persona pueda revisarlo y enviarlo, o para que `send-draft` pueda enviarlo más tarde. Establezca `thread_id` y `in_reply_to` para redactar una respuesta dentro de una conversación existente"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "Para"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "Direcciones de destinatarios del mensaje"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "Una o más direcciones `To:` para el correo electrónico"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "CC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "Direcciones en copia carbón (CC)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "Una o más direcciones `Cc:` para el correo electrónico"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "CCO"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "Direcciones de copia oculta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "Una o más direcciones `Bcc:` para el correo electrónico"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "Asunto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "El asunto del correo electrónico"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "El asunto del correo electrónico"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "Cuerpo del mensaje"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "El cuerpo del mensaje"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "El cuerpo del mensaje"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "Archivos adjuntos"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "Archivos adjuntos del mensaje"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "Cualquier archivo adjunto para el mensaje"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "Datos del adjunto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Los datos, el nombre del archivo y el tipo MIME del archivo adjunto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Los datos, el nombre del archivo y el tipo MIME del archivo adjunto"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Datos del archivo"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Datos de archivo codificados en Base64 o datos brutos para codificar con codificación Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Datos de archivo codificados en Base64 o datos brutos para codificar con codificación Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Tipo MIME"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "La cadena MIME para el archivo"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "La cadena MIME para el archivo"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Detección automática"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Detectar automáticamente del nombre de archivo; válido solo en entrada"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Detectar automáticamente del nombre de archivo; válido solo en entrada"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Texto sin formato"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Texto sin formato"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Texto HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Texto HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Archivo PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Archivo PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Documento MS Word docx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Documento de MS Word `docx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Documento MS PowerPoint pptx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Documento de MS PowerPoint `pptx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Documento MS Excel xlsx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Documento de MS Excel `xlsx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nombre de archivo"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "El nombre del archivo"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "El nombre del archivo"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "Codificación del adjunto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "La codificación que se usará para el archivo adjunto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "La codificación que se usará para el archivo adjunto:\n- `default`: `quoted-printable` para datos de cadena, `base64` para datos binarios\n- `none`: sin codificación de contenido (no recomendado)\n- `quoted-printable`: codificación quoted printable\n- `base64`: codificación base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' para datos de cadena, 'base64' para datos binarios"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` para datos de cadena, `base64` para datos binarios"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Ninguno"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Sin codificación de contenido (no recomendado)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Sin codificación de contenido (no recomendado)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal para datos de cadena"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal para datos de cadena"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal para datos binarios"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal para datos binarios"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "Encabezados"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Encabezados opcionales que se enviarán con el archivo adjunto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Encabezados opcionales que se enviarán con el archivo adjunto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "Codificación del cuerpo"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "La codificación que se usará para el archivo adjunto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "La codificación que se usará para el archivo adjunto:\n- `default`: `quoted-printable` para datos de cadena, `base64` para datos binarios\n- `none`: sin codificación de contenido (no recomendado)\n- `quoted-printable`: codificación quoted printable\n- `base64`: codificación base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' para datos de cadena, 'base64' para datos binarios"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` para datos de cadena, `base64` para datos binarios"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Ninguno"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Sin codificación de contenido (no recomendado)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Sin codificación de contenido (no recomendado)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal para datos de cadena"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal para datos de cadena"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal para datos binarios"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal para datos binarios"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "Tipo MIME del cuerpo"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "El tipo MIME del cuerpo del mensaje"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "El tipo MIME del cuerpo del mensaje"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Texto sin formato"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Texto sin formato"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Texto HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Texto HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "Remitente"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "La dirección del remitente del correo electrónico"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "La dirección del remitente del correo electrónico"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID del hilo"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "El ID del hilo de Gmail al que añadir el mensaje"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "El ID del hilo de Gmail al que añadir el mensaje; establézcalo para responder dentro de una conversación existente. Gmail solo lo respeta cuando `subject` coincide con el asunto del hilo y `in_reply_to` (o `references`) nombra un mensaje del hilo. Los eventos de observación portan este valor como `threadId`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "En respuesta a"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "El valor de la cabecera Message-ID del mensaje al que se responde"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "El valor de la cabecera `Message-ID` del mensaje al que se responde, incluidos los corchetes angulares; se envía como cabecera `In-Reply-To` y, a menos que se establezca `references`, también como cabecera `References`, para que los clientes de correo y Gmail agrupen la respuesta bajo el mensaje original. Los eventos de observación portan este valor como `Message-ID`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Referencias"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Los valores de la cabecera Message-ID de la conversación a la que se responde"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "El valor de la cabecera `References`: los valores `Message-ID` de los mensajes de la conversación a la que se responde, del más antiguo al más reciente, separados por espacios e incluidos los corchetes angulares. Si no se establece, se usa `in_reply_to`. Los eventos de observación portan la cabecera `References` del mensaje original"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "Buscar borradores"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "Buscar borradores"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "Busca borradores en la cuenta; cada borrador se devuelve con su ID y con el ID y el ID de hilo del mensaje que contiene. Use `get-draft` para recuperar el contenido de un borrador"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Criterios de búsqueda"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "Los criterios de búsqueda de Gmail para recuperar los borradores"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "Los criterios de búsqueda de Gmail para recuperar los borradores; p. ej. `to:me@gmail.com subject:hello`; si no se establecen, se devuelven todos los borradores"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Resultados máximos"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "El número máximo de resultados a devolver"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "El número máximo de resultados a devolver"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "¿Incluir spam y papelera?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "¿Incluir las carpetas de spam y papelera en la búsqueda?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "¿Incluir las carpetas de spam y papelera en la búsqueda?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token de página"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token de página para recuperar una página específica de resultados en la lista"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token de página para recuperar una página específica de resultados en la lista"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "Recuperar un borrador"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "Recuperar un borrador"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "Recupera un borrador y el mensaje que contiene en el `format` solicitado"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID del borrador"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "El ID del borrador a recuperar"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "El ID del borrador a recuperar; `list-drafts` y `create-draft` devuelven este valor como `id`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Formato del mensaje"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "Cuánto del mensaje del borrador recuperar"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "Cuánto del mensaje del borrador recuperar; si no se establece, se devuelve el mensaje completo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Completo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "El mensaje completo, incluidas todas las cabeceras y el cuerpo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "El mensaje completo, incluidas todas las cabeceras y las partes MIME del cuerpo; los datos de los archivos adjuntos no se incluyen y deben recuperarse con `get-attachment`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadatos"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "Solo los ID de mensaje, las etiquetas, el fragmento y las cabeceras"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "Solo los ID de mensaje, las etiquetas, el fragmento y las cabeceras; sin cuerpo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "Mínimo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "Solo los ID de mensaje y las etiquetas"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "Solo los ID de mensaje y las etiquetas; sin cabeceras ni cuerpo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "Sin procesar"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "El mensaje completo como datos MIME codificados en base64url"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "El mensaje completo como datos MIME codificados en base64url en `raw`; el cuerpo no se analiza"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "Enviar un borrador"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "Enviar un borrador existente tal cual"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "Envía el borrador identificado por `id` tal cual a los destinatarios que indica; Gmail elimina el borrador y devuelve el mensaje enviado. Use primero `get-draft` para revisar lo que se enviará"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID del borrador"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "El ID del borrador a enviar"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "El ID del borrador a enviar; `list-drafts` y `create-draft` devuelven este valor como `id`"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "Eliminar un borrador"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "Eliminar un borrador de forma permanente; esto no se puede deshacer"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "Elimina un borrador de forma permanente. **Esto no se puede deshacer**: el borrador no va a la papelera y no queda ninguna copia.\n\nLa API de Gmail no devuelve contenido para esta llamada"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID del borrador"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "El ID del borrador a eliminar de forma permanente"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "El ID del borrador a eliminar de forma permanente; `list-drafts` y `create-draft` devuelven este valor como `id`"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/fr.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/fr.json
@@ -860,8 +860,8 @@
           "message": "Créer et transmettre un nouvel e-mail sortant via Gmail"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "Crée un nouvel e-mail sortant à partir des adresses de destinataires, de l'objet, du corps et des pièces jointes fournis, et transmet ce nouvel e-mail via Gmail."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "Crée un nouvel e-mail sortant à partir des adresses de destinataires, de l'objet, du corps et des pièces jointes fournis, et transmet ce nouvel e-mail via Gmail. Définissez `thread_id` et `in_reply_to` pour envoyer l'e-mail en réponse au sein d'une conversation existante"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "L'adresse de l'expéditeur de l'e-mail"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID du fil"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "L'ID du fil de discussion Gmail auquel ajouter le message"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "L'ID du fil de discussion Gmail auquel ajouter le message ; définissez-le pour répondre au sein d'une conversation existante. Gmail ne le respecte que si `subject` correspond à l'objet du fil et si `in_reply_to` (ou `references`) désigne un message du fil. Les événements de surveillance transmettent cette valeur sous `threadId`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "En réponse à"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "La valeur de l'en-tête Message-ID du message auquel on répond"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "La valeur de l'en-tête `Message-ID` du message auquel on répond, chevrons compris ; envoyée comme en-tête `In-Reply-To` et, sauf si `references` est défini, également comme en-tête `References`, afin que les clients de messagerie et Gmail rattachent la réponse au message d'origine. Les événements de surveillance transmettent cette valeur sous `Message-ID`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Références"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Les valeurs des en-têtes Message-ID de la conversation à laquelle on répond"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "La valeur de l'en-tête `References` : les valeurs `Message-ID` des messages de la conversation à laquelle on répond, du plus ancien au plus récent, séparées par des espaces et chevrons compris. Si elle n'est pas définie, `in_reply_to` est utilisé. Les événements de surveillance transmettent l'en-tête `References` du message d'origine"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "Rechercher des messages avec leurs métadonnées"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "Rechercher des messages et renvoyer chaque résultat avec ses en-têtes"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "Recherche des messages dans le compte et renvoie chaque message correspondant avec ses métadonnées, au lieu des simples ID de message et de fil que renvoie `list`. Chaque résultat est récupéré séparément dans le `format` demandé, de sorte qu'une page de `maxResults` messages coûte `maxResults` + 1 requêtes API ; gardez `maxResults` petit et utilisez `pageToken` pour parcourir les pages suivantes"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Critères de recherche"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "Les critères de recherche Gmail pour récupérer les messages"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "Les critères de recherche Gmail pour récupérer les messages ; ex. : `in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Résultats max"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Nombre maximal de résultats à renvoyer"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "Le nombre maximal de résultats à renvoyer ; chaque message renvoyé coûte une requête API supplémentaire"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Inclure le spam et la corbeille ?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Inclure les dossiers spam et corbeille dans la recherche ?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Inclure les dossiers spam et corbeille dans la recherche ?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "Étiquettes"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "Renvoyer uniquement les messages avec tous les ID de libellé spécifiés"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "Renvoyer uniquement les messages avec des libellés correspondant à tous les identifiants de libellé spécifiés. Les messages d'un fil peuvent avoir des libellés que d'autres messages du même fil n'ont pas"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Jeton de page"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Jeton de page pour récupérer une page spécifique de résultats dans la liste"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Jeton de page pour récupérer une page spécifique de résultats dans la liste"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Format du message"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Quelle part de chaque message correspondant récupérer"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Quelle part de chaque message correspondant récupérer"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Métadonnées"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "Uniquement les ID de message, les étiquettes, l'extrait et les en-têtes demandés"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "Uniquement les ID de message, les étiquettes, l'extrait et les en-têtes nommés dans `metadata_headers` ; pas de corps"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Complet"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Le message complet, y compris tous les en-têtes et le corps"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Le message complet, y compris tous les en-têtes et les parties MIME du corps ; les données des pièces jointes ne sont pas incluses et doivent être récupérées avec `get-attachment`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "En-têtes de métadonnées"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "Les en-têtes de message à récupérer pour chaque message correspondant"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "Les en-têtes de message à récupérer pour chaque message correspondant ; ignoré sauf si `format` vaut `metadata`"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "Restaurer un message depuis la corbeille"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "Déplacer un message de la corbeille vers la boîte aux lettres"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "Déplace le message identifié par `id` hors de la corbeille de Gmail et le remet dans la boîte aux lettres, annulant `trash-message` ; un message que Gmail a déjà purgé de la corbeille ne peut pas être restauré"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID de message"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "L'ID du message à restaurer depuis la corbeille"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "L'ID du message à restaurer depuis la corbeille ; les événements de surveillance transmettent cette valeur sous `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "Modifier les étiquettes d'un message"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "Ajouter des étiquettes à un message et lui en retirer"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "Ajoute les étiquettes de `addLabelIds` au message identifié par `id` et lui retire les étiquettes de `removeLabelIds` en un seul appel. Les étiquettes système de Gmail se modifient de la même façon : retirez `UNREAD` pour marquer un message comme lu, retirez `INBOX` pour l'archiver ou ajoutez `STARRED` pour le suivre. Utilisez `list-labels` pour trouver l'ID d'une étiquette ou `create-label` pour en créer une nouvelle"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID de message"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "L'ID du message dont modifier les étiquettes"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "L'ID du message dont modifier les étiquettes ; les événements de surveillance transmettent cette valeur sous `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "Étiquettes à ajouter"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "Les ID des étiquettes à ajouter au message"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "Les ID des étiquettes à ajouter au message ; une étiquette est identifiée par son ID (ex. : `INBOX`, `STARRED`, `Label_12`), pas par son nom"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "Étiquettes à retirer"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "Les ID des étiquettes à retirer du message"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "Les ID des étiquettes à retirer du message ; une étiquette est identifiée par son ID (ex. : `INBOX`, `UNREAD`, `Label_12`), pas par son nom"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "Lister les étiquettes"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "Lister toutes les étiquettes du compte"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "Liste toutes les étiquettes du compte, aussi bien les étiquettes système de Gmail (`INBOX`, `UNREAD`, `STARRED`, etc.) que les étiquettes créées par l'utilisateur, chacune avec l'ID qu'acceptent `modify-message-labels` et l'option de recherche `labelIds`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "Créer une étiquette"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "Créer une nouvelle étiquette utilisateur dans le compte"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "Crée une nouvelle étiquette utilisateur dans le compte et la renvoie avec l'ID qu'accepte `modify-message-labels`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "Nom de l'étiquette"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "Le nom affiché de l'étiquette"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "Le nom affiché de l'étiquette ; utilisez `/` pour imbriquer une étiquette sous une autre, ex. : `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "Visibilité dans la liste des étiquettes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "Indique si l'étiquette est affichée dans la liste des étiquettes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Indique si l'étiquette est affichée dans la liste des étiquettes de l'interface web de Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "Afficher"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "Afficher l'étiquette dans la liste des étiquettes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "Afficher si non lu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "Afficher l'étiquette dans la liste des étiquettes uniquement tant qu'elle contient des messages non lus"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "Masquer"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "Ne pas afficher l'étiquette dans la liste des étiquettes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "Visibilité dans la liste des messages"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "Indique si les messages portant l'étiquette sont affichés dans la liste des messages"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Indique si les messages portant l'étiquette sont affichés dans la liste des messages de l'interface web de Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "Afficher"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "Afficher les messages portant l'étiquette dans la liste des messages"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "Masquer"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "Ne pas afficher les messages portant l'étiquette dans la liste des messages"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "Créer un brouillon"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "Créer un nouveau brouillon d'e-mail dans Gmail sans l'envoyer"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "Crée un nouveau brouillon d'e-mail à partir des adresses de destinataires, de l'objet, du corps et des pièces jointes fournis, et l'enregistre dans le dossier des brouillons de Gmail sans l'envoyer, afin qu'une personne puisse le relire et l'envoyer, ou que `send-draft` puisse l'envoyer plus tard. Définissez `thread_id` et `in_reply_to` pour rédiger une réponse au sein d'une conversation existante"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "À"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "Adresses des destinataires du message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "Une ou plusieurs adresses `To:` pour l'e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "CC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "Adresses en copie carbone"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "Une ou plusieurs adresses `Cc:` pour l'e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "BCC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "Adresses en copie carbone invisible (CCI)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "Une ou plusieurs adresses `Bcc:` pour l'e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "Sujet"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "L'objet de l'e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "L'objet de l'e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "Corps du message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "Le corps du message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "Le corps du message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "Pièces jointes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "Pièces jointes du message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "Pièces jointes éventuelles pour le message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "Données de la pièce jointe"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Les données, le nom de fichier et le type MIME pour la pièce jointe"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Les données, le nom de fichier et le type MIME pour la pièce jointe"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Données du fichier"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Données de fichier encodées en Base64 ou données brutes à encoder en Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Données de fichier encodées en Base64 ou données brutes à encoder en Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Type MIME"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "La chaîne de type MIME pour le fichier"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "La chaîne de type MIME pour le fichier"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Détection automatique"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Détection automatique à partir du nom de fichier ; valable uniquement en entrée"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Détection automatique à partir du nom de fichier ; valable uniquement en entrée"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Texte brut"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Texte brut"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Texte HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Texte HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Fichier PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Fichier PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Document Word docx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Document Word `docx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Document PowerPoint pptx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Document PowerPoint `pptx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Document Excel xlsx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Document Excel `xlsx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nom de fichier"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Le nom du fichier"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Le nom du fichier"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "Encodage de la pièce jointe"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "L'encodage à utiliser pour la pièce jointe"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "L'encodage à utiliser pour la pièce jointe :\n- `default` : `quoted-printable` pour les données de type chaîne, `base64` pour les données binaires\n- `none` : aucun encodage de contenu (non recommandé)\n- `quoted-printable` : encodage quoted-printable \n- `base64` : encodage base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' pour le texte, 'base64' pour les données binaires"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` pour les données de type chaîne, `base64` pour les données binaires"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Aucun"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Aucun encodage de contenu (non recommandé)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Aucun encodage de contenu (non recommandé)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Idéal pour les données de type chaîne"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Idéal pour les données de type chaîne"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Idéal pour les données binaires"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Idéal pour les données binaires"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "En-têtes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "En-têtes facultatifs à envoyer avec la pièce jointe"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "En-têtes facultatifs à envoyer avec la pièce jointe"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "Encodage du corps"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "L'encodage à utiliser pour la pièce jointe"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "L'encodage à utiliser pour la pièce jointe :\n- `default` : `quoted-printable` pour les données de type chaîne, `base64` pour les données binaires\n- `none` : aucun encodage de contenu (non recommandé)\n- `quoted-printable` : encodage quoted-printable \n- `base64` : encodage base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' pour le texte, 'base64' pour les données binaires"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` pour les données de type chaîne, `base64` pour les données binaires"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Aucun"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Aucun encodage de contenu (non recommandé)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Aucun encodage de contenu (non recommandé)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Idéal pour les données de type chaîne"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Idéal pour les données de type chaîne"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Idéal pour les données binaires"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Idéal pour les données binaires"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "Type MIME du corps"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "Le type MIME du corps du message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "Le type MIME du corps du message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Texte brut"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Texte brut"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Texte HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Texte HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "Expéditeur"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "L'adresse de l'expéditeur de l'e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "L'adresse de l'expéditeur de l'e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID du fil"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "L'ID du fil de discussion Gmail auquel ajouter le message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "L'ID du fil de discussion Gmail auquel ajouter le message ; définissez-le pour répondre au sein d'une conversation existante. Gmail ne le respecte que si `subject` correspond à l'objet du fil et si `in_reply_to` (ou `references`) désigne un message du fil. Les événements de surveillance transmettent cette valeur sous `threadId`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "En réponse à"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "La valeur de l'en-tête Message-ID du message auquel on répond"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "La valeur de l'en-tête `Message-ID` du message auquel on répond, chevrons compris ; envoyée comme en-tête `In-Reply-To` et, sauf si `references` est défini, également comme en-tête `References`, afin que les clients de messagerie et Gmail rattachent la réponse au message d'origine. Les événements de surveillance transmettent cette valeur sous `Message-ID`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Références"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Les valeurs des en-têtes Message-ID de la conversation à laquelle on répond"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "La valeur de l'en-tête `References` : les valeurs `Message-ID` des messages de la conversation à laquelle on répond, du plus ancien au plus récent, séparées par des espaces et chevrons compris. Si elle n'est pas définie, `in_reply_to` est utilisé. Les événements de surveillance transmettent l'en-tête `References` du message d'origine"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "Rechercher des brouillons"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "Rechercher des brouillons"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "Recherche des brouillons dans le compte ; chaque brouillon est renvoyé avec son ID ainsi que l'ID et l'ID de fil du message qu'il contient. Utilisez `get-draft` pour récupérer le contenu d'un brouillon"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Critères de recherche"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "Les critères de recherche Gmail pour récupérer les brouillons"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "Les critères de recherche Gmail pour récupérer les brouillons ; ex. : `to:me@gmail.com subject:hello` ; s'ils ne sont pas définis, tous les brouillons sont renvoyés"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Résultats max"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Nombre maximal de résultats à renvoyer"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "Nombre maximal de résultats à renvoyer"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Inclure le spam et la corbeille ?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Inclure les dossiers spam et corbeille dans la recherche ?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Inclure les dossiers spam et corbeille dans la recherche ?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Jeton de page"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Jeton de page pour récupérer une page spécifique de résultats dans la liste"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Jeton de page pour récupérer une page spécifique de résultats dans la liste"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "Récupérer un brouillon"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "Récupérer un brouillon"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "Récupère un brouillon et le message qu'il contient dans le `format` demandé"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID du brouillon"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "L'ID du brouillon à récupérer"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "L'ID du brouillon à récupérer ; `list-drafts` et `create-draft` renvoient cette valeur sous `id`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Format du message"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "Quelle part du message du brouillon récupérer"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "Quelle part du message du brouillon récupérer ; si non défini, le message complet est renvoyé"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Complet"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Le message complet, y compris tous les en-têtes et le corps"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Le message complet, y compris tous les en-têtes et les parties MIME du corps ; les données des pièces jointes ne sont pas incluses et doivent être récupérées avec `get-attachment`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Métadonnées"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "Uniquement les ID de message, les étiquettes, l'extrait et les en-têtes"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "Uniquement les ID de message, les étiquettes, l'extrait et les en-têtes ; pas de corps"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "Minimal"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "Uniquement les ID de message et les étiquettes"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "Uniquement les ID de message et les étiquettes ; ni en-têtes ni corps"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "Brut"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "Le message complet sous forme de données MIME encodées en base64url"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "Le message complet sous forme de données MIME encodées en base64url dans `raw` ; le corps n'est pas analysé"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "Envoyer un brouillon"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "Envoyer un brouillon existant tel quel"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "Envoie le brouillon identifié par `id` tel quel aux destinataires qu'il désigne ; Gmail supprime le brouillon et renvoie le message envoyé. Utilisez d'abord `get-draft` pour vérifier ce qui sera envoyé"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID du brouillon"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "L'ID du brouillon à envoyer"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "L'ID du brouillon à envoyer ; `list-drafts` et `create-draft` renvoient cette valeur sous `id`"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "Supprimer un brouillon"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "Supprimer définitivement un brouillon ; cette opération est irréversible"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "Supprime définitivement un brouillon. **Cette opération est irréversible** : le brouillon n'est pas placé dans la corbeille et aucune copie n'est conservée.\n\nL'API Gmail ne renvoie aucun contenu pour cet appel"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID du brouillon"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "L'ID du brouillon à supprimer définitivement"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "L'ID du brouillon à supprimer définitivement ; `list-drafts` et `create-draft` renvoient cette valeur sous `id`"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/it.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/it.json
@@ -860,8 +860,8 @@
           "message": "Crea e invia una nuova email in uscita tramite Gmail"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "Crea una nuova email in uscita a partire da indirizzi dei destinatari, oggetto, corpo e allegati forniti, e la trasmette tramite Gmail."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "Crea una nuova email in uscita a partire da indirizzi dei destinatari, oggetto, corpo e allegati forniti, e la trasmette tramite Gmail. Imposta `thread_id` e `in_reply_to` per inviare l'email come risposta all'interno di una conversazione esistente"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "L'indirizzo del mittente per l'email"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID thread"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "L'ID del thread di Gmail a cui aggiungere il messaggio"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "L'ID del thread di Gmail a cui aggiungere il messaggio; impostalo per rispondere all'interno di una conversazione esistente. Gmail lo rispetta solo quando `subject` corrisponde all'oggetto del thread e `in_reply_to` (o `references`) indica un messaggio del thread. Gli eventi di monitoraggio includono questo valore come `threadId`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "In risposta a"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Il valore dell'intestazione Message-ID del messaggio a cui si risponde"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Il valore dell'intestazione `Message-ID` del messaggio a cui si risponde, parentesi angolari comprese; inviato come intestazione `In-Reply-To` e, a meno che non sia impostato `references`, anche come intestazione `References`, in modo che i client di posta e Gmail raggruppino la risposta sotto il messaggio originale. Gli eventi di monitoraggio includono questo valore come `Message-ID`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Riferimenti"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "I valori delle intestazioni Message-ID della conversazione a cui si risponde"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Il valore dell'intestazione `References`: i valori `Message-ID` dei messaggi della conversazione a cui si risponde, dal più vecchio al più recente, separati da spazi e parentesi angolari comprese. Se non è impostato, viene usato `in_reply_to`. Gli eventi di monitoraggio includono l'intestazione `References` del messaggio originale"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "Cerca messaggi con metadati"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "Cerca messaggi e restituisce ogni risultato con le sue intestazioni"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "Cerca messaggi nell'account e restituisce ogni messaggio corrispondente con i suoi metadati, anziché i soli ID di messaggio e di thread restituiti da `list`. Ogni risultato viene recuperato separatamente nel `format` richiesto, quindi una pagina di `maxResults` messaggi costa `maxResults` + 1 richieste API; mantieni `maxResults` basso e usa `pageToken` per scorrere le pagine successive"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Criteri di ricerca"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "I criteri di ricerca di Gmail per recuperare i messaggi"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "I criteri di ricerca di Gmail per recuperare i messaggi; es.: `in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Risultati massimi"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Il numero massimo di risultati da restituire"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "Il numero massimo di risultati da restituire; ogni messaggio restituito costa una richiesta API aggiuntiva"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Includere spam e cestino?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Includere le cartelle spam e cestino nella ricerca?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Includere le cartelle spam e cestino nella ricerca?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "Etichette"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "Restituisci solo messaggi con etichette corrispondenti a tutti gli ID indicati"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "Restituisce solo i messaggi con etichette corrispondenti a tutti gli ID etichetta specificati. I messaggi in un thread potrebbero avere etichette che altri messaggi nello stesso thread non hanno"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token di pagina"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token di pagina per recuperare una pagina specifica di risultati nell'elenco"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token di pagina per recuperare una pagina specifica di risultati nell'elenco"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Formato del messaggio"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Quanto di ogni messaggio corrispondente recuperare"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Quanto di ogni messaggio corrispondente recuperare"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadati"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "Solo ID dei messaggi, etichette, frammento e le intestazioni richieste"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "Solo ID dei messaggi, etichette, frammento e le intestazioni indicate in `metadata_headers`; nessun corpo"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Completo"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Il messaggio completo, comprese tutte le intestazioni e il corpo"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Il messaggio completo, comprese tutte le intestazioni e le parti MIME del corpo; i dati degli allegati non sono inclusi e devono essere recuperati con `get-attachment`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "Intestazioni dei metadati"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "Le intestazioni del messaggio da recuperare per ogni messaggio corrispondente"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "Le intestazioni del messaggio da recuperare per ogni messaggio corrispondente; ignorato a meno che `format` non sia `metadata`"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "Ripristina un messaggio dal cestino"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "Sposta un messaggio dal cestino di nuovo nella casella di posta"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "Sposta il messaggio identificato da `id` fuori dal cestino di Gmail e di nuovo nella casella di posta, annullando `trash-message`; un messaggio che Gmail ha già eliminato dal cestino non può essere ripristinato"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID messaggio"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "L'ID del messaggio da ripristinare dal cestino"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "L'ID del messaggio da ripristinare dal cestino; gli eventi di monitoraggio includono questo valore come `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "Modifica le etichette di un messaggio"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "Aggiungi etichette a un messaggio e rimuovile"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "Aggiunge le etichette in `addLabelIds` al messaggio identificato da `id` e ne rimuove le etichette in `removeLabelIds` in una sola chiamata. Le etichette di sistema di Gmail si modificano allo stesso modo: rimuovi `UNREAD` per segnare un messaggio come letto, rimuovi `INBOX` per archiviarlo o aggiungi `STARRED` per contrassegnarlo con una stella. Usa `list-labels` per trovare l'ID di un'etichetta o `create-label` per crearne una nuova"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID messaggio"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "L'ID del messaggio di cui modificare le etichette"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "L'ID del messaggio di cui modificare le etichette; gli eventi di monitoraggio includono questo valore come `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "Etichette da aggiungere"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "Gli ID delle etichette da aggiungere al messaggio"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "Gli ID delle etichette da aggiungere al messaggio; un'etichetta è identificata dal suo ID (es. `INBOX`, `STARRED`, `Label_12`), non dal nome"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "Etichette da rimuovere"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "Gli ID delle etichette da rimuovere dal messaggio"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "Gli ID delle etichette da rimuovere dal messaggio; un'etichetta è identificata dal suo ID (es. `INBOX`, `UNREAD`, `Label_12`), non dal nome"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "Elenca etichette"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "Elenca tutte le etichette dell'account"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "Elenca tutte le etichette dell'account, sia le etichette di sistema di Gmail (`INBOX`, `UNREAD`, `STARRED` e così via) sia quelle create dall'utente, ciascuna con l'ID accettato da `modify-message-labels` e dall'opzione di ricerca `labelIds`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "Crea un'etichetta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "Crea una nuova etichetta utente nell'account"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "Crea una nuova etichetta utente nell'account e la restituisce con l'ID accettato da `modify-message-labels`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "Nome dell'etichetta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "Il nome visualizzato dell'etichetta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "Il nome visualizzato dell'etichetta; usa `/` per annidare un'etichetta sotto un'altra, es. `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "Visibilità nell'elenco delle etichette"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "Se l'etichetta viene mostrata nell'elenco delle etichette"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Se l'etichetta viene mostrata nell'elenco delle etichette dell'interfaccia web di Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "Mostra"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "Mostra l'etichetta nell'elenco delle etichette"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "Mostra se non letti"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "Mostra l'etichetta nell'elenco delle etichette solo finché contiene messaggi non letti"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "Nascondi"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "Non mostrare l'etichetta nell'elenco delle etichette"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "Visibilità nell'elenco dei messaggi"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "Se i messaggi con l'etichetta vengono mostrati nell'elenco dei messaggi"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Se i messaggi con l'etichetta vengono mostrati nell'elenco dei messaggi dell'interfaccia web di Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "Mostra"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "Mostra i messaggi con l'etichetta nell'elenco dei messaggi"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "Nascondi"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "Non mostrare i messaggi con l'etichetta nell'elenco dei messaggi"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "Crea una bozza"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "Crea una nuova bozza di email in Gmail senza inviarla"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "Crea una nuova bozza di email a partire da indirizzi dei destinatari, oggetto, corpo e allegati forniti e la salva nella cartella delle bozze di Gmail senza inviarla, in modo che una persona possa rivederla e inviarla, oppure che `send-draft` possa inviarla in seguito. Imposta `thread_id` e `in_reply_to` per preparare una risposta all'interno di una conversazione esistente"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "A"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "Indirizzi dei destinatari del messaggio"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "Uno o più indirizzi `To:` per l'email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "CC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "Indirizzi in copia conoscenza (Cc)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "Uno o più indirizzi `Cc:` per l'e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "CCN"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "Indirizzi in copia conoscenza nascosta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "Uno o più indirizzi `Bcc:` per l'email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "Oggetto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "L'oggetto dell'email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "L'oggetto dell'email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "Corpo del messaggio"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "Il corpo del messaggio"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "Il corpo del messaggio"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "Allegati"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "Allegati del messaggio"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "Eventuali allegati per il messaggio"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "Dati allegato"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "I dati, il nome del file e il tipo MIME per l'allegato"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "I dati, il nome del file e il tipo MIME per l'allegato"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dati File"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dati file codificati in Base64 o dati grezzi da codificare con l'encoding Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dati file codificati in Base64 o dati grezzi da codificare con l'encoding Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Tipo MIME"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Stringa tipo MIME del file"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Stringa tipo MIME del file"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Rilevamento automatico"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Rilevamento automatico dal nome del file; valido solo in input"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Rilevamento automatico dal nome del file; valido solo in input"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Testo normale"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Testo normale"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Testo HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Testo HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "File PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "File PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Documento MS Word docx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Documento MS Word `docx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Documento MS PowerPoint pptx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Documento MS PowerPoint `pptx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Documento MS Excel xlsx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Documento MS Excel `xlsx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nome file"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Il nome del file"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Il nome del file"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "Codifica allegato"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "La codifica da utilizzare per l'allegato"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "La codifica da utilizzare per l'allegato:\n- `default`: `quoted-printable` per dati stringa, `base64` per dati binari\n- `none`: nessuna codifica del contenuto (non consigliato)\n- `quoted-printable`: codifica quoted-printable \n- `base64`: codifica base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' per dati stringa, 'base64' per dati binari"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` per dati stringa, `base64` per dati binari"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Nessuno"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Nessuna codifica dei contenuti (non consigliato)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Nessuna codifica dei contenuti (non consigliato)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideale per dati stringa"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideale per dati stringa"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideale per dati binari"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideale per dati binari"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "Intestazioni"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Intestazioni opzionali da inviare con l'allegato"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Intestazioni opzionali da inviare con l'allegato"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "Codifica corpo"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "La codifica da utilizzare per l'allegato"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "La codifica da utilizzare per l'allegato:\n- `default`: `quoted-printable` per dati stringa, `base64` per dati binari\n- `none`: nessuna codifica del contenuto (non consigliato)\n- `quoted-printable`: codifica quoted-printable \n- `base64`: codifica base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' per dati stringa, 'base64' per dati binari"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` per dati stringa, `base64` per dati binari"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Nessuno"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Nessuna codifica dei contenuti (non consigliato)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Nessuna codifica dei contenuti (non consigliato)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideale per dati stringa"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideale per dati stringa"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideale per dati binari"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideale per dati binari"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "Tipo MIME del corpo"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "Il tipo MIME del corpo del messaggio"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "Il tipo MIME del corpo del messaggio"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Testo normale"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Testo normale"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Testo HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Testo HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "Mittente"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "L'indirizzo del mittente per l'email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "L'indirizzo del mittente per l'email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID thread"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "L'ID del thread di Gmail a cui aggiungere il messaggio"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "L'ID del thread di Gmail a cui aggiungere il messaggio; impostalo per rispondere all'interno di una conversazione esistente. Gmail lo rispetta solo quando `subject` corrisponde all'oggetto del thread e `in_reply_to` (o `references`) indica un messaggio del thread. Gli eventi di monitoraggio includono questo valore come `threadId`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "In risposta a"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Il valore dell'intestazione Message-ID del messaggio a cui si risponde"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Il valore dell'intestazione `Message-ID` del messaggio a cui si risponde, parentesi angolari comprese; inviato come intestazione `In-Reply-To` e, a meno che non sia impostato `references`, anche come intestazione `References`, in modo che i client di posta e Gmail raggruppino la risposta sotto il messaggio originale. Gli eventi di monitoraggio includono questo valore come `Message-ID`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Riferimenti"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "I valori delle intestazioni Message-ID della conversazione a cui si risponde"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Il valore dell'intestazione `References`: i valori `Message-ID` dei messaggi della conversazione a cui si risponde, dal più vecchio al più recente, separati da spazi e parentesi angolari comprese. Se non è impostato, viene usato `in_reply_to`. Gli eventi di monitoraggio includono l'intestazione `References` del messaggio originale"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "Cerca bozze"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "Cerca bozze"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "Cerca bozze nell'account; ogni bozza viene restituita con il suo ID e con l'ID e l'ID thread del messaggio che contiene. Usa `get-draft` per recuperare il contenuto di una bozza"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Criteri di ricerca"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "I criteri di ricerca Gmail per recuperare le bozze"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "I criteri di ricerca Gmail per recuperare le bozze; es. `to:me@gmail.com subject:hello`; se non impostati, vengono restituite tutte le bozze"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Risultati massimi"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Il numero massimo di risultati da restituire"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "Il numero massimo di risultati da restituire"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Includere spam e cestino?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Includere le cartelle spam e cestino nella ricerca?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Includere le cartelle spam e cestino nella ricerca?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token di pagina"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token di pagina per recuperare una pagina specifica di risultati nell'elenco"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token di pagina per recuperare una pagina specifica di risultati nell'elenco"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "Recupera una bozza"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "Recupera una bozza"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "Recupera una bozza e il messaggio che contiene nel `format` richiesto"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID bozza"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "L'ID della bozza da recuperare"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "L'ID della bozza da recuperare; `list-drafts` e `create-draft` restituiscono questo valore come `id`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Formato del messaggio"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "Quanto del messaggio della bozza recuperare"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "Quanto del messaggio della bozza recuperare; se non impostato, viene restituito il messaggio completo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Completo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Il messaggio completo, comprese tutte le intestazioni e il corpo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Il messaggio completo, comprese tutte le intestazioni e le parti MIME del corpo; i dati degli allegati non sono inclusi e devono essere recuperati con `get-attachment`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadati"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "Solo ID dei messaggi, etichette, frammento e intestazioni"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "Solo ID dei messaggi, etichette, frammento e intestazioni; nessun corpo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "Minimo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "Solo ID dei messaggi ed etichette"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "Solo ID dei messaggi ed etichette; nessuna intestazione e nessun corpo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "Grezzo"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "Il messaggio completo come dati MIME codificati in base64url"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "Il messaggio completo come dati MIME codificati in base64url in `raw`; il corpo non viene analizzato"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "Invia una bozza"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "Invia una bozza esistente così com'è"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "Invia la bozza identificata da `id` così com'è ai destinatari che indica; Gmail rimuove la bozza e restituisce il messaggio inviato. Usa prima `get-draft` per controllare cosa verrà inviato"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID bozza"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "L'ID della bozza da inviare"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "L'ID della bozza da inviare; `list-drafts` e `create-draft` restituiscono questo valore come `id`"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "Elimina una bozza"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "Elimina definitivamente una bozza; questa operazione non può essere annullata"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "Elimina definitivamente una bozza. **Questa operazione non può essere annullata**: la bozza non viene spostata nel cestino e non ne rimane alcuna copia.\n\nL'API di Gmail non restituisce alcun contenuto per questa chiamata"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID bozza"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "L'ID della bozza da eliminare definitivamente"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "L'ID della bozza da eliminare definitivamente; `list-drafts` e `create-draft` restituiscono questo valore come `id`"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/ja.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/ja.json
@@ -860,8 +860,8 @@
           "message": "Gmail経由で新しい送信メールを作成して送信"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "指定された宛先アドレス、件名、本文、添付ファイルから新しい送信メールを作成し、Gmail経由で送信します。"
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "指定された宛先アドレス、件名、本文、添付ファイルから新しい送信メールを作成し、Gmail経由で送信します。既存の会話内で返信として送信するには、`thread_id` と `in_reply_to` を設定してください"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "メールの送信者アドレス"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "スレッド ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "メッセージを追加する Gmail スレッドの ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "メッセージを追加する Gmail スレッドの ID。既存の会話内で返信する場合に設定します。Gmail がこの値を尊重するのは、`subject` がスレッドの件名と一致し、`in_reply_to`（または `references`）がスレッド内のメッセージを指している場合のみです。監視イベントはこの値を `threadId` として保持します"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "返信先"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "返信対象メッセージの Message-ID ヘッダーの値"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "返信対象メッセージの `Message-ID` ヘッダーの値（山かっこを含む）。`In-Reply-To` ヘッダーとして送信され、`references` が設定されていない場合は `References` ヘッダーとしても送信されるため、メールクライアントと Gmail は返信を元のメッセージの下にスレッド化します。監視イベントはこの値を `Message-ID` として保持します"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "参照"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "返信対象の会話の Message-ID ヘッダーの値"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "`References` ヘッダーの値。返信対象の会話に含まれるメッセージの `Message-ID` 値を、古い順にスペース区切りで山かっこを含めて指定します。設定されていない場合は `in_reply_to` が使用されます。監視イベントは元のメッセージの `References` ヘッダーを保持します"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "メタデータ付きでメッセージを検索"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "メッセージを検索し、一致した各メッセージをヘッダー付きで返します"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "アカウント内のメッセージを検索し、`list` が返すメッセージ ID とスレッド ID だけではなく、一致した各メッセージをメタデータ付きで返します。一致した各メッセージは要求された `format` で個別に取得されるため、`maxResults` 件のページには `maxResults` + 1 回の API リクエストが必要です。`maxResults` を小さく保ち、以降のページは `pageToken` で取得してください"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "検索条件"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "メッセージを取得するためのGmail検索条件"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "メッセージを取得するためのGmail検索条件（例: `in:inbox to:me@gmail.com subject:hello is:unread`）"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "最大結果数"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "返す結果の最大数"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "返す結果の最大数。返されるメッセージごとに API リクエストが 1 回追加で必要になります"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "迷惑メールとゴミ箱を含めるか？"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "検索に迷惑メールとゴミ箱フォルダを含めますか？"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "検索に迷惑メールとゴミ箱フォルダを含めますか？"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "ラベル"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "指定されたすべてのラベルIDに一致するラベルを持つメッセージのみを返す"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "指定されたすべてのラベルIDに一致するラベルを持つメッセージのみを返します。スレッド内のメッセージには、同じスレッド内の他のメッセージにはないラベルが付いている場合があります"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "ページトークン"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "リスト内の特定の結果ページを取得するためのページトークン"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "リスト内の特定の結果ページを取得するためのページトークン"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "メッセージ形式"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "一致した各メッセージをどこまで取得するか"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "一致した各メッセージをどこまで取得するか"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "メタデータ"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "メッセージ ID、ラベル、スニペット、および要求されたヘッダーのみ"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "メッセージ ID、ラベル、スニペット、および `metadata_headers` で指定されたヘッダーのみ。本文は含まれません"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "完全"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "すべてのヘッダーと本文を含む完全なメッセージ"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "すべてのヘッダーと MIME 本文パートを含む完全なメッセージ。添付ファイルのデータは含まれないため、`get-attachment` で取得する必要があります"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "メタデータヘッダー"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "一致した各メッセージについて取得するメッセージヘッダー"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "一致した各メッセージについて取得するメッセージヘッダー。`format` が `metadata` でない場合は無視されます"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "メッセージをゴミ箱から復元"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "メッセージをゴミ箱からメールボックスに戻します"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "`id` で指定されたメッセージを Gmail のゴミ箱からメールボックスに戻し、`trash-message` を取り消します。Gmail がすでにゴミ箱から完全に削除したメッセージは復元できません"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "メッセージ ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "ゴミ箱から復元するメッセージの ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "ゴミ箱から復元するメッセージの ID。監視イベントはこの値を `message_id` として保持します"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "メッセージのラベルを変更"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "メッセージにラベルを追加し、メッセージからラベルを削除します"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "`id` で指定されたメッセージに `addLabelIds` のラベルを追加し、`removeLabelIds` のラベルを削除する処理を 1 回の呼び出しで行います。Gmail のシステムラベルも同じ方法で変更できます。`UNREAD` を削除すると既読に、`INBOX` を削除するとアーカイブに、`STARRED` を追加するとスター付きになります。ラベルの ID を調べるには `list-labels` を、新しいラベルを作成するには `create-label` を使用してください"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "メッセージ ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "ラベルを変更するメッセージの ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "ラベルを変更するメッセージの ID。監視イベントはこの値を `message_id` として保持します"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "追加するラベル"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "メッセージに追加するラベルの ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "メッセージに追加するラベルの ID。ラベルは名前ではなく ID（例: `INBOX`、`STARRED`、`Label_12`）で識別されます"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "削除するラベル"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "メッセージから削除するラベルの ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "メッセージから削除するラベルの ID。ラベルは名前ではなく ID（例: `INBOX`、`UNREAD`、`Label_12`）で識別されます"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "ラベルの一覧"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "アカウント内のすべてのラベルを一覧表示します"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "アカウント内のすべてのラベルを、Gmail のシステムラベル（`INBOX`、`UNREAD`、`STARRED` など）とユーザーが作成したラベルの両方について、`modify-message-labels` および検索オプション `labelIds` が受け取る ID とともに一覧表示します"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "ラベルを作成"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "アカウントに新しいユーザーラベルを作成します"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "アカウントに新しいユーザーラベルを作成し、`modify-message-labels` が受け取る ID とともに返します"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "ラベル名"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "ラベルの表示名"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "ラベルの表示名。`/` を使うとラベルを別のラベルの下にネストできます（例: `Projects/Alpha`）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "ラベルリストでの表示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "ラベルをラベルリストに表示するかどうか"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Gmail ウェブインターフェースのラベルリストにラベルを表示するかどうか"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "表示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "ラベルをラベルリストに表示します"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "未読がある場合に表示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "未読メッセージがある間のみ、ラベルをラベルリストに表示します"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "非表示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "ラベルをラベルリストに表示しません"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "メッセージリストでの表示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "このラベルの付いたメッセージをメッセージリストに表示するかどうか"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Gmail ウェブインターフェースのメッセージリストに、このラベルの付いたメッセージを表示するかどうか"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "表示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "このラベルの付いたメッセージをメッセージリストに表示します"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "非表示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "このラベルの付いたメッセージをメッセージリストに表示しません"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "下書きを作成"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "送信せずに Gmail に新しい下書きメールを作成します"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "指定された宛先アドレス、件名、本文、添付ファイルから新しい下書きメールを作成し、送信せずに Gmail の下書きフォルダに保存します。これにより、人が確認してから送信したり、後で `send-draft` で送信したりできます。既存の会話内で返信を下書きするには、`thread_id` と `in_reply_to` を設定してください"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "宛先"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "メッセージの受信者アドレス"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "メール用の1つ以上の `To:` アドレス"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "CC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "CCアドレス"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "メールの1つ以上の `Cc:` アドレス"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "BCC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "BCCアドレス"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "メール用の1つ以上の `Bcc:` アドレス"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "サブジェクト"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "メールの件名"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "メールの件名"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "メッセージボディ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "メッセージ本文"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "メッセージ本文"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "添付ファイル"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "メッセージの添付ファイル"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "メッセージの添付ファイル"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "添付データ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "データ、ファイル名、MIMEタイプの添付ファイル"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "データ、ファイル名、MIMEタイプの添付ファイル"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "ファイルデータ"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64でエンコードされたファイルデータまたは、Base64エンコードでエンコードされるべき生データ"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64でエンコードされたファイルデータまたは、Base64エンコードでエンコードされるべき生データ"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME タイプ"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "ファイルのMIMEタイプ文字列"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "ファイルのMIMEタイプ文字列"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "自動検出"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "ファイル名から自動検出；入力時のみ有効"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "ファイル名から自動検出；入力時のみ有効"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "プレーンテキスト"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "プレーンテキスト"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTMLテキスト"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTMLテキスト"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF ファイル"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF ファイル"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx ドキュメント"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` ドキュメント"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx ドキュメント"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` ドキュメント"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx ドキュメント"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` ドキュメント"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "ファイル名"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "ファイル名"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "ファイル名"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "添付エンコーディング"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "添付ファイルに使用するエンコーディング"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "添付ファイルに使用するエンコーディング:\n- `default`: 文字列データには `quoted-printable`、バイナリデータには `base64`\n- `none`: コンテンツエンコーディングなし（非推奨）\n- `quoted-printable`: quoted printableエンコーディング\n- `base64`: base64エンコーディング"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "自動"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "文字列データには「quoted-printable」、バイナリデータには「base64」"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "文字列データには `quoted-printable`、バイナリデータには `base64`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "なし"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "コンテンツエンコーディングなし（非推奨）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "コンテンツエンコーディングなし（非推奨）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "文字列データに最適"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "文字列データに最適"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "バイナリデータに最適"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "バイナリデータに最適"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "ヘッダー"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "添付ファイルに送信するオプションのヘッダー"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "添付ファイルに送信するオプションのヘッダー"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "本文のエンコーディング"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "添付ファイルに使用するエンコーディング"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "添付ファイルに使用するエンコーディング:\n- `default`: 文字列データには `quoted-printable`、バイナリデータには `base64`\n- `none`: コンテンツエンコーディングなし（非推奨）\n- `quoted-printable`: quoted printableエンコーディング\n- `base64`: base64エンコーディング"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "自動"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "文字列データには「quoted-printable」、バイナリデータには「base64」"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "文字列データには `quoted-printable`、バイナリデータには `base64`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "なし"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "コンテンツエンコーディングなし（非推奨）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "コンテンツエンコーディングなし（非推奨）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "文字列データに最適"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "文字列データに最適"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "バイナリデータに最適"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "バイナリデータに最適"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "本文のMIMEタイプ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "メッセージ本文のMIMEタイプ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "メッセージ本文のMIMEタイプ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "プレーンテキスト"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "プレーンテキスト"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTMLテキスト"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTMLテキスト"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "送信者"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "メールの送信者アドレス"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "メールの送信者アドレス"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "スレッド ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "メッセージを追加する Gmail スレッドの ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "メッセージを追加する Gmail スレッドの ID。既存の会話内で返信する場合に設定します。Gmail がこの値を尊重するのは、`subject` がスレッドの件名と一致し、`in_reply_to`（または `references`）がスレッド内のメッセージを指している場合のみです。監視イベントはこの値を `threadId` として保持します"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "返信先"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "返信対象メッセージの Message-ID ヘッダーの値"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "返信対象メッセージの `Message-ID` ヘッダーの値（山かっこを含む）。`In-Reply-To` ヘッダーとして送信され、`references` が設定されていない場合は `References` ヘッダーとしても送信されるため、メールクライアントと Gmail は返信を元のメッセージの下にスレッド化します。監視イベントはこの値を `Message-ID` として保持します"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "参照"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "返信対象の会話の Message-ID ヘッダーの値"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "`References` ヘッダーの値。返信対象の会話に含まれるメッセージの `Message-ID` 値を、古い順にスペース区切りで山かっこを含めて指定します。設定されていない場合は `in_reply_to` が使用されます。監視イベントは元のメッセージの `References` ヘッダーを保持します"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "下書きの検索"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "下書きを検索します"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "アカウント内の下書きを検索します。各下書きは、その ID と、含まれるメッセージの ID およびスレッド ID とともに返されます。下書きの内容を取得するには `get-draft` を使用してください"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "検索条件"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "下書きを取得するための Gmail 検索条件"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "下書きを取得するための Gmail 検索条件（例: `to:me@gmail.com subject:hello`）。設定されていない場合はすべての下書きが返されます"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "最大結果数"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "返す結果の最大数"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "返す結果の最大数"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "迷惑メールとゴミ箱を含めるか？"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "検索に迷惑メールとゴミ箱フォルダを含めますか？"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "検索に迷惑メールとゴミ箱フォルダを含めますか？"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "ページトークン"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "リスト内の特定の結果ページを取得するためのページトークン"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "リスト内の特定の結果ページを取得するためのページトークン"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "下書きの取得"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "下書きを取得します"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "下書きと、それに含まれるメッセージを要求された `format` で取得します"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "下書き ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "取得する下書きの ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "取得する下書きの ID。`list-drafts` と `create-draft` はこの値を `id` として返します"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "メッセージ形式"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "下書きのメッセージをどこまで取得するか"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "下書きのメッセージをどこまで取得するか。設定されていない場合は完全なメッセージが返されます"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "完全"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "すべてのヘッダーと本文を含む完全なメッセージ"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "すべてのヘッダーと MIME 本文パートを含む完全なメッセージ。添付ファイルのデータは含まれないため、`get-attachment` で取得する必要があります"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "メタデータ"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "メッセージ ID、ラベル、スニペット、ヘッダーのみ"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "メッセージ ID、ラベル、スニペット、ヘッダーのみ。本文は含まれません"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "最小"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "メッセージ ID とラベルのみ"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "メッセージ ID とラベルのみ。ヘッダーも本文も含まれません"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "未加工"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "base64url でエンコードされた MIME データとしての完全なメッセージ"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "`raw` に base64url でエンコードされた MIME データとして格納された完全なメッセージ。本文は解析されません"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "下書きを送信"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "既存の下書きをそのまま送信します"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "`id` で指定された下書きを、そこに記載された宛先にそのまま送信します。Gmail は下書きを削除し、送信済みメッセージを返します。送信内容を確認するには、先に `get-draft` を使用してください"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "下書き ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "送信する下書きの ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "送信する下書きの ID。`list-drafts` と `create-draft` はこの値を `id` として返します"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "下書きを削除"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "下書きを完全に削除します。この操作は元に戻せません"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "下書きを完全に削除します。**この操作は元に戻せません**: 下書きはゴミ箱に移動せず、コピーも残りません。\n\nGmail API はこの呼び出しに対して内容を返しません"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "下書き ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "完全に削除する下書きの ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "完全に削除する下書きの ID。`list-drafts` と `create-draft` はこの値を `id` として返します"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/ko.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/ko.json
@@ -860,8 +860,8 @@
           "message": "Gmail을 통해 새 발신 이메일 생성 및 전송"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "제공된 수신자 주소, 제목, 본문 및 첨부 파일로 새 발신 이메일을 생성하고 Gmail을 통해 전송합니다."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "제공된 수신자 주소, 제목, 본문 및 첨부 파일로 새 발신 이메일을 생성하고 Gmail을 통해 전송합니다. 기존 대화 안에서 답장으로 보내려면 `thread_id`와 `in_reply_to`을(를) 설정하세요."
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "이메일 발신자 주소"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "스레드 ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "메시지를 추가할 Gmail 스레드의 ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "메시지를 추가할 Gmail 스레드의 ID입니다. 기존 대화 안에서 답장하려면 이 값을 설정하세요. Gmail은 `subject`이(가) 스레드의 제목과 일치하고 `in_reply_to`(또는 `references`)가 스레드 내 메시지를 가리킬 때만 이 값을 적용합니다. 감시 이벤트는 이 값을 `threadId`(으)로 전달합니다."
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "답장 대상"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "답장하는 메시지의 Message-ID 헤더 값"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "답장하는 메시지의 `Message-ID` 헤더 값이며 꺾쇠괄호를 포함합니다. `In-Reply-To` 헤더로 전송되고, `references`이(가) 설정되지 않은 경우 `References` 헤더로도 전송되므로 메일 클라이언트와 Gmail이 답장을 원본 메시지 아래에 스레드로 묶습니다. 감시 이벤트는 이 값을 `Message-ID`(으)로 전달합니다."
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "참조"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "답장하는 대화의 Message-ID 헤더 값"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "`References` 헤더 값입니다. 답장하는 대화에 포함된 메시지들의 `Message-ID` 값을 가장 오래된 것부터 공백으로 구분하고 꺾쇠괄호를 포함하여 지정합니다. 설정하지 않으면 `in_reply_to`이(가) 사용됩니다. 감시 이벤트는 원본 메시지의 `References` 헤더를 전달합니다."
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "메타데이터와 함께 메시지 검색"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "메시지를 검색하고 일치하는 각 메시지를 헤더와 함께 반환합니다"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "계정에서 메시지를 검색하고, `list`이(가) 반환하는 메시지 ID와 스레드 ID만이 아니라 일치하는 각 메시지를 메타데이터와 함께 반환합니다. 일치하는 각 메시지는 요청한 `format`(으)로 개별 조회되므로 `maxResults`개의 메시지가 있는 한 페이지에는 `maxResults` + 1회의 API 요청이 필요합니다. `maxResults`을(를) 작게 유지하고 다음 페이지는 `pageToken`(으)로 조회하세요."
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "검색 기준"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "메시지를 가져오기 위한 Gmail 검색 기준"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "메시지를 가져오기 위한 Gmail 검색 기준(예: `in:inbox to:me@gmail.com subject:hello is:unread`)"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "최대 결과 수"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "반환할 최대 결과 수"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "반환할 최대 결과 수입니다. 반환되는 메시지마다 API 요청이 한 번 추가로 필요합니다."
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "스팸 및 휴지통 포함 여부"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "검색 시 스팸 및 휴지통 폴더를 포함할까요?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "검색 시 스팸 및 휴지통 폴더를 포함할까요?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "라벨"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "지정된 모든 레이블 ID와 일치하는 레이블이 있는 메시지만 반환"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "지정된 모든 레이블 ID와 일치하는 레이블이 있는 메시지만 반환합니다. 스레드의 특정 메시지에는 동일한 스레드의 다른 메시지에는 없는 레이블이 포함되어 있을 수 있습니다."
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "페이지 토큰"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "목록에서 특정 결과 페이지를 가져오기 위한 페이지 토큰"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "목록에서 특정 결과 페이지를 가져오기 위한 페이지 토큰"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "메시지 형식"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "일치하는 각 메시지를 어느 범위까지 가져올지"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "일치하는 각 메시지를 어느 범위까지 가져올지"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "메타데이터"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "메시지 ID, 라벨, 스니펫 및 요청한 헤더만"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "메시지 ID, 라벨, 스니펫 및 `metadata_headers`에 지정된 헤더만 포함하며 본문은 포함하지 않습니다."
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "전체"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "모든 헤더와 본문을 포함한 전체 메시지"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "모든 헤더와 MIME 본문 파트를 포함한 전체 메시지입니다. 첨부 파일 데이터는 포함되지 않으므로 `get-attachment`(으)로 가져와야 합니다."
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "메타데이터 헤더"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "일치하는 각 메시지에 대해 가져올 메시지 헤더"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "일치하는 각 메시지에 대해 가져올 메시지 헤더입니다. `format`이(가) `metadata`이(가) 아니면 무시됩니다."
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "휴지통에서 메시지 복원"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "휴지통에 있는 메시지를 메일함으로 다시 이동합니다"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "`id`(으)로 지정된 메시지를 Gmail 휴지통에서 메일함으로 다시 이동하여 `trash-message`을(를) 되돌립니다. Gmail이 이미 휴지통에서 완전히 삭제한 메시지는 복원할 수 없습니다."
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "메시지 ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "휴지통에서 복원할 메시지의 ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "휴지통에서 복원할 메시지의 ID입니다. 감시 이벤트는 이 값을 `message_id`(으)로 전달합니다."
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "메시지 라벨 변경"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "메시지에 라벨을 추가하고 메시지에서 라벨을 제거합니다"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "한 번의 호출로 `id`(으)로 지정된 메시지에 `addLabelIds`의 라벨을 추가하고 `removeLabelIds`의 라벨을 제거합니다. Gmail 시스템 라벨도 같은 방식으로 변경됩니다. `UNREAD`을(를) 제거하면 읽음으로 표시되고, `INBOX`을(를) 제거하면 보관 처리되며, `STARRED`을(를) 추가하면 별표가 표시됩니다. 라벨 ID를 찾으려면 `list-labels`을(를), 새 라벨을 만들려면 `create-label`을(를) 사용하세요."
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "메시지 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "라벨을 변경할 메시지의 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "라벨을 변경할 메시지의 ID입니다. 감시 이벤트는 이 값을 `message_id`(으)로 전달합니다."
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "추가할 라벨"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "메시지에 추가할 라벨의 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "메시지에 추가할 라벨의 ID입니다. 라벨은 이름이 아니라 ID(예: `INBOX`, `STARRED`, `Label_12`)로 식별됩니다."
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "제거할 라벨"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "메시지에서 제거할 라벨의 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "메시지에서 제거할 라벨의 ID입니다. 라벨은 이름이 아니라 ID(예: `INBOX`, `UNREAD`, `Label_12`)로 식별됩니다."
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "라벨 목록"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "계정의 모든 라벨을 나열합니다"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "계정의 모든 라벨을 나열합니다. Gmail 시스템 라벨(`INBOX`, `UNREAD`, `STARRED` 등)과 사용자가 만든 라벨을 모두 포함하며, 각 라벨은 `modify-message-labels` 및 검색 옵션 `labelIds`이(가) 사용하는 ID와 함께 반환됩니다."
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "라벨 만들기"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "계정에 새 사용자 라벨을 만듭니다"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "계정에 새 사용자 라벨을 만들고 `modify-message-labels`이(가) 사용하는 ID와 함께 반환합니다."
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "라벨 이름"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "라벨의 표시 이름"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "라벨의 표시 이름입니다. 라벨을 다른 라벨 아래에 중첩하려면 `/`을(를) 사용하세요(예: `Projects/Alpha`)."
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "라벨 목록 표시 여부"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "라벨을 라벨 목록에 표시할지 여부"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Gmail 웹 인터페이스의 라벨 목록에 라벨을 표시할지 여부"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "표시"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "라벨 목록에 라벨을 표시합니다"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "읽지 않은 항목이 있을 때 표시"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "읽지 않은 메시지가 있는 동안에만 라벨 목록에 라벨을 표시합니다"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "숨기기"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "라벨 목록에 라벨을 표시하지 않습니다"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "메시지 목록 표시 여부"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "이 라벨이 있는 메시지를 메시지 목록에 표시할지 여부"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Gmail 웹 인터페이스의 메시지 목록에 이 라벨이 있는 메시지를 표시할지 여부"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "표시"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "이 라벨이 있는 메시지를 메시지 목록에 표시합니다"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "숨기기"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "이 라벨이 있는 메시지를 메시지 목록에 표시하지 않습니다"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "임시보관 메일 만들기"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "보내지 않고 Gmail에 새 임시보관 메일을 만듭니다"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "제공된 수신자 주소, 제목, 본문 및 첨부 파일로 새 임시보관 메일을 만들어 보내지 않고 Gmail 임시보관함에 저장합니다. 이를 통해 사람이 검토한 후 보내거나 나중에 `send-draft`(으)로 보낼 수 있습니다. 기존 대화 안에서 답장을 작성하려면 `thread_id`와 `in_reply_to`을(를) 설정하세요."
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "받는 사람"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "메시지 수신자 주소"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "이메일의 하나 이상의 `To:` 주소"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "참조"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "참조(CC) 주소"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "이메일의 하나 이상의 `Cc:` 주소"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "숨은 참조"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "숨은 참조 주소"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "이메일의 하나 이상의 `Bcc:` 주소"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "제목"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "이메일 제목"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "이메일 제목"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "메시지 본문"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "메시지 본문"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "메시지 본문"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "첨부 파일"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "메시지 첨부 파일"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "메시지의 모든 첨부 파일"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "첨부 파일 데이터"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "데이터, 파일 이름 및 MIME 유형을 포함한 첨부 파일"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "데이터, 파일 이름 및 MIME 유형을 포함한 첨부 파일"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "파일 데이터"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 인코딩된 파일 데이터 또는 Base64로 인코딩할 원시 데이터"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 인코딩된 파일 데이터 또는 Base64로 인코딩할 원시 데이터"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME 유형"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "파일에 대한 MIME 유형 문자열"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "파일에 대한 MIME 유형 문자열"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "자동 감지"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "파일 이름에서 자동 감지; 입력 시에만 유효"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "파일 이름에서 자동 감지; 입력 시에만 유효"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "일반 텍스트"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "일반 텍스트"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 텍스트"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 텍스트"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF 파일"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF 파일"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx 문서"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` 문서"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx 문서"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` 문서"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx 문서"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` 문서"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "파일 이름"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "파일 이름"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "파일 이름"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "첨부 파일 인코딩"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "첨부 파일에 사용할 인코딩"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "첨부 파일에 사용할 인코딩:\n- `default`: 문자열 데이터의 경우 `quoted-printable`, 바이너리 데이터의 경우 `base64`\n- `none`: 콘텐츠 인코딩 없음(권장되지 않음)\n- `quoted-printable`: quoted printable 인코딩\n- `base64`: base64 인코딩"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "자동"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "문자열 데이터의 경우 'quoted-printable', 바이너리 데이터의 경우 'base64'"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "문자열 데이터의 경우 `quoted-printable`, 바이너리 데이터의 경우 `base64`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "없음"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "콘텐츠 인코딩 없음(권장하지 않음)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "콘텐츠 인코딩 없음(권장하지 않음)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "문자열 데이터에 적합"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "문자열 데이터에 적합"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "바이너리 데이터에 적합"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "바이너리 데이터에 적합"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "헤더"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "첨부 파일과 함께 전송할 선택적 헤더"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "첨부 파일과 함께 전송할 선택적 헤더"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "본문 인코딩"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "첨부 파일에 사용할 인코딩"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "첨부 파일에 사용할 인코딩:\n- `default`: 문자열 데이터의 경우 `quoted-printable`, 바이너리 데이터의 경우 `base64`\n- `none`: 콘텐츠 인코딩 없음(권장되지 않음)\n- `quoted-printable`: quoted printable 인코딩\n- `base64`: base64 인코딩"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "자동"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "문자열 데이터의 경우 'quoted-printable', 바이너리 데이터의 경우 'base64'"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "문자열 데이터의 경우 `quoted-printable`, 바이너리 데이터의 경우 `base64`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "없음"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "콘텐츠 인코딩 없음(권장하지 않음)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "콘텐츠 인코딩 없음(권장하지 않음)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "문자열 데이터에 적합"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "문자열 데이터에 적합"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "바이너리 데이터에 적합"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "바이너리 데이터에 적합"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "본문 MIME 유형"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "메시지 본문의 MIME 유형"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "메시지 본문의 MIME 유형"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "일반 텍스트"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "일반 텍스트"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 텍스트"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 텍스트"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "발신자"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "이메일 발신자 주소"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "이메일 발신자 주소"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "스레드 ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "메시지를 추가할 Gmail 스레드의 ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "메시지를 추가할 Gmail 스레드의 ID입니다. 기존 대화 안에서 답장하려면 이 값을 설정하세요. Gmail은 `subject`이(가) 스레드의 제목과 일치하고 `in_reply_to`(또는 `references`)가 스레드 내 메시지를 가리킬 때만 이 값을 적용합니다. 감시 이벤트는 이 값을 `threadId`(으)로 전달합니다."
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "답장 대상"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "답장하는 메시지의 Message-ID 헤더 값"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "답장하는 메시지의 `Message-ID` 헤더 값이며 꺾쇠괄호를 포함합니다. `In-Reply-To` 헤더로 전송되고, `references`이(가) 설정되지 않은 경우 `References` 헤더로도 전송되므로 메일 클라이언트와 Gmail이 답장을 원본 메시지 아래에 스레드로 묶습니다. 감시 이벤트는 이 값을 `Message-ID`(으)로 전달합니다."
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "참조"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "답장하는 대화의 Message-ID 헤더 값"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "`References` 헤더 값입니다. 답장하는 대화에 포함된 메시지들의 `Message-ID` 값을 가장 오래된 것부터 공백으로 구분하고 꺾쇠괄호를 포함하여 지정합니다. 설정하지 않으면 `in_reply_to`이(가) 사용됩니다. 감시 이벤트는 원본 메시지의 `References` 헤더를 전달합니다."
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "임시보관 메일 검색"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "임시보관 메일을 검색합니다"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "계정에서 임시보관 메일을 검색합니다. 각 임시보관 메일은 자체 ID와 함께 포함된 메시지의 ID 및 스레드 ID를 함께 반환합니다. 임시보관 메일의 내용을 가져오려면 `get-draft`을(를) 사용하세요."
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "검색 기준"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "임시보관 메일을 가져오기 위한 Gmail 검색 기준"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "임시보관 메일을 가져오기 위한 Gmail 검색 기준입니다(예: `to:me@gmail.com subject:hello`). 설정하지 않으면 모든 임시보관 메일이 반환됩니다."
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "최대 결과 수"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "반환할 최대 결과 수"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "반환할 최대 결과 수"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "스팸 및 휴지통 포함 여부"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "검색 시 스팸 및 휴지통 폴더를 포함할까요?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "검색 시 스팸 및 휴지통 폴더를 포함할까요?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "페이지 토큰"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "목록에서 특정 결과 페이지를 가져오기 위한 페이지 토큰"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "목록에서 특정 결과 페이지를 가져오기 위한 페이지 토큰"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "임시보관 메일 가져오기"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "임시보관 메일을 가져옵니다"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "임시보관 메일과 여기에 포함된 메시지를 요청한 `format`(으)로 가져옵니다."
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "임시보관 메일 ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "가져올 임시보관 메일의 ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "가져올 임시보관 메일의 ID입니다. `list-drafts`와 `create-draft`은(는) 이 값을 `id`(으)로 반환합니다."
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "메시지 형식"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "임시보관 메일의 메시지를 어느 범위까지 가져올지"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "임시보관 메일의 메시지를 어느 범위까지 가져올지입니다. 설정하지 않으면 전체 메시지가 반환됩니다."
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "전체"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "모든 헤더와 본문을 포함한 전체 메시지"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "모든 헤더와 MIME 본문 파트를 포함한 전체 메시지입니다. 첨부 파일 데이터는 포함되지 않으므로 `get-attachment`(으)로 가져와야 합니다."
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "메타데이터"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "메시지 ID, 라벨, 스니펫 및 헤더만"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "메시지 ID, 라벨, 스니펫 및 헤더만 포함하며 본문은 포함하지 않습니다."
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "최소"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "메시지 ID와 라벨만"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "메시지 ID와 라벨만 포함하며 헤더와 본문은 포함하지 않습니다."
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "원본"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "base64url로 인코딩된 MIME 데이터 형태의 전체 메시지"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "`raw`에 base64url로 인코딩된 MIME 데이터 형태로 담긴 전체 메시지입니다. 본문은 파싱되지 않습니다."
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "임시보관 메일 보내기"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "기존 임시보관 메일을 그대로 보냅니다"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "`id`(으)로 지정된 임시보관 메일을 그 안에 지정된 수신자에게 그대로 보냅니다. Gmail은 임시보관 메일을 삭제하고 보낸 메시지를 반환합니다. 무엇이 전송될지 확인하려면 먼저 `get-draft`을(를) 사용하세요."
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "임시보관 메일 ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "보낼 임시보관 메일의 ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "보낼 임시보관 메일의 ID입니다. `list-drafts`와 `create-draft`은(는) 이 값을 `id`(으)로 반환합니다."
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "임시보관 메일 삭제"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "임시보관 메일을 영구적으로 삭제합니다. 이 작업은 취소할 수 없습니다"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "임시보관 메일을 영구적으로 삭제합니다. **이 작업은 취소할 수 없습니다**: 임시보관 메일은 휴지통으로 이동하지 않으며 복사본도 남지 않습니다.\n\nGmail API는 이 호출에 대해 아무 내용도 반환하지 않습니다."
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "임시보관 메일 ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "영구적으로 삭제할 임시보관 메일의 ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "영구적으로 삭제할 임시보관 메일의 ID입니다. `list-drafts`와 `create-draft`은(는) 이 값을 `id`(으)로 반환합니다."
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/pl.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/pl.json
@@ -860,8 +860,8 @@
           "message": "Utwórz i wyślij nową wiadomość wychodzącą przez Gmail"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "Tworzy nową wiadomość wychodzącą na podstawie podanych adresów odbiorców, tematu, treści i załączników, a następnie przesyła ją przez Gmail."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "Tworzy nową wiadomość wychodzącą na podstawie podanych adresów odbiorców, tematu, treści i załączników, a następnie przesyła ją przez Gmail. Ustaw `thread_id` i `in_reply_to`, aby wysłać wiadomość jako odpowiedź w ramach istniejącej rozmowy"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "Adres nadawcy wiadomości e-mail"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "Identyfikator wątku"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "Identyfikator wątku Gmail, do którego ma zostać dodana wiadomość"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "Identyfikator wątku Gmail, do którego ma zostać dodana wiadomość; ustaw go, aby odpowiedzieć w ramach istniejącej rozmowy. Gmail uwzględnia go tylko wtedy, gdy `subject` odpowiada tematowi wątku, a `in_reply_to` (lub `references`) wskazuje wiadomość z tego wątku. Zdarzenia obserwatora przekazują tę wartość jako `threadId`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "W odpowiedzi na"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Wartość nagłówka Message-ID wiadomości, na którą udzielana jest odpowiedź"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Wartość nagłówka `Message-ID` wiadomości, na którą udzielana jest odpowiedź, wraz z nawiasami ostrymi; wysyłana jako nagłówek `In-Reply-To` oraz, o ile nie ustawiono `references`, także jako nagłówek `References`, dzięki czemu klienty poczty i Gmail umieszczają odpowiedź pod oryginalną wiadomością. Zdarzenia obserwatora przekazują tę wartość jako `Message-ID`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Odwołania"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Wartości nagłówków Message-ID rozmowy, na którą udzielana jest odpowiedź"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Wartość nagłówka `References`: wartości `Message-ID` wiadomości w rozmowie, na którą udzielana jest odpowiedź, od najstarszej, rozdzielone spacjami i wraz z nawiasami ostrymi. Jeśli nie zostanie ustawiona, używana jest wartość `in_reply_to`. Zdarzenia obserwatora przekazują nagłówek `References` oryginalnej wiadomości"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "Wyszukaj wiadomości z metadanymi"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "Wyszukaj wiadomości i zwróć każde dopasowanie wraz z jego nagłówkami"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "Wyszukuje wiadomości na koncie i zwraca każdą pasującą wiadomość wraz z jej metadanymi, zamiast samych identyfikatorów wiadomości i wątków zwracanych przez `list`. Każde dopasowanie jest pobierane osobno w żądanym `format`, więc strona z `maxResults` wiadomościami kosztuje `maxResults` + 1 żądań API; utrzymuj małą wartość `maxResults` i używaj `pageToken`, aby przechodzić do kolejnych stron"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Kryteria wyszukiwania"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "Kryteria wyszukiwania Gmail do pobierania wiadomości"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "Kryteria wyszukiwania Gmail do pobierania wiadomości; np.: `in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Maksymalna liczba wyników"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Maksymalna liczba wyników do zwrócenia"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "Maksymalna liczba wyników do zwrócenia; każda zwrócona wiadomość kosztuje jedno dodatkowe żądanie API"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Uwzględnić spam i kosz?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Czy uwzględnić foldery spam i kosz w wyszukiwaniu?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Czy uwzględnić foldery spam i kosz w wyszukiwaniu?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "Etykiety"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "Zwracaj tylko wiadomości z etykietami pasującymi do wszystkich podanych ID"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "Zwracaj tylko wiadomości z etykietami pasującymi do wszystkich podanych identyfikatorów etykiet. Wiadomości w wątku mogą mieć etykiety, których nie mają inne wiadomości w tym samym wątku"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token strony"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token strony służący do pobrania określonej strony wyników na liście"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token strony służący do pobrania określonej strony wyników na liście"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Format wiadomości"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Jaka część każdej pasującej wiadomości ma zostać pobrana"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Jaka część każdej pasującej wiadomości ma zostać pobrana"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadane"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "Tylko identyfikatory wiadomości, etykiety, fragment i żądane nagłówki"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "Tylko identyfikatory wiadomości, etykiety, fragment i nagłówki wymienione w `metadata_headers`; bez treści"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Pełny"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Cała wiadomość wraz ze wszystkimi nagłówkami i treścią"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Cała wiadomość wraz ze wszystkimi nagłówkami i częściami MIME treści; dane załączników nie są dołączane i należy je pobrać za pomocą `get-attachment`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "Nagłówki metadanych"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "Nagłówki wiadomości do pobrania dla każdej pasującej wiadomości"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "Nagłówki wiadomości do pobrania dla każdej pasującej wiadomości; ignorowane, o ile `format` nie ma wartości `metadata`"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "Przywróć wiadomość z kosza"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "Przenieś wiadomość z kosza z powrotem do skrzynki"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "Przenosi wiadomość wskazaną przez `id` z kosza Gmail z powrotem do skrzynki, cofając `trash-message`; wiadomości, którą Gmail już usunął z kosza, nie można przywrócić"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "Identyfikator wiadomości"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "Identyfikator wiadomości do przywrócenia z kosza"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "Identyfikator wiadomości do przywrócenia z kosza; zdarzenia obserwatora przekazują tę wartość jako `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "Zmień etykiety wiadomości"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "Dodaj etykiety do wiadomości i usuń je z niej"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "Jednym wywołaniem dodaje do wiadomości wskazanej przez `id` etykiety z `addLabelIds` i usuwa z niej etykiety z `removeLabelIds`. Etykiety systemowe Gmail zmienia się w ten sam sposób: usuń `UNREAD`, aby oznaczyć wiadomość jako przeczytaną, usuń `INBOX`, aby ją zarchiwizować, lub dodaj `STARRED`, aby ją oznaczyć gwiazdką. Użyj `list-labels`, aby znaleźć identyfikator etykiety, lub `create-label`, aby utworzyć nową"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "Identyfikator wiadomości"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "Identyfikator wiadomości, której etykiety mają zostać zmienione"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "Identyfikator wiadomości, której etykiety mają zostać zmienione; zdarzenia obserwatora przekazują tę wartość jako `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "Etykiety do dodania"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "Identyfikatory etykiet do dodania do wiadomości"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "Identyfikatory etykiet do dodania do wiadomości; etykieta jest identyfikowana przez swój identyfikator (np. `INBOX`, `STARRED`, `Label_12`), a nie przez nazwę"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "Etykiety do usunięcia"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "Identyfikatory etykiet do usunięcia z wiadomości"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "Identyfikatory etykiet do usunięcia z wiadomości; etykieta jest identyfikowana przez swój identyfikator (np. `INBOX`, `UNREAD`, `Label_12`), a nie przez nazwę"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "Wyświetl etykiety"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "Wyświetl wszystkie etykiety na koncie"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "Wyświetla wszystkie etykiety na koncie, zarówno etykiety systemowe Gmail (`INBOX`, `UNREAD`, `STARRED` itd.), jak i etykiety utworzone przez użytkownika, każdą z identyfikatorem przyjmowanym przez `modify-message-labels` oraz opcję wyszukiwania `labelIds`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "Utwórz etykietę"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "Utwórz nową etykietę użytkownika na koncie"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "Tworzy nową etykietę użytkownika na koncie i zwraca ją z identyfikatorem przyjmowanym przez `modify-message-labels`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "Nazwa etykiety"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "Wyświetlana nazwa etykiety"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "Wyświetlana nazwa etykiety; użyj `/`, aby zagnieździć etykietę pod inną, np. `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "Widoczność na liście etykiet"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "Czy etykieta jest wyświetlana na liście etykiet"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Czy etykieta jest wyświetlana na liście etykiet w interfejsie WWW Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "Pokaż"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "Pokazuj etykietę na liście etykiet"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "Pokaż, jeśli nieprzeczytane"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "Pokazuj etykietę na liście etykiet tylko wtedy, gdy zawiera nieprzeczytane wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "Ukryj"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "Nie pokazuj etykiety na liście etykiet"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "Widoczność na liście wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "Czy wiadomości z etykietą są wyświetlane na liście wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Czy wiadomości z etykietą są wyświetlane na liście wiadomości w interfejsie WWW Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "Pokaż"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "Pokazuj wiadomości z etykietą na liście wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "Ukryj"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "Nie pokazuj wiadomości z etykietą na liście wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "Utwórz wersję roboczą"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "Utwórz nową wersję roboczą wiadomości e-mail w Gmail bez jej wysyłania"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "Tworzy nową wersję roboczą wiadomości e-mail na podstawie podanych adresów odbiorców, tematu, treści i załączników i zapisuje ją w folderze wersji roboczych Gmail bez wysyłania, aby osoba mogła ją przejrzeć i wysłać lub aby `send-draft` mogła wysłać ją później. Ustaw `thread_id` i `in_reply_to`, aby przygotować odpowiedź w ramach istniejącej rozmowy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "Do"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "Adresy odbiorców wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "Jeden lub więcej adresów `To:` dla wiadomości e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "DW"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "Adresy DW (kopia do wiadomości)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "Jeden lub więcej adresów `Cc:` dla wiadomości e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "UDW"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "Adresy kopii ukrytej (BCC)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "Jeden lub więcej adresów `Bcc:` dla wiadomości e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "Temat"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "Temat wiadomości e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "Temat wiadomości e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "Treść wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "Treść wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "Treść wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "Załączniki"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "Załączniki wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "Wszelkie załączniki do wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "Dane dołącznika"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Dane, nazwa pliku i typ MIME załącznika"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Dane, nazwa pliku i typ MIME załącznika"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dane pliku"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dane pliku zakodowane w formacie Base64 lub dane surowe do zakodowania w formacie Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dane pliku zakodowane w formacie Base64 lub dane surowe do zakodowania w formacie Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Typ MIME"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Ciąg typu MIME pliku"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Ciąg typu MIME pliku"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Wykrywanie automatyczne"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Wykrywanie automatyczne na podstawie nazwy pliku; ważne tylko dla danych wejściowych"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Wykrywanie automatyczne na podstawie nazwy pliku; ważne tylko dla danych wejściowych"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Zwykły tekst"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Zwykły tekst"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Tekst HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Tekst HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Plik PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Plik PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Dokument MS Word docx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Dokument MS Word `docx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Dokument MS PowerPoint pptx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Dokument MS PowerPoint `pptx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Dokument MS Excel xlsx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Dokument MS Excel `xlsx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nazwa pliku"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Nazwa pliku"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Nazwa pliku"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "Kodowanie dołącznika"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Kodowanie do użycia dla załącznika"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Kodowanie do użycia dla załącznika:\n- `default`: `quoted-printable` dla danych tekstowych, `base64` dla danych binarnych\n- `none`: brak kodowania zawartości (niezalecane)\n- `quoted-printable`: kodowanie quoted printable \n- `base64`: kodowanie base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' dla danych tekstowych, 'base64' dla danych binarnych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` dla danych tekstowych, `base64` dla danych binarnych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Brak"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Brak kodowania zawartości (niezalecane)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Brak kodowania zawartości (niezalecane)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Idealne dla danych tekstowych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Idealne dla danych tekstowych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Idealne dla danych binarnych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Idealne dla danych binarnych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "Nagłówki"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Opcjonalne nagłówki do wysłania z załącznikiem"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Opcjonalne nagłówki do wysłania z załącznikiem"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "Kodowanie treści"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Kodowanie do użycia dla załącznika"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Kodowanie do użycia dla załącznika:\n- `default`: `quoted-printable` dla danych tekstowych, `base64` dla danych binarnych\n- `none`: brak kodowania zawartości (niezalecane)\n- `quoted-printable`: kodowanie quoted printable \n- `base64`: kodowanie base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' dla danych tekstowych, 'base64' dla danych binarnych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` dla danych tekstowych, `base64` dla danych binarnych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Brak"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Brak kodowania zawartości (niezalecane)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Brak kodowania zawartości (niezalecane)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Idealne dla danych tekstowych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Idealne dla danych tekstowych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Idealne dla danych binarnych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Idealne dla danych binarnych"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "Typ MIME treści"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "Typ MIME treści wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "Typ MIME treści wiadomości"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Zwykły tekst"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Zwykły tekst"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Tekst HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Tekst HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "Nadawca"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "Adres nadawcy wiadomości e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "Adres nadawcy wiadomości e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "Identyfikator wątku"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "Identyfikator wątku Gmail, do którego ma zostać dodana wiadomość"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "Identyfikator wątku Gmail, do którego ma zostać dodana wiadomość; ustaw go, aby odpowiedzieć w ramach istniejącej rozmowy. Gmail uwzględnia go tylko wtedy, gdy `subject` odpowiada tematowi wątku, a `in_reply_to` (lub `references`) wskazuje wiadomość z tego wątku. Zdarzenia obserwatora przekazują tę wartość jako `threadId`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "W odpowiedzi na"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Wartość nagłówka Message-ID wiadomości, na którą udzielana jest odpowiedź"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Wartość nagłówka `Message-ID` wiadomości, na którą udzielana jest odpowiedź, wraz z nawiasami ostrymi; wysyłana jako nagłówek `In-Reply-To` oraz, o ile nie ustawiono `references`, także jako nagłówek `References`, dzięki czemu klienty poczty i Gmail umieszczają odpowiedź pod oryginalną wiadomością. Zdarzenia obserwatora przekazują tę wartość jako `Message-ID`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Odwołania"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Wartości nagłówków Message-ID rozmowy, na którą udzielana jest odpowiedź"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Wartość nagłówka `References`: wartości `Message-ID` wiadomości w rozmowie, na którą udzielana jest odpowiedź, od najstarszej, rozdzielone spacjami i wraz z nawiasami ostrymi. Jeśli nie zostanie ustawiona, używana jest wartość `in_reply_to`. Zdarzenia obserwatora przekazują nagłówek `References` oryginalnej wiadomości"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "Wyszukaj wersje robocze"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "Wyszukaj wersje robocze"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "Wyszukuje wersje robocze na koncie; każda wersja robocza jest zwracana ze swoim identyfikatorem oraz identyfikatorem i identyfikatorem wątku wiadomości, którą zawiera. Użyj `get-draft`, aby pobrać zawartość wersji roboczej"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Kryteria wyszukiwania"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "Kryteria wyszukiwania Gmail do pobierania wersji roboczych"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "Kryteria wyszukiwania Gmail do pobierania wersji roboczych; np. `to:me@gmail.com subject:hello`; jeśli nie zostaną ustawione, zwracane są wszystkie wersje robocze"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Maksymalna liczba wyników"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Maksymalna liczba wyników do zwrócenia"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "Maksymalna liczba wyników do zwrócenia"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Uwzględnić spam i kosz?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Czy uwzględnić foldery spam i kosz w wyszukiwaniu?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Czy uwzględnić foldery spam i kosz w wyszukiwaniu?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token strony"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token strony służący do pobrania określonej strony wyników na liście"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token strony służący do pobrania określonej strony wyników na liście"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "Pobierz wersję roboczą"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "Pobierz wersję roboczą"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "Pobiera wersję roboczą i zawartą w niej wiadomość w żądanym `format`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Identyfikator wersji roboczej"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "Identyfikator wersji roboczej do pobrania"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "Identyfikator wersji roboczej do pobrania; `list-drafts` i `create-draft` zwracają tę wartość jako `id`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Format wiadomości"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "Jaka część wiadomości wersji roboczej ma zostać pobrana"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "Jaka część wiadomości wersji roboczej ma zostać pobrana; jeśli nie zostanie ustawiona, zwracana jest cała wiadomość"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Pełny"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Cała wiadomość wraz ze wszystkimi nagłówkami i treścią"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Cała wiadomość wraz ze wszystkimi nagłówkami i częściami MIME treści; dane załączników nie są dołączane i należy je pobrać za pomocą `get-attachment`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadane"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "Tylko identyfikatory wiadomości, etykiety, fragment i nagłówki"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "Tylko identyfikatory wiadomości, etykiety, fragment i nagłówki; bez treści"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "Minimalny"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "Tylko identyfikatory wiadomości i etykiety"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "Tylko identyfikatory wiadomości i etykiety; bez nagłówków i bez treści"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "Surowy"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "Cała wiadomość jako dane MIME zakodowane w base64url"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "Cała wiadomość jako dane MIME zakodowane w base64url w `raw`; treść nie jest analizowana"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "Wyślij wersję roboczą"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "Wyślij istniejącą wersję roboczą w niezmienionej postaci"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "Wysyła wersję roboczą wskazaną przez `id` w niezmienionej postaci do wskazanych w niej odbiorców; Gmail usuwa wersję roboczą i zwraca wysłaną wiadomość. Najpierw użyj `get-draft`, aby sprawdzić, co zostanie wysłane"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Identyfikator wersji roboczej"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "Identyfikator wersji roboczej do wysłania"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "Identyfikator wersji roboczej do wysłania; `list-drafts` i `create-draft` zwracają tę wartość jako `id`"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "Usuń wersję roboczą"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "Trwale usuń wersję roboczą; tej operacji nie można cofnąć"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "Trwale usuwa wersję roboczą. **Tej operacji nie można cofnąć**: wersja robocza nie trafia do kosza i nie pozostaje żadna kopia.\n\nInterfejs API Gmail nie zwraca żadnej treści dla tego wywołania"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Identyfikator wersji roboczej"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "Identyfikator wersji roboczej do trwałego usunięcia"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "Identyfikator wersji roboczej do trwałego usunięcia; `list-drafts` i `create-draft` zwracają tę wartość jako `id`"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/root.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/root.json
@@ -860,8 +860,8 @@
           "message": "Create and transmit a new outgoing email through Gmail"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "The sender's address for the email"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "Thread ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "The ID of the Gmail thread to add the message to"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "In Reply To"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "The Message-ID header value of the message being answered"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "References"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "The Message-ID header values of the conversation being answered"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "Search for Messages with Metadata"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "Search for messages and return each match with its headers"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Search Criteria"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "The gmail search criteria for retrieving the messages"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Max Results"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "The maximum number of results to return"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "The maximum number of results to return; each message returned costs one additional API request"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Include Spam and Trash?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Include the spam and trash folders in the search?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Include the spam and trash folders in the search?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "Labels"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "Only return messages with labels that match all of the specified label IDs"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Page Token"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Page token to retrieve a specific page of results in the list"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Page token to retrieve a specific page of results in the list"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Message Format"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "How much of each matching message to retrieve"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "How much of each matching message to retrieve"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadata"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "Message IDs, labels, snippet, and the requested headers only"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Full"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "The complete message including all headers and the body"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "Metadata Headers"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "The message headers to retrieve for each matching message"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "Restore a Message from the Trash"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "Move a message from the trash back into the mailbox"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "Message ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "The ID of the message to restore from the trash"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "The ID of the message to restore from the trash; watch events carry this value as `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "Change a Message's Labels"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "Add labels to and remove labels from a message"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "Message ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "The ID of the message to relabel"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "The ID of the message to relabel; watch events carry this value as `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "Labels to Add"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "The IDs of the labels to add to the message"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "Labels to Remove"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "The IDs of the labels to remove from the message"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "List Labels"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "List all labels in the account"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "Create a Label"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "Create a new user label in the account"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "Label Name"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "The display name of the label"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "Label List Visibility"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "Whether the label is shown in the label list"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Whether the label is shown in the label list of the Gmail web interface"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "Show"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "Show the label in the label list"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "Show If Unread"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "Show the label in the label list only while it has unread messages"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "Hide"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "Do not show the label in the label list"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "Message List Visibility"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "Whether messages with the label are shown in the message list"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Whether messages with the label are shown in the message list of the Gmail web interface"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "Show"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "Show messages with the label in the message list"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "Hide"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "Do not show messages with the label in the message list"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "Create a Draft"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "Create a new draft email in Gmail without sending it"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "To"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "Message recipient addresses"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "One or more `To:` addresses for the email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "CC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "Carbon copy addresses"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "One or more `Cc:` addresses for the email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "BCC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "Blind carbon copy addresses"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "One or more `Bcc:` addresses for the email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "Subject"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "The subject for the email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "The subject for the email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "Message Body"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "The message body"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "The message body"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "Attachments"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "Message attachments"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "Any attachments for the message"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "Attachment Data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "The data, file name, and MIME type for the attachment"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "The data, file name, and MIME type for the attachment"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "File Data"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-encoded file data or raw data to be encoded with base64 encoding"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-encoded file data or raw data to be encoded with base64 encoding"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME Type"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "The MIME type string for the file"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "The MIME type string for the file"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Autodetect"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Autodetect from the file name; valid only on input"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Autodetect from the file name; valid only on input"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Plain text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Plain text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF file"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF file"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Filename"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "The filename"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "The filename"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "Attachment Encoding"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "The encoding to use for the attachment"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' for string data, 'base64' for binary data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` for string data, `base64` for binary data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "None"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "No content encoding (not recommended)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "No content encoding (not recommended)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal for string data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal for string data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal for binary data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal for binary data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "Headers"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Optional headers to send with the attachment"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Optional headers to send with the attachment"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "Body Encoding"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "The encoding to use for the attachment"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' for string data, 'base64' for binary data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` for string data, `base64` for binary data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "None"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "No content encoding (not recommended)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "No content encoding (not recommended)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal for string data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideal for string data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal for binary data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideal for binary data"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "Body Mime Type"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "The MIME type of the message body"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "The MIME type of the message body"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Plain text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Plain text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "Sender"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "The sender's address for the email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "The sender's address for the email"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "Thread ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "The ID of the Gmail thread to add the message to"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "In Reply To"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "The Message-ID header value of the message being answered"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "References"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "The Message-ID header values of the conversation being answered"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "Search for Drafts"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "Search for drafts"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Search Criteria"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "The gmail search criteria for retrieving the drafts"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Max Results"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "The maximum number of results to return"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "The maximum number of results to return"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Include Spam and Trash?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Include the spam and trash folders in the search?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Include the spam and trash folders in the search?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Page Token"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Page token to retrieve a specific page of results in the list"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Page token to retrieve a specific page of results in the list"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "Retrieve a Draft"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "Retrieve a draft"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "Retrieves a draft and the message it holds in the requested `format`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Draft ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "The ID of the draft to retrieve"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Message Format"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "How much of the draft's message to retrieve"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "How much of the draft's message to retrieve; if not set, the complete message is returned"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Full"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "The complete message including all headers and the body"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadata"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "Message IDs, labels, snippet, and headers only"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "Message IDs, labels, snippet, and headers only; no body"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "Minimal"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "Message IDs and labels only"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "Message IDs and labels only; no headers and no body"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "Raw"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "The complete message as base64url-encoded MIME data"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "Send a Draft"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "Send an existing draft as it is"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Draft ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "The ID of the draft to send"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "Delete a Draft"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "Permanently delete a draft; this cannot be undone"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Draft ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "The ID of the draft to delete permanently"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/sk.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/sk.json
@@ -860,8 +860,8 @@
           "message": "Vytvoriť a odoslať nový odchádzajúci e-mail cez Gmail"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "Vytvorí nový odchádzajúci e-mail zo zadaných adries príjemcov, predmetu, tela a príloh a odošle ho cez Gmail."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "Vytvorí nový odchádzajúci e-mail zo zadaných adries príjemcov, predmetu, tela a príloh a odošle ho cez Gmail. Nastavením `thread_id` a `in_reply_to` odošlete e-mail ako odpoveď v rámci existujúcej konverzácie"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "Adresa odosielateľa e-mailu"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID vlákna"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "ID vlákna Gmailu, do ktorého sa má správa pridať"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "ID vlákna Gmailu, do ktorého sa má správa pridať; nastavte túto hodnotu, ak chcete odpovedať v rámci existujúcej konverzácie. Gmail ju rešpektuje len vtedy, keď `subject` zodpovedá predmetu vlákna a `in_reply_to` (alebo `references`) uvádza správu z tohto vlákna. Udalosti sledovania nesú túto hodnotu ako `threadId`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "Odpoveď na"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Hodnota hlavičky Message-ID správy, na ktorú sa odpovedá"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Hodnota hlavičky `Message-ID` správy, na ktorú sa odpovedá, vrátane lomených zátvoriek; odosiela sa ako hlavička `In-Reply-To` a, ak nie je nastavené `references`, aj ako hlavička `References`, aby poštoví klienti aj Gmail zaradili odpoveď pod pôvodnú správu. Udalosti sledovania nesú túto hodnotu ako `Message-ID`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Referencie"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Hodnoty hlavičiek Message-ID konverzácie, na ktorú sa odpovedá"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Hodnota hlavičky `References`: hodnoty `Message-ID` správ v konverzácii, na ktorú sa odpovedá, od najstaršej, oddelené medzerami a vrátane lomených zátvoriek. Ak nie je nastavená, použije sa `in_reply_to`. Udalosti sledovania nesú hlavičku `References` pôvodnej správy"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "Vyhľadať správy s metadátami"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "Vyhľadať správy a vrátiť každú nájdenú správu s jej hlavičkami"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "Vyhľadá správy v účte a vráti každú zodpovedajúcu správu s jej metadátami namiesto samotných ID správ a vlákien, ktoré vracia `list`. Každá nájdená správa sa načítava samostatne v požadovanom `format`, takže stránka s `maxResults` správami stojí `maxResults` + 1 požiadaviek na API; udržiavajte `maxResults` malé a na prechádzanie ďalších stránok použite `pageToken`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Kritériá vyhľadávania"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "Vyhľadávacie kritériá Gmailu na načítanie správ"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "Vyhľadávacie kritériá Gmailu na načítanie správ; napr.: `in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Maximálny počet výsledkov"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Maximálny počet výsledkov, ktoré sa majú vrátiť"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "Maximálny počet výsledkov, ktoré sa majú vrátiť; každá vrátená správa stojí jednu ďalšiu požiadavku na API"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Zahrnúť spam a kôš?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Zahrnúť do vyhľadávania priečinky spam a kôš?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Zahrnúť do vyhľadávania priečinky spam a kôš?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "Štítky"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "Vrátiť iba správy so štítkami, ktoré zodpovedajú všetkým zadaným ID štítkov"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "Vrátiť iba správy so štítkami, ktoré zodpovedajú všetkým zadaným ID štítkov. Správy vo vlákne môžu mať štítky, ktoré iné správy v tom istom vlákne nemajú"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token stránky"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token stránky na načítanie konkrétnej stránky výsledkov v zozname"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token stránky na načítanie konkrétnej stránky výsledkov v zozname"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Formát správy"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Koľko z každej zodpovedajúcej správy sa má načítať"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Koľko z každej zodpovedajúcej správy sa má načítať"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadáta"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "Iba ID správ, štítky, úryvok a požadované hlavičky"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "Iba ID správ, štítky, úryvok a hlavičky uvedené v `metadata_headers`; bez tela"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Úplný"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Celá správa vrátane všetkých hlavičiek a tela"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Celá správa vrátane všetkých hlavičiek a častí tela MIME; údaje príloh nie sú zahrnuté a je potrebné ich načítať pomocou `get-attachment`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "Hlavičky metadát"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "Hlavičky správy, ktoré sa majú načítať pre každú zodpovedajúcu správu"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "Hlavičky správy, ktoré sa majú načítať pre každú zodpovedajúcu správu; ignoruje sa, ak `format` nie je `metadata`"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "Obnoviť správu z koša"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "Presunúť správu z koša späť do schránky"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "Presunie správu identifikovanú pomocou `id` z koša Gmailu späť do schránky, čím vráti späť akciu `trash-message`; správu, ktorú Gmail už z koša odstránil, nie je možné obnoviť"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID správy"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "ID správy, ktorá sa má obnoviť z koša"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "ID správy, ktorá sa má obnoviť z koša; udalosti sledovania nesú túto hodnotu ako `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "Zmeniť štítky správy"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "Pridať štítky k správe a odobrať ich z nej"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "Jedným volaním pridá k správe identifikovanej pomocou `id` štítky uvedené v `addLabelIds` a odoberie z nej štítky uvedené v `removeLabelIds`. Systémové štítky Gmailu sa menia rovnakým spôsobom: odoberte `UNREAD`, ak chcete správu označiť ako prečítanú, odoberte `INBOX`, ak ju chcete archivovať, alebo pridajte `STARRED`, ak ju chcete označiť hviezdičkou. Pomocou `list-labels` zistíte ID štítku a pomocou `create-label` vytvoríte nový"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "ID správy"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "ID správy, ktorej štítky sa majú zmeniť"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "ID správy, ktorej štítky sa majú zmeniť; udalosti sledovania nesú túto hodnotu ako `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "Štítky na pridanie"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "ID štítkov, ktoré sa majú k správe pridať"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "ID štítkov, ktoré sa majú k správe pridať; štítok je identifikovaný svojím ID (napr. `INBOX`, `STARRED`, `Label_12`), nie názvom"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "Štítky na odobratie"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "ID štítkov, ktoré sa majú zo správy odobrať"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "ID štítkov, ktoré sa majú zo správy odobrať; štítok je identifikovaný svojím ID (napr. `INBOX`, `UNREAD`, `Label_12`), nie názvom"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "Vypísať štítky"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "Vypísať všetky štítky v účte"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "Vypíše všetky štítky v účte, systémové štítky Gmailu (`INBOX`, `UNREAD`, `STARRED` a ďalšie) aj štítky vytvorené používateľom, každý s ID, ktoré prijímajú `modify-message-labels` a možnosť vyhľadávania `labelIds`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "Vytvoriť štítok"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "Vytvoriť v účte nový používateľský štítok"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "Vytvorí v účte nový používateľský štítok a vráti ho s ID, ktoré prijíma `modify-message-labels`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "Názov štítku"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "Zobrazovaný názov štítku"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "Zobrazovaný názov štítku; pomocou `/` je možné štítok vnoriť pod iný, napr. `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "Viditeľnosť v zozname štítkov"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "Či sa štítok zobrazuje v zozname štítkov"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Či sa štítok zobrazuje v zozname štítkov webového rozhrania Gmailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "Zobraziť"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "Zobraziť štítok v zozname štítkov"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "Zobraziť, ak je neprečítané"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "Zobraziť štítok v zozname štítkov len vtedy, keď obsahuje neprečítané správy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "Skryť"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "Nezobrazovať štítok v zozname štítkov"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "Viditeľnosť v zozname správ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "Či sa správy s týmto štítkom zobrazujú v zozname správ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Či sa správy s týmto štítkom zobrazujú v zozname správ webového rozhrania Gmailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "Zobraziť"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "Zobraziť správy s týmto štítkom v zozname správ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "Skryť"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "Nezobrazovať správy s týmto štítkom v zozname správ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "Vytvoriť koncept"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "Vytvoriť v Gmaile nový koncept e-mailu bez jeho odoslania"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "Vytvorí nový koncept e-mailu zo zadaných adries príjemcov, predmetu, tela a príloh a uloží ho do priečinka konceptov Gmailu bez odoslania, aby ho mohol skontrolovať a odoslať človek alebo aby ho mohla neskôr odoslať akcia `send-draft`. Nastavením `thread_id` a `in_reply_to` pripravíte odpoveď v rámci existujúcej konverzácie"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "Komu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "Adresy príjemcov správy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "Jedna alebo viacero adries `To:` pre e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "Kópia"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "Adresy kópie (Cc)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "Jedna alebo viacero adries `Cc:` pre e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "Skrytá kópia"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "Adresy skrytej kópie"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "Jedna alebo viacero adries `Bcc:` pre e-mail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "Predmet"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "Predmet e-mailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "Predmet e-mailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "Telo správy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "Telo správy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "Telo správy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "Prílohy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "Prílohy správy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "Akékoľvek prílohy správy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "Dáta prílohy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Dáta, názov súboru a MIME typ prílohy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Dáta, názov súboru a MIME typ prílohy"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dáta súboru"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dáta súboru zakódované v Base64 alebo nezakódované dáta, ktoré sa majú zakódovať pomocou Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dáta súboru zakódované v Base64 alebo nezakódované dáta, ktoré sa majú zakódovať pomocou Base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Typ MIME"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Reťazec MIME typu súboru"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Reťazec MIME typu súboru"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Automatické detekovanie"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické detekovanie z názvu súboru; platné iba pri vstupe"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické detekovanie z názvu súboru; platné iba pri vstupe"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Obyčajný text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Obyčajný text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF súbor"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF súbor"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Dokument MS Word docx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Dokument MS Word `docx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Dokument MS PowerPoint pptx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Dokument MS PowerPoint `pptx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Dokument MS Excel xlsx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Dokument MS Excel `xlsx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Názov súboru"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Názov súboru"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Názov súboru"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "Kódovanie prílohy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Kódovanie použité pre prílohu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Kódovanie použité pre prílohu:\n- `default`: `quoted-printable` pre reťazcové dáta, `base64` pre binárne dáta\n- `none`: žiadne kódovanie obsahu (neodporúča sa)\n- `quoted-printable`: kódovanie quoted printable \n- `base64`: kódovanie base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' pre reťazcové dáta, 'base64' pre binárne dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` pre reťazcové dáta, `base64` pre binárne dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Žiadne"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Bez kódovania obsahu (neodporúča sa)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Bez kódovania obsahu (neodporúča sa)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideálne pre reťazcové dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideálne pre reťazcové dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideálne pre binárne dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideálne pre binárne dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "Hlavičky"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Voliteľné hlavičky, ktoré sa pošlú s prílohou"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Voliteľné hlavičky, ktoré sa pošlú s prílohou"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "Kódovanie tela"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Kódovanie použité pre prílohu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Kódovanie použité pre prílohu:\n- `default`: `quoted-printable` pre reťazcové dáta, `base64` pre binárne dáta\n- `none`: žiadne kódovanie obsahu (neodporúča sa)\n- `quoted-printable`: kódovanie quoted printable \n- `base64`: kódovanie base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Auto"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' pre reťazcové dáta, 'base64' pre binárne dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` pre reťazcové dáta, `base64` pre binárne dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Žiadne"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Bez kódovania obsahu (neodporúča sa)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Bez kódovania obsahu (neodporúča sa)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ideálne pre reťazcové dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ideálne pre reťazcové dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideálne pre binárne dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ideálne pre binárne dáta"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "Typ MIME tela"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "Typ MIME tela správy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "Typ MIME tela správy"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Obyčajný text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Obyčajný text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "Odosielateľ"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "Adresa odosielateľa e-mailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "Adresa odosielateľa e-mailu"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "ID vlákna"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "ID vlákna Gmailu, do ktorého sa má správa pridať"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "ID vlákna Gmailu, do ktorého sa má správa pridať; nastavte túto hodnotu, ak chcete odpovedať v rámci existujúcej konverzácie. Gmail ju rešpektuje len vtedy, keď `subject` zodpovedá predmetu vlákna a `in_reply_to` (alebo `references`) uvádza správu z tohto vlákna. Udalosti sledovania nesú túto hodnotu ako `threadId`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "Odpoveď na"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Hodnota hlavičky Message-ID správy, na ktorú sa odpovedá"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Hodnota hlavičky `Message-ID` správy, na ktorú sa odpovedá, vrátane lomených zátvoriek; odosiela sa ako hlavička `In-Reply-To` a, ak nie je nastavené `references`, aj ako hlavička `References`, aby poštoví klienti aj Gmail zaradili odpoveď pod pôvodnú správu. Udalosti sledovania nesú túto hodnotu ako `Message-ID`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Referencie"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Hodnoty hlavičiek Message-ID konverzácie, na ktorú sa odpovedá"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Hodnota hlavičky `References`: hodnoty `Message-ID` správ v konverzácii, na ktorú sa odpovedá, od najstaršej, oddelené medzerami a vrátane lomených zátvoriek. Ak nie je nastavená, použije sa `in_reply_to`. Udalosti sledovania nesú hlavičku `References` pôvodnej správy"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "Vyhľadať koncepty"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "Vyhľadať koncepty"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "Vyhľadá koncepty v účte; každý koncept sa vracia so svojím ID a s ID a ID vlákna správy, ktorú obsahuje. Obsah konceptu načítate pomocou `get-draft`"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Kritériá vyhľadávania"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "Kritériá vyhľadávania Gmailu na načítanie konceptov"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "Kritériá vyhľadávania Gmailu na načítanie konceptov; napr. `to:me@gmail.com subject:hello`; ak nie sú nastavené, vrátia sa všetky koncepty"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Maximálny počet výsledkov"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Maximálny počet výsledkov, ktoré sa majú vrátiť"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "Maximálny počet výsledkov, ktoré sa majú vrátiť"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Zahrnúť spam a kôš?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Zahrnúť do vyhľadávania priečinky spam a kôš?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Zahrnúť do vyhľadávania priečinky spam a kôš?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token stránky"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token stránky na načítanie konkrétnej stránky výsledkov v zozname"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Token stránky na načítanie konkrétnej stránky výsledkov v zozname"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "Získať koncept"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "Získať koncept"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "Načíta koncept a správu, ktorú obsahuje, v požadovanom `format`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID konceptu"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "ID konceptu, ktorý sa má načítať"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "ID konceptu, ktorý sa má načítať; `list-drafts` a `create-draft` vracajú túto hodnotu ako `id`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Formát správy"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "Koľko zo správy konceptu sa má načítať"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "Koľko zo správy konceptu sa má načítať; ak nie je nastavené, vráti sa celá správa"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Úplný"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Celá správa vrátane všetkých hlavičiek a tela"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Celá správa vrátane všetkých hlavičiek a častí tela MIME; údaje príloh nie sú zahrnuté a je potrebné ich načítať pomocou `get-attachment`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Metadáta"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "Iba ID správ, štítky, úryvok a hlavičky"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "Iba ID správ, štítky, úryvok a hlavičky; bez tela"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "Minimálny"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "Iba ID správ a štítky"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "Iba ID správ a štítky; bez hlavičiek a bez tela"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "Nespracovaný"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "Celá správa ako údaje MIME kódované pomocou base64url"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "Celá správa ako údaje MIME kódované pomocou base64url v `raw`; telo sa neparsuje"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "Odoslať koncept"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "Odoslať existujúci koncept tak, ako je"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "Odošle koncept identifikovaný pomocou `id` tak, ako je, príjemcom, ktorých uvádza; Gmail koncept odstráni a vráti odoslanú správu. Najprv pomocou `get-draft` skontrolujte, čo sa odošle"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID konceptu"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "ID konceptu, ktorý sa má odoslať"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "ID konceptu, ktorý sa má odoslať; `list-drafts` a `create-draft` vracajú túto hodnotu ako `id`"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "Vymazať koncept"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "Natrvalo vymazať koncept; túto akciu nie je možné vrátiť späť"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "Natrvalo vymaže koncept. **Túto akciu nie je možné vrátiť späť**: koncept sa nepresunie do koša a nezostane žiadna kópia.\n\nGmail API pre toto volanie nevracia žiadny obsah"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "ID konceptu"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "ID konceptu, ktorý sa má natrvalo vymazať"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "ID konceptu, ktorý sa má natrvalo vymazať; `list-drafts` a `create-draft` vracajú túto hodnotu ako `id`"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/uk.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/uk.json
@@ -860,8 +860,8 @@
           "message": "Створити та надіслати новий вихідний електронний лист через Gmail"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "Створює новий вихідний електронний лист із наданих адрес одержувачів, теми, тіла та вкладень і надсилає його через Gmail."
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "Створює новий вихідний електронний лист із наданих адрес одержувачів, теми, тіла та вкладень і надсилає його через Gmail. Задайте `thread_id` і `in_reply_to`, щоб надіслати лист як відповідь у межах наявної розмови"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "Адреса відправника електронного листа"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "Ідентифікатор гілки"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "Ідентифікатор гілки Gmail, до якої потрібно додати повідомлення"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "Ідентифікатор гілки Gmail, до якої потрібно додати повідомлення; задайте його, щоб відповісти в межах наявної розмови. Gmail враховує його лише тоді, коли `subject` збігається з темою гілки, а `in_reply_to` (або `references`) вказує на повідомлення з цієї гілки. Події спостереження містять це значення як `threadId`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "У відповідь на"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Значення заголовка Message-ID повідомлення, на яке надається відповідь"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Значення заголовка `Message-ID` повідомлення, на яке надається відповідь, разом із кутовими дужками; надсилається як заголовок `In-Reply-To` і, якщо не задано `references`, також як заголовок `References`, щоб поштові клієнти та Gmail розміщували відповідь під вихідним повідомленням. Події спостереження містять це значення як `Message-ID`"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Посилання"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Значення заголовків Message-ID розмови, на яку надається відповідь"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Значення заголовка `References`: значення `Message-ID` повідомлень у розмові, на яку надається відповідь, від найстарішого, розділені пробілами та разом із кутовими дужками. Якщо не задано, використовується `in_reply_to`. Події спостереження містять заголовок `References` вихідного повідомлення"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "Пошук повідомлень із метаданими"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "Знайти повідомлення та повернути кожен збіг разом із його заголовками"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "Шукає повідомлення в обліковому записі та повертає кожне відповідне повідомлення разом із його метаданими замість самих лише ідентифікаторів повідомлень і гілок, які повертає `list`. Кожен збіг отримується окремо в запитаному `format`, тому сторінка з `maxResults` повідомлень коштує `maxResults` + 1 запитів до API; тримайте `maxResults` невеликим і використовуйте `pageToken` для переходу до наступних сторінок"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Критерії пошуку"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "Критерії пошуку gmail для отримання повідомлень"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "Критерії пошуку gmail для отримання повідомлень; наприклад: `in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Макс. результатів"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Максимальна кількість результатів для повернення"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "Максимальна кількість результатів для повернення; кожне повернуте повідомлення коштує один додатковий запит до API"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Включати спам і кошик?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Включати папки спаму та кошика в пошук?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Включати папки спаму та кошика в пошук?"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "Мітки"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "Повертати лише повідомлення з мітками, що відповідають усім вказаним ID міток"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "Повертати лише повідомлення з мітками, які відповідають усім указаним ідентифікаторам міток. Повідомлення в ланцюжку можуть мати мітки, яких немає в інших повідомленнях того самого ланцюжка"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Токен сторінки"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Токен сторінки для отримання певної сторінки результатів у списку"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Токен сторінки для отримання певної сторінки результатів у списку"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Формат повідомлення"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Яку частину кожного відповідного повідомлення отримувати"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "Яку частину кожного відповідного повідомлення отримувати"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Метадані"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "Лише ідентифікатори повідомлень, мітки, фрагмент і запитані заголовки"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "Лише ідентифікатори повідомлень, мітки, фрагмент і заголовки, зазначені в `metadata_headers`; без тіла"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Повний"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Повне повідомлення з усіма заголовками та тілом"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Повне повідомлення з усіма заголовками та частинами тіла MIME; дані вкладень не включаються, їх потрібно отримати за допомогою `get-attachment`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "Заголовки метаданих"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "Заголовки повідомлення, які потрібно отримати для кожного відповідного повідомлення"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "Заголовки повідомлення, які потрібно отримати для кожного відповідного повідомлення; ігнорується, якщо `format` не дорівнює `metadata`"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "Відновити повідомлення з кошика"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "Перемістити повідомлення з кошика назад до поштової скриньки"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "Переміщує повідомлення, визначене `id`, з кошика Gmail назад до поштової скриньки, скасовуючи `trash-message`; повідомлення, яке Gmail уже остаточно видалив із кошика, відновити неможливо"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "Ідентифікатор повідомлення"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "Ідентифікатор повідомлення, яке потрібно відновити з кошика"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "Ідентифікатор повідомлення, яке потрібно відновити з кошика; події спостереження містять це значення як `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "Змінити мітки повідомлення"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "Додати мітки до повідомлення та видалити їх із нього"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "Одним викликом додає мітки з `addLabelIds` до повідомлення, визначеного `id`, і видаляє з нього мітки з `removeLabelIds`. Системні мітки Gmail змінюються так само: видаліть `UNREAD`, щоб позначити повідомлення як прочитане, видаліть `INBOX`, щоб архівувати його, або додайте `STARRED`, щоб позначити його зірочкою. Використовуйте `list-labels`, щоб знайти ідентифікатор мітки, або `create-label`, щоб створити нову"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "Ідентифікатор повідомлення"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "Ідентифікатор повідомлення, мітки якого потрібно змінити"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "Ідентифікатор повідомлення, мітки якого потрібно змінити; події спостереження містять це значення як `message_id`"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "Мітки для додавання"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "Ідентифікатори міток, які потрібно додати до повідомлення"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "Ідентифікатори міток, які потрібно додати до повідомлення; мітка визначається за її ідентифікатором (напр. `INBOX`, `STARRED`, `Label_12`), а не за назвою"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "Мітки для видалення"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "Ідентифікатори міток, які потрібно видалити з повідомлення"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "Ідентифікатори міток, які потрібно видалити з повідомлення; мітка визначається за її ідентифікатором (напр. `INBOX`, `UNREAD`, `Label_12`), а не за назвою"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "Список міток"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "Перелічити всі мітки в обліковому записі"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "Перелічує всі мітки в обліковому записі — як системні мітки Gmail (`INBOX`, `UNREAD`, `STARRED` тощо), так і створені користувачем, кожну з ідентифікатором, який приймають `modify-message-labels` і параметр пошуку `labelIds`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "Створити мітку"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "Створити нову користувацьку мітку в обліковому записі"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "Створює нову користувацьку мітку в обліковому записі та повертає її з ідентифікатором, який приймає `modify-message-labels`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "Назва мітки"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "Відображувана назва мітки"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "Відображувана назва мітки; використовуйте `/`, щоб вкласти мітку в іншу, напр. `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "Видимість у списку міток"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "Чи показувати мітку в списку міток"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "Чи показувати мітку в списку міток вебінтерфейсу Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "Показувати"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "Показувати мітку в списку міток"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "Показувати, якщо є непрочитані"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "Показувати мітку в списку міток лише тоді, коли в ній є непрочитані повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "Приховати"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "Не показувати мітку в списку міток"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "Видимість у списку повідомлень"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "Чи показувати повідомлення з цією міткою в списку повідомлень"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "Чи показувати повідомлення з цією міткою в списку повідомлень вебінтерфейсу Gmail"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "Показувати"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "Показувати повідомлення з цією міткою в списку повідомлень"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "Приховати"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "Не показувати повідомлення з цією міткою в списку повідомлень"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "Створити чернетку"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "Створити нову чернетку електронного листа в Gmail без надсилання"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "Створює нову чернетку електронного листа з наданих адрес одержувачів, теми, тіла та вкладень і зберігає її в папці чернеток Gmail без надсилання, щоб людина могла переглянути та надіслати її або щоб `send-draft` міг надіслати її пізніше. Задайте `thread_id` і `in_reply_to`, щоб підготувати відповідь у межах наявної розмови"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "Кому"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "Адреси одержувачів повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "Одна або кілька адрес `To:` для електронного листа"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "CC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "Адреси для копії"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "Одна або кілька адрес `Cc:` для електронного листа"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "BCC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "Адреси прихованої копії"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "Одна або кілька адрес `Bcc:` для електронного листа"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "Тема"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "Тема електронного листа"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "Тема електронного листа"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "Тіло повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "Тіло повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "Тіло повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "Вкладення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "Вкладення повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "Будь-які вкладення для повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "Дані вкладення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Дані, ім’я файлу та MIME-тип для вкладення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "Дані, ім’я файлу та MIME-тип для вкладення"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Дані файлу"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Дані файлу у форматі base64 або сирові дані, що кодуються за допомогою base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Дані файлу у форматі base64 або сирові дані, що кодуються за допомогою base64"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME-тип"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Строка MIME-типу файлу"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Строка MIME-типу файлу"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Автоматичне визначення"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Автоматичне визначення за назвою файлу; дійсно лише для вхідних даних"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Автоматичне визначення за назвою файлу; дійсно лише для вхідних даних"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Звичайний текст"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Звичайний текст"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Текст HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Текст HTML"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Файл PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Файл PDF"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Документ MS Word docx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Документ MS Word `docx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Документ MS PowerPoint pptx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Документ MS PowerPoint `pptx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Документ MS Excel xlsx"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Документ MS Excel `xlsx`"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Назва файлу"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Ім’я файлу"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Ім’я файлу"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "Кодування вкладення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Кодування для вкладення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Кодування для вкладення:\n- `default`: `quoted-printable` для рядкових даних, `base64` для двійкових даних\n- `none`: без кодування вмісту (не рекомендовано)\n- `quoted-printable`: кодування quoted printable \n- `base64`: кодування base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Авто"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' для рядкових даних, 'base64' для двійкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` для рядкових даних, `base64` для двійкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Немає"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Без кодування вмісту (не рекомендовано)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Без кодування вмісту (не рекомендовано)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ідеально для рядкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ідеально для рядкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ідеально для двійкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ідеально для двійкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "Заголовки"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Додаткові заголовки, які відправляються разом із вкладенням"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "Додаткові заголовки, які відправляються разом із вкладенням"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "Кодування тіла"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "Кодування для вкладення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "Кодування для вкладення:\n- `default`: `quoted-printable` для рядкових даних, `base64` для двійкових даних\n- `none`: без кодування вмісту (не рекомендовано)\n- `quoted-printable`: кодування quoted printable \n- `base64`: кодування base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "Авто"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "'quoted-printable' для рядкових даних, 'base64' для двійкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "`quoted-printable` для рядкових даних, `base64` для двійкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "Немає"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Без кодування вмісту (не рекомендовано)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "Без кодування вмісту (не рекомендовано)"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "Ідеально для рядкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "Ідеально для рядкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "Ідеально для двійкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "Ідеально для двійкових даних"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "MIME-тип тіла"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "MIME-тип тіла повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "MIME-тип тіла повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Звичайний текст"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Звичайний текст"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Текст HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Текст HTML"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "Відправник"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "Адреса відправника електронного листа"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "Адреса відправника електронного листа"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "Ідентифікатор гілки"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "Ідентифікатор гілки Gmail, до якої потрібно додати повідомлення"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "Ідентифікатор гілки Gmail, до якої потрібно додати повідомлення; задайте його, щоб відповісти в межах наявної розмови. Gmail враховує його лише тоді, коли `subject` збігається з темою гілки, а `in_reply_to` (або `references`) вказує на повідомлення з цієї гілки. Події спостереження містять це значення як `threadId`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "У відповідь на"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "Значення заголовка Message-ID повідомлення, на яке надається відповідь"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "Значення заголовка `Message-ID` повідомлення, на яке надається відповідь, разом із кутовими дужками; надсилається як заголовок `In-Reply-To` і, якщо не задано `references`, також як заголовок `References`, щоб поштові клієнти та Gmail розміщували відповідь під вихідним повідомленням. Події спостереження містять це значення як `Message-ID`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "Посилання"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "Значення заголовків Message-ID розмови, на яку надається відповідь"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "Значення заголовка `References`: значення `Message-ID` повідомлень у розмові, на яку надається відповідь, від найстарішого, розділені пробілами та разом із кутовими дужками. Якщо не задано, використовується `in_reply_to`. Події спостереження містять заголовок `References` вихідного повідомлення"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "Пошук чернеток"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "Знайти чернетки"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "Шукає чернетки в обліковому записі; кожна чернетка повертається зі своїм ідентифікатором, а також ідентифікатором та ідентифікатором гілки повідомлення, яке вона містить. Використовуйте `get-draft`, щоб отримати вміст чернетки"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "Критерії пошуку"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "Критерії пошуку Gmail для отримання чернеток"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "Критерії пошуку Gmail для отримання чернеток; напр. `to:me@gmail.com subject:hello`; якщо не задано, повертаються всі чернетки"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "Макс. результатів"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "Максимальна кількість результатів для повернення"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "Максимальна кількість результатів для повернення"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "Включати спам і кошик?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Включати папки спаму та кошика в пошук?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "Включати папки спаму та кошика в пошук?"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Токен сторінки"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Токен сторінки для отримання певної сторінки результатів у списку"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "Токен сторінки для отримання певної сторінки результатів у списку"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "Отримати чернетку"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "Отримати чернетку"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "Отримує чернетку та повідомлення, яке вона містить, у запитаному `format`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Ідентифікатор чернетки"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "Ідентифікатор чернетки, яку потрібно отримати"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "Ідентифікатор чернетки, яку потрібно отримати; `list-drafts` і `create-draft` повертають це значення як `id`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "Формат повідомлення"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "Яку частину повідомлення чернетки отримувати"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "Яку частину повідомлення чернетки отримувати; якщо не задано, повертається повне повідомлення"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "Повний"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "Повне повідомлення з усіма заголовками та тілом"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "Повне повідомлення з усіма заголовками та частинами тіла MIME; дані вкладень не включаються, їх потрібно отримати за допомогою `get-attachment`"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "Метадані"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "Лише ідентифікатори повідомлень, мітки, фрагмент і заголовки"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "Лише ідентифікатори повідомлень, мітки, фрагмент і заголовки; без тіла"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "Мінімальний"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "Лише ідентифікатори повідомлень і мітки"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "Лише ідентифікатори повідомлень і мітки; без заголовків і без тіла"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "Необроблений"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "Повне повідомлення у вигляді даних MIME, закодованих у base64url"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "Повне повідомлення у вигляді даних MIME, закодованих у base64url, у `raw`; тіло не розбирається"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "Надіслати чернетку"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "Надіслати наявну чернетку як є"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "Надсилає чернетку, визначену `id`, як є одержувачам, яких вона вказує; Gmail видаляє чернетку та повертає надіслане повідомлення. Спочатку використовуйте `get-draft`, щоб перевірити, що буде надіслано"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Ідентифікатор чернетки"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "Ідентифікатор чернетки, яку потрібно надіслати"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "Ідентифікатор чернетки, яку потрібно надіслати; `list-drafts` і `create-draft` повертають це значення як `id`"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "Видалити чернетку"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "Остаточно видалити чернетку; цю дію не можна скасувати"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "Остаточно видаляє чернетку. **Цю дію не можна скасувати**: чернетка не потрапляє в кошик і копій не залишається.\n\nGmail API не повертає вмісту для цього виклику"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "Ідентифікатор чернетки"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "Ідентифікатор чернетки, яку потрібно остаточно видалити"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "Ідентифікатор чернетки, яку потрібно остаточно видалити; `list-drafts` і `create-draft` повертають це значення як `id`"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/zh-Hant.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/zh-Hant.json
@@ -860,8 +860,8 @@
           "message": "透過 Gmail 建立並傳送新的外發電子郵件"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "根據提供的收件者地址、主旨、本文和附件建立新的外發電子郵件，並透過 Gmail 傳送該新郵件。"
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "根據提供的收件者地址、主旨、本文和附件建立新的外發電子郵件，並透過 Gmail 傳送該新郵件。設定 `thread_id` 與 `in_reply_to` 即可將該郵件作為現有對話中的回覆傳送"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "電子郵件的寄件者位址"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "對話群組 ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "要將郵件加入的 Gmail 對話群組 ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "要將郵件加入的 Gmail 對話群組 ID；設定此值即可在現有的對話中回覆。只有當 `subject` 與對話群組的主旨相符，且 `in_reply_to`（或 `references`）指向該對話群組中的郵件時，Gmail 才會採用此值。監視事件會將此值作為 `threadId` 傳遞"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "回覆對象"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "所回覆郵件的 Message-ID 標頭值"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "所回覆郵件的 `Message-ID` 標頭值，包含角括號；會作為 `In-Reply-To` 標頭傳送，且在未設定 `references` 時也會作為 `References` 標頭傳送，讓郵件用戶端和 Gmail 將回覆歸入原始郵件之下。監視事件會將此值作為 `Message-ID` 傳遞"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "參照"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "所回覆對話的 Message-ID 標頭值"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "`References` 標頭值：所回覆對話中各郵件的 `Message-ID` 值，由最舊到最新排列，以空格分隔並包含角括號。若未設定，則使用 `in_reply_to`。監視事件會傳遞原始郵件的 `References` 標頭"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "搜尋郵件並取得中繼資料"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "搜尋郵件並將每個相符項目連同其標頭一併傳回"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "搜尋帳戶中的郵件，並將每封相符的郵件連同其中繼資料一併傳回，而非只傳回 `list` 所傳回的郵件 ID 與對話群組 ID。每個相符項目會以要求的 `format` 個別擷取，因此一頁 `maxResults` 封郵件需要 `maxResults` + 1 次 API 要求；請將 `maxResults` 保持較小的值，並使用 `pageToken` 逐頁瀏覽後續頁面"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "搜尋準則"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "用於擷取郵件的 Gmail 搜尋條件"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "用於擷取郵件的 Gmail 搜尋條件；例如：`in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "最大結果數"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "要傳回的結果數量上限"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "要傳回的結果數量上限；每傳回一封郵件就需要額外一次 API 要求"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "包含垃圾郵件與垃圾桶？"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "是否在搜尋中包含垃圾郵件和垃圾桶資料夾？"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "是否在搜尋中包含垃圾郵件和垃圾桶資料夾？"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "標籤"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "僅傳回包含符合所有指定標籤 ID 之標籤的郵件"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "僅傳回包含符合所有指定標籤 ID 之標籤的郵件。會話群組中的某些郵件可能帶有同一會話群組中其他郵件所沒有的標籤"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "頁面標記"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "用於擷取清單中特定頁面結果的頁面權杖"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "用於擷取清單中特定頁面結果的頁面權杖"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "郵件格式"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "每封相符郵件要擷取的範圍"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "每封相符郵件要擷取的範圍"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "中繼資料"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "僅包含郵件 ID、標籤、摘要與所要求的標頭"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "僅包含郵件 ID、標籤、摘要與 `metadata_headers` 中指定的標頭；不含內文"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "完整"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "包含所有標頭與內文的完整郵件"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "包含所有標頭與 MIME 內文部分的完整郵件；不含附件資料，附件資料必須以 `get-attachment` 擷取"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "中繼資料標頭"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "每封相符郵件要擷取的郵件標頭"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "每封相符郵件要擷取的郵件標頭；除非 `format` 為 `metadata`，否則會被忽略"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "從垃圾桶還原郵件"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "將郵件從垃圾桶移回信箱"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "將 `id` 所指定的郵件從 Gmail 垃圾桶移回信箱，以復原 `trash-message`；Gmail 已從垃圾桶永久清除的郵件無法還原"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "訊息 ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "要從垃圾桶還原的郵件 ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "要從垃圾桶還原的郵件 ID；監視事件會將此值作為 `message_id` 傳遞"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "變更郵件的標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "為郵件新增標籤及移除郵件的標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "在單次呼叫中，為 `id` 所指定的郵件新增 `addLabelIds` 中的標籤，並移除 `removeLabelIds` 中的標籤。Gmail 的系統標籤也以相同方式變更：移除 `UNREAD` 可將郵件標示為已讀、移除 `INBOX` 可將其封存、新增 `STARRED` 可為其加上星號。使用 `list-labels` 查詢標籤 ID，或使用 `create-label` 建立新標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "訊息 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "要變更標籤的郵件 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "要變更標籤的郵件 ID；監視事件會將此值作為 `message_id` 傳遞"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "要新增的標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "要新增至郵件的標籤 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "要新增至郵件的標籤 ID；標籤以其 ID（例如 `INBOX`、`STARRED`、`Label_12`）識別，而非名稱"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "要移除的標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "要從郵件移除的標籤 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "要從郵件移除的標籤 ID；標籤以其 ID（例如 `INBOX`、`UNREAD`、`Label_12`）識別，而非名稱"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "列出標籤"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "列出帳戶中的所有標籤"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "列出帳戶中的所有標籤，包括 Gmail 的系統標籤（`INBOX`、`UNREAD`、`STARRED` 等）與使用者建立的標籤，每個標籤都附有 `modify-message-labels` 與搜尋選項 `labelIds` 所使用的 ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "建立標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "在帳戶中建立新的使用者標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "在帳戶中建立新的使用者標籤，並連同 `modify-message-labels` 所使用的 ID 一併傳回"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "標籤名稱"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "標籤的顯示名稱"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "標籤的顯示名稱；使用 `/` 可將標籤巢狀置於另一個標籤之下，例如 `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "標籤清單可見性"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "標籤是否顯示在標籤清單中"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "標籤是否顯示在 Gmail 網頁介面的標籤清單中"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "顯示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "在標籤清單中顯示標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "有未讀時顯示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "僅在標籤含有未讀郵件時，才在標籤清單中顯示該標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "隱藏"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "不在標籤清單中顯示標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "郵件清單可見性"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "帶有此標籤的郵件是否顯示在郵件清單中"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "帶有此標籤的郵件是否顯示在 Gmail 網頁介面的郵件清單中"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "顯示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "在郵件清單中顯示帶有此標籤的郵件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "隱藏"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "不在郵件清單中顯示帶有此標籤的郵件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "建立草稿"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "在 Gmail 中建立新的電子郵件草稿而不傳送"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "根據提供的收件者地址、主旨、本文和附件建立新的電子郵件草稿，並儲存至 Gmail 的草稿資料夾而不傳送，以便由人員檢閱後傳送，或稍後由 `send-draft` 傳送。設定 `thread_id` 與 `in_reply_to` 即可在現有的對話中草擬回覆"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "收件者"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "郵件收件者位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "電子郵件的一個或多個 `To:` 位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "CC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "副本地址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "電子郵件的一或多個 `Cc:` 地址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "BCC"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "密件副本位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "電子郵件的一個或多個 `Bcc:` 位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "主旨"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "電子郵件的主旨"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "電子郵件的主旨"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "訊息內文"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "郵件本文"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "郵件本文"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "附件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "郵件附件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "郵件的任何附件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "附件資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "資料、檔案名稱與 MIME 類型的附件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "資料、檔案名稱與 MIME 類型的附件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "檔案資料"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料，將以 Base64 編碼"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料，將以 Base64 編碼"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME 類型"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "自動偵測"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "根據檔案名稱自動偵測；僅在輸入時有效"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "根據檔案名稱自動偵測；僅在輸入時有效"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF檔案"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF檔案"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "檔案名稱"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "檔案名稱"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "檔案名稱"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "附件編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "用於附件的編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "用於附件的編碼：\n- `default`：字串資料使用 `quoted-printable`，二進位資料使用 `base64`\n- `none`：無內容編碼（不建議）\n- `quoted-printable`：quoted printable 編碼\n- `base64`：base64 編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "自動"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "字串資料使用「quoted-printable」，二進位資料使用「base64」"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "字串資料使用 `quoted-printable`，二進位資料使用 `base64`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "無"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "無內容編碼（不建議）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "無內容編碼（不建議）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "適合字串資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "適合字串資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "適合二進位資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "適合二進位資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "標頭"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "可選的附加標頭，用於附件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "可選的附加標頭，用於附件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "內文編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "用於附件的編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "用於附件的編碼：\n- `default`：字串資料使用 `quoted-printable`，二進位資料使用 `base64`\n- `none`：無內容編碼（不建議）\n- `quoted-printable`：quoted printable 編碼\n- `base64`：base64 編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "自動"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "字串資料使用「quoted-printable」，二進位資料使用「base64」"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "字串資料使用 `quoted-printable`，二進位資料使用 `base64`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "無"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "無內容編碼（不建議）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "無內容編碼（不建議）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "適合字串資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "適合字串資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "適合二進位資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "適合二進位資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "內文 MIME 類型"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "郵件內文的 MIME 類型"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "郵件內文的 MIME 類型"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "傳送者"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "電子郵件的寄件者位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "電子郵件的寄件者位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "對話群組 ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "要將郵件加入的 Gmail 對話群組 ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "要將郵件加入的 Gmail 對話群組 ID；設定此值即可在現有的對話中回覆。只有當 `subject` 與對話群組的主旨相符，且 `in_reply_to`（或 `references`）指向該對話群組中的郵件時，Gmail 才會採用此值。監視事件會將此值作為 `threadId` 傳遞"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "回覆對象"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "所回覆郵件的 Message-ID 標頭值"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "所回覆郵件的 `Message-ID` 標頭值，包含角括號；會作為 `In-Reply-To` 標頭傳送，且在未設定 `references` 時也會作為 `References` 標頭傳送，讓郵件用戶端和 Gmail 將回覆歸入原始郵件之下。監視事件會將此值作為 `Message-ID` 傳遞"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "參照"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "所回覆對話的 Message-ID 標頭值"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "`References` 標頭值：所回覆對話中各郵件的 `Message-ID` 值，由最舊到最新排列，以空格分隔並包含角括號。若未設定，則使用 `in_reply_to`。監視事件會傳遞原始郵件的 `References` 標頭"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "搜尋草稿"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "搜尋草稿"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "搜尋帳戶中的草稿；每份草稿會連同其 ID，以及其所含郵件的 ID 與對話群組 ID 一併傳回。使用 `get-draft` 擷取草稿的內容"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "搜尋準則"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "用於擷取草稿的 Gmail 搜尋準則"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "用於擷取草稿的 Gmail 搜尋準則；例如 `to:me@gmail.com subject:hello`；若未設定，則傳回所有草稿"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "最大結果數"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "要傳回的結果數量上限"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "要傳回的結果數量上限"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "包含垃圾郵件與垃圾桶？"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "是否在搜尋中包含垃圾郵件和垃圾桶資料夾？"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "是否在搜尋中包含垃圾郵件和垃圾桶資料夾？"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "頁面標記"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "用於擷取清單中特定頁面結果的頁面權杖"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "用於擷取清單中特定頁面結果的頁面權杖"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "擷取草稿"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "擷取草稿"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "以要求的 `format` 擷取草稿及其所含的郵件"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "草稿 ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "要擷取的草稿 ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "要擷取的草稿 ID；`list-drafts` 與 `create-draft` 會將此值作為 `id` 傳回"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "郵件格式"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "草稿郵件要擷取的範圍"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "草稿郵件要擷取的範圍；若未設定，則傳回完整郵件"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "完整"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "包含所有標頭與內文的完整郵件"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "包含所有標頭與 MIME 內文部分的完整郵件；不含附件資料，附件資料必須以 `get-attachment` 擷取"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "中繼資料"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "僅包含郵件 ID、標籤、摘要與標頭"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "僅包含郵件 ID、標籤、摘要與標頭；不含內文"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "最小"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "僅包含郵件 ID 與標籤"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "僅包含郵件 ID 與標籤；不含標頭與內文"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "原始"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "以 base64url 編碼的 MIME 資料形式呈現的完整郵件"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "以 base64url 編碼的 MIME 資料形式置於 `raw` 中的完整郵件；不會解析內文"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "傳送草稿"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "依原樣傳送現有的草稿"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "將 `id` 所指定的草稿依原樣傳送給其中指定的收件者；Gmail 會移除該草稿並傳回已傳送的郵件。請先使用 `get-draft` 檢閱將要傳送的內容"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "草稿 ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "要傳送的草稿 ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "要傳送的草稿 ID；`list-drafts` 與 `create-draft` 會將此值作為 `id` 傳回"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "刪除草稿"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "永久刪除草稿；此操作無法復原"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "永久刪除草稿。**此操作無法復原**：草稿不會移至垃圾桶，且不會保留任何複本。\n\nGmail API 對此呼叫不傳回任何內容"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "草稿 ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "要永久刪除的草稿 ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "要永久刪除的草稿 ID；`list-drafts` 與 `create-draft` 會將此值作為 `id` 傳回"
         }
       }
     }

--- a/qlib/GmailDataProvider/i18n/data-provider.R21haWw/zh-TW.json
+++ b/qlib/GmailDataProvider/i18n/data-provider.R21haWw/zh-TW.json
@@ -860,8 +860,8 @@
           "message": "透過 Gmail 建立並傳送新的外寄電子郵件"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.desc": {
-          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail.",
-          "message": "根據提供的收件者地址、主旨、內文與附件建立新的外寄電子郵件，並透過 Gmail 傳送該電子郵件。"
+          "source": "Creates a new outgoing email from the supplied recipient addresses, subject, body, and attachments, and transmits that new email through Gmail. Set `thread_id` and `in_reply_to` to send the email as a reply within an existing conversation",
+          "message": "根據提供的收件者地址、主旨、本文和附件建立新的外發電子郵件，並透過 Gmail 傳送該新郵件。設定 `thread_id` 與 `in_reply_to` 即可將該郵件作為現有對話中的回覆傳送"
         },
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dG8.display_name": {
           "source": "To",
@@ -1246,6 +1246,958 @@
         "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.c2VuZGVy.desc": {
           "source": "The sender's address for the email",
           "message": "電子郵件的寄件者位址"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "對話群組 ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "要將郵件加入的 Gmail 對話群組 ID"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "要將郵件加入的 Gmail 對話群組 ID；設定此值即可在現有的對話中回覆。只有當 `subject` 與對話群組的主旨相符，且 `in_reply_to`（或 `references`）指向該對話群組中的郵件時，Gmail 才會採用此值。監視事件會將此值作為 `threadId` 傳遞"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "回覆對象"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "所回覆郵件的 Message-ID 標頭值"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "所回覆郵件的 `Message-ID` 標頭值，包含角括號；會作為 `In-Reply-To` 標頭傳送，且在未設定 `references` 時也會作為 `References` 標頭傳送，讓郵件用戶端和 Gmail 將回覆歸入原始郵件之下。監視事件會將此值作為 `Message-ID` 傳遞"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "參照"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "所回覆對話的 Message-ID 標頭值"
+        },
+        "app.R21haWw.action.c2VuZC1tZXNzYWdl.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "`References` 標頭值：所回覆對話中各郵件的 `Message-ID` 值，由最舊到最新排列，以空格分隔並包含角括號。若未設定，則使用 `in_reply_to`。監視事件會傳遞原始郵件的 `References` 標頭"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.display_name": {
+          "source": "Search for Messages with Metadata",
+          "message": "搜尋郵件並取得中繼資料"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.short_desc": {
+          "source": "Search for messages and return each match with its headers",
+          "message": "搜尋郵件並將每個相符項目連同其標頭一併傳回"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.desc": {
+          "source": "Search for messages in the account and return each matching message with its metadata, instead of the bare message and thread IDs that `list` returns. Each match is retrieved separately in the requested `format`, so a page of `maxResults` messages costs `maxResults` + 1 API requests; keep `maxResults` small and use `pageToken` to walk further pages",
+          "message": "搜尋帳戶中的郵件，並將每封相符的郵件連同其中繼資料一併傳回，而非只傳回 `list` 所傳回的郵件 ID 與對話群組 ID。每個相符項目會以要求的 `format` 個別擷取，因此一頁 `maxResults` 封郵件需要 `maxResults` + 1 次 API 要求；請將 `maxResults` 保持較小的值，並使用 `pageToken` 逐頁瀏覽後續頁面"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "搜尋條件"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the messages",
+          "message": "用於擷取郵件的 Gmail 搜尋條件"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the messages; ex: `in:inbox to:me@gmail.com subject:hello is:unread`",
+          "message": "用於擷取郵件的 Gmail 搜尋條件；例如：`in:inbox to:me@gmail.com subject:hello is:unread`"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "最大結果數"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "要傳回的結果數量上限"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return; each message returned costs one additional API request",
+          "message": "要傳回的結果數量上限；每傳回一封郵件就需要額外一次 API 要求"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "包含垃圾郵件和垃圾桶？"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "搜尋時是否包含垃圾郵件和垃圾桶資料夾？"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "搜尋時是否包含垃圾郵件和垃圾桶資料夾？"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.display_name": {
+          "source": "Labels",
+          "message": "標籤"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.short_desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs",
+          "message": "僅傳回標籤符合所有指定標籤 ID 的郵件"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bGFiZWxJZHM.desc": {
+          "source": "Only return messages with labels that match all of the specified label IDs. Messages in a thread might have labels that other messages in the same thread don't have",
+          "message": "僅傳回標籤符合所有指定標籤 ID 的郵件。討論串中的郵件可能包含同一討論串中其他郵件所沒有的標籤"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "頁面 Token"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "用於擷取清單中特定結果頁面的頁面權杖"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "用於擷取清單中特定結果頁面的頁面權杖"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "郵件格式"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.short_desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "每封相符郵件要擷取的範圍"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.desc": {
+          "source": "How much of each matching message to retrieve",
+          "message": "每封相符郵件要擷取的範圍"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "中繼資料"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and the requested headers only",
+          "message": "僅包含郵件 ID、標籤、摘要與所要求的標頭"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and the headers named in `metadata_headers` only; no body",
+          "message": "僅包含郵件 ID、標籤、摘要與 `metadata_headers` 中指定的標頭；不含內文"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "完整"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "包含所有標頭與內文的完整郵件"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "包含所有標頭與 MIME 內文部分的完整郵件；不含附件資料，附件資料必須以 `get-attachment` 擷取"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.display_name": {
+          "source": "Metadata Headers",
+          "message": "中繼資料標頭"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.short_desc": {
+          "source": "The message headers to retrieve for each matching message",
+          "message": "每封相符郵件要擷取的郵件標頭"
+        },
+        "app.R21haWw.action.bGlzdC13aXRoLW1ldGFkYXRh.option.bWV0YWRhdGFfaGVhZGVycw.desc": {
+          "source": "The message headers to retrieve for each matching message; ignored unless `format` is `metadata`",
+          "message": "每封相符郵件要擷取的郵件標頭；除非 `format` 為 `metadata`，否則會被忽略"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.display_name": {
+          "source": "Restore a Message from the Trash",
+          "message": "從垃圾桶還原郵件"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.short_desc": {
+          "source": "Move a message from the trash back into the mailbox",
+          "message": "將郵件從垃圾桶移回信箱"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.desc": {
+          "source": "Moves the message identified by `id` out of Gmail's trash folder and back into the mailbox, undoing `trash-message`; a message that Gmail has already purged from the trash cannot be restored",
+          "message": "將 `id` 所指定的郵件從 Gmail 垃圾桶移回信箱，以復原 `trash-message`；Gmail 已從垃圾桶永久清除的郵件無法還原"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "訊息 ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.short_desc": {
+          "source": "The ID of the message to restore from the trash",
+          "message": "要從垃圾桶還原的郵件 ID"
+        },
+        "app.R21haWw.action.dW50cmFzaC1tZXNzYWdl.option.aWQ.desc": {
+          "source": "The ID of the message to restore from the trash; watch events carry this value as `message_id`",
+          "message": "要從垃圾桶還原的郵件 ID；監視事件會將此值作為 `message_id` 傳遞"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.display_name": {
+          "source": "Change a Message's Labels",
+          "message": "變更郵件的標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.short_desc": {
+          "source": "Add labels to and remove labels from a message",
+          "message": "為郵件新增標籤及移除郵件的標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.desc": {
+          "source": "Adds the labels in `addLabelIds` to and removes the labels in `removeLabelIds` from the message identified by `id` in one call. Gmail's system labels are changed the same way: remove `UNREAD` to mark a message as read, remove `INBOX` to archive it, or add `STARRED` to star it. Use `list-labels` to find a label's ID or `create-label` to make a new one",
+          "message": "在單次呼叫中，為 `id` 所指定的郵件新增 `addLabelIds` 中的標籤，並移除 `removeLabelIds` 中的標籤。Gmail 的系統標籤也以相同方式變更：移除 `UNREAD` 可將郵件標示為已讀、移除 `INBOX` 可將其封存、新增 `STARRED` 可為其加上星號。使用 `list-labels` 查詢標籤 ID，或使用 `create-label` 建立新標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.display_name": {
+          "source": "Message ID",
+          "message": "訊息 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.short_desc": {
+          "source": "The ID of the message to relabel",
+          "message": "要變更標籤的郵件 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.aWQ.desc": {
+          "source": "The ID of the message to relabel; watch events carry this value as `message_id`",
+          "message": "要變更標籤的郵件 ID；監視事件會將此值作為 `message_id` 傳遞"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.display_name": {
+          "source": "Labels to Add",
+          "message": "要新增的標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to add to the message",
+          "message": "要新增至郵件的標籤 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.YWRkTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to add to the message; a label is identified by its ID (ex: `INBOX`, `STARRED`, `Label_12`), not its name",
+          "message": "要新增至郵件的標籤 ID；標籤以其 ID（例如 `INBOX`、`STARRED`、`Label_12`）識別，而非名稱"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.display_name": {
+          "source": "Labels to Remove",
+          "message": "要移除的標籤"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.short_desc": {
+          "source": "The IDs of the labels to remove from the message",
+          "message": "要從郵件移除的標籤 ID"
+        },
+        "app.R21haWw.action.bW9kaWZ5LW1lc3NhZ2UtbGFiZWxz.option.cmVtb3ZlTGFiZWxJZHM.desc": {
+          "source": "The IDs of the labels to remove from the message; a label is identified by its ID (ex: `INBOX`, `UNREAD`, `Label_12`), not its name",
+          "message": "要從郵件移除的標籤 ID；標籤以其 ID（例如 `INBOX`、`UNREAD`、`Label_12`）識別，而非名稱"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.display_name": {
+          "source": "List Labels",
+          "message": "列出標籤"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.short_desc": {
+          "source": "List all labels in the account",
+          "message": "列出帳戶中的所有標籤"
+        },
+        "app.R21haWw.action.bGlzdC1sYWJlbHM.desc": {
+          "source": "Lists all labels in the account, both Gmail's system labels (`INBOX`, `UNREAD`, `STARRED`, and so on) and user-created labels, each with the ID that `modify-message-labels` and the `labelIds` search option take",
+          "message": "列出帳戶中的所有標籤，包括 Gmail 的系統標籤（`INBOX`、`UNREAD`、`STARRED` 等）與使用者建立的標籤，每個標籤都附有 `modify-message-labels` 與搜尋選項 `labelIds` 所使用的 ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.display_name": {
+          "source": "Create a Label",
+          "message": "建立標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.short_desc": {
+          "source": "Create a new user label in the account",
+          "message": "在帳戶中建立新的使用者標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.desc": {
+          "source": "Creates a new user label in the account and returns it with the ID that `modify-message-labels` takes",
+          "message": "在帳戶中建立新的使用者標籤，並連同 `modify-message-labels` 所使用的 ID 一併傳回"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.display_name": {
+          "source": "Label Name",
+          "message": "標籤名稱"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.short_desc": {
+          "source": "The display name of the label",
+          "message": "標籤的顯示名稱"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bmFtZQ.desc": {
+          "source": "The display name of the label; use `/` to nest a label under another, ex: `Projects/Alpha`",
+          "message": "標籤的顯示名稱；使用 `/` 可將標籤巢狀置於另一個標籤之下，例如 `Projects/Alpha`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.display_name": {
+          "source": "Label List Visibility",
+          "message": "標籤清單可見性"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.short_desc": {
+          "source": "Whether the label is shown in the label list",
+          "message": "標籤是否顯示在標籤清單中"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.desc": {
+          "source": "Whether the label is shown in the label list of the Gmail web interface",
+          "message": "標籤是否顯示在 Gmail 網頁介面的標籤清單中"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.display_name": {
+          "source": "Show",
+          "message": "顯示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvdw.desc": {
+          "source": "Show the label in the label list",
+          "message": "在標籤清單中顯示標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.display_name": {
+          "source": "Show If Unread",
+          "message": "有未讀時顯示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsU2hvd0lmVW5yZWFk.desc": {
+          "source": "Show the label in the label list only while it has unread messages",
+          "message": "僅在標籤含有未讀郵件時，才在標籤清單中顯示該標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.display_name": {
+          "source": "Hide",
+          "message": "隱藏"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bGFiZWxMaXN0VmlzaWJpbGl0eQ.allowed-value.c3RyaW5nOmxhYmVsSGlkZQ.desc": {
+          "source": "Do not show the label in the label list",
+          "message": "不在標籤清單中顯示標籤"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.display_name": {
+          "source": "Message List Visibility",
+          "message": "郵件清單可見性"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.short_desc": {
+          "source": "Whether messages with the label are shown in the message list",
+          "message": "帶有此標籤的郵件是否顯示在郵件清單中"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.desc": {
+          "source": "Whether messages with the label are shown in the message list of the Gmail web interface",
+          "message": "帶有此標籤的郵件是否顯示在 Gmail 網頁介面的郵件清單中"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.display_name": {
+          "source": "Show",
+          "message": "顯示"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOnNob3c.desc": {
+          "source": "Show messages with the label in the message list",
+          "message": "在郵件清單中顯示帶有此標籤的郵件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.display_name": {
+          "source": "Hide",
+          "message": "隱藏"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWxhYmVs.option.bWVzc2FnZUxpc3RWaXNpYmlsaXR5.allowed-value.c3RyaW5nOmhpZGU.desc": {
+          "source": "Do not show messages with the label in the message list",
+          "message": "不在郵件清單中顯示帶有此標籤的郵件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.display_name": {
+          "source": "Create a Draft",
+          "message": "建立草稿"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.short_desc": {
+          "source": "Create a new draft email in Gmail without sending it",
+          "message": "在 Gmail 中建立新的電子郵件草稿而不傳送"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.desc": {
+          "source": "Creates a new draft email from the supplied recipient addresses, subject, body, and attachments, and stores it in Gmail's drafts folder without sending it, so that a person can review and send it, or so that `send-draft` can send it later. Set `thread_id` and `in_reply_to` to draft a reply within an existing conversation",
+          "message": "根據提供的收件者地址、主旨、本文和附件建立新的電子郵件草稿，並儲存至 Gmail 的草稿資料夾而不傳送，以便由人員檢閱後傳送，或稍後由 `send-draft` 傳送。設定 `thread_id` 與 `in_reply_to` 即可在現有的對話中草擬回覆"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.display_name": {
+          "source": "To",
+          "message": "收件者"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.short_desc": {
+          "source": "Message recipient addresses",
+          "message": "郵件收件者位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dG8.desc": {
+          "source": "One or more `To:` addresses for the email",
+          "message": "電子郵件的一或多個 `To:` 位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.display_name": {
+          "source": "CC",
+          "message": "副本"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.short_desc": {
+          "source": "Carbon copy addresses",
+          "message": "副本 (CC) 位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Y2M.desc": {
+          "source": "One or more `Cc:` addresses for the email",
+          "message": "電子郵件的一或多個 `Cc:` 位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.display_name": {
+          "source": "BCC",
+          "message": "密件副本"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.short_desc": {
+          "source": "Blind carbon copy addresses",
+          "message": "密件副本位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YmNj.desc": {
+          "source": "One or more `Bcc:` addresses for the email",
+          "message": "電子郵件的一或多個 `Bcc:` 位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.display_name": {
+          "source": "Subject",
+          "message": "主題"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.short_desc": {
+          "source": "The subject for the email",
+          "message": "電子郵件主旨"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c3ViamVjdA.desc": {
+          "source": "The subject for the email",
+          "message": "電子郵件主旨"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.display_name": {
+          "source": "Message Body",
+          "message": "訊息內文"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.short_desc": {
+          "source": "The message body",
+          "message": "郵件內文"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keQ.desc": {
+          "source": "The message body",
+          "message": "郵件內文"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.display_name": {
+          "source": "Attachments",
+          "message": "附件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.short_desc": {
+          "source": "Message attachments",
+          "message": "郵件附件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.desc": {
+          "source": "Any attachments for the message",
+          "message": "郵件的任何附件"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.display_name": {
+          "source": "Attachment Data",
+          "message": "附件資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.short_desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "附件的資料、檔名與 MIME 類型"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZGF0YQ.desc": {
+          "source": "The data, file name, and MIME type for the attachment",
+          "message": "附件的資料、檔名與 MIME 類型"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "檔案資料"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME 類型"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "自動偵測"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "從檔名自動偵測；僅適用於輸入"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "從檔名自動偵測；僅適用於輸入"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF 檔案"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF 檔案"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` 文件"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "檔案名稱"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "檔案名"
+        },
+        "app.R21haWw.type.YWN0aW9uOlkzSmxZWFJsTFdSeVlXWjA6RmlsZURhdGFUeXBlOmZpbGUjZDY3YWQ5M2RhZTlkNjJhOWRmN2JiY2UxOWE4MjE1ZTRiYTg3ZjEwMGRjZjUyYjRhNWVhMWE2ZmM4ZDU2M2M1MjpvcHRpb246WVhSMFlXTm9iV1Z1ZEhNOmZpZWxkOlpHRjBZUQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "檔案名"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.display_name": {
+          "source": "Attachment Encoding",
+          "message": "附件編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "用於附件的編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "用於附件的編碼：\n- `default`：字串資料使用 `quoted-printable`，二進位資料使用 `base64`\n- `none`：無內容編碼（不建議）\n- `quoted-printable`：quoted printable 編碼\n- `base64`：base64 編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "自動"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "字串資料使用 'quoted-printable'，二進位資料使用 'base64'"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "字串資料使用 `quoted-printable`，二進位資料使用 `base64`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "無"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "無內容編碼（不建議）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "無內容編碼（不建議）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "適合字串資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "適合字串資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "適合二進位資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.ZW5jb2Rpbmc.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "適合二進位資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.display_name": {
+          "source": "Headers",
+          "message": "標頭"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.short_desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "傳送附件時可選的標頭"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.YXR0YWNobWVudHM.field.aGRy.desc": {
+          "source": "Optional headers to send with the attachment",
+          "message": "傳送附件時可選的標頭"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.display_name": {
+          "source": "Body Encoding",
+          "message": "本文編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.short_desc": {
+          "source": "The encoding to use for the attachment",
+          "message": "用於附件的編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.desc": {
+          "source": "The encoding to use for the attachment:\n- `default`: `quoted-printable` for string data, `base64` for binary data\n- `none`: no content encoding (not recommended)\n- `quoted-printable`: quoted printable encoding \n- `base64`: base64 encoding",
+          "message": "用於附件的編碼：\n- `default`：字串資料使用 `quoted-printable`，二進位資料使用 `base64`\n- `none`：無內容編碼（不建議）\n- `quoted-printable`：quoted printable 編碼\n- `base64`：base64 編碼"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.display_name": {
+          "source": "Auto",
+          "message": "自動"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.short_desc": {
+          "source": "'quoted-printable' for string data, 'base64' for binary data",
+          "message": "字串資料使用 'quoted-printable'，二進位資料使用 'base64'"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmRlZmF1bHQ.desc": {
+          "source": "`quoted-printable` for string data, `base64` for binary data",
+          "message": "字串資料使用 `quoted-printable`，二進位資料使用 `base64`"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.display_name": {
+          "source": "None",
+          "message": "無"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.short_desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "無內容編碼（不建議）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOm5vbmU.desc": {
+          "source": "No content encoding (not recommended)",
+          "message": "無內容編碼（不建議）"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.display_name": {
+          "source": "Quoted Printable",
+          "message": "Quoted Printable"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.short_desc": {
+          "source": "Ideal for string data",
+          "message": "適合字串資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOnF1b3RlZC1wcmludGFibGU.desc": {
+          "source": "Ideal for string data",
+          "message": "適合字串資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.display_name": {
+          "source": "Base64",
+          "message": "Base64"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.short_desc": {
+          "source": "Ideal for binary data",
+          "message": "適合二進位資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1lbmNvZGluZw.allowed-value.c3RyaW5nOmJhc2U2NA.desc": {
+          "source": "Ideal for binary data",
+          "message": "適合二進位資料"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.display_name": {
+          "source": "Body Mime Type",
+          "message": "本文 MIME 類型"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.short_desc": {
+          "source": "The MIME type of the message body",
+          "message": "郵件本文的 MIME 類型"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.desc": {
+          "source": "The MIME type of the message body",
+          "message": "郵件本文的 MIME 類型"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.Ym9keS1taW1lLXR5cGU.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.display_name": {
+          "source": "Sender",
+          "message": "發送者"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.short_desc": {
+          "source": "The sender's address for the email",
+          "message": "電子郵件的寄件者位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.c2VuZGVy.desc": {
+          "source": "The sender's address for the email",
+          "message": "電子郵件的寄件者位址"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.display_name": {
+          "source": "Thread ID",
+          "message": "對話群組 ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.short_desc": {
+          "source": "The ID of the Gmail thread to add the message to",
+          "message": "要將郵件加入的 Gmail 對話群組 ID"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.dGhyZWFkX2lk.desc": {
+          "source": "The ID of the Gmail thread to add the message to; set this to reply within an existing conversation. Gmail only honors it when `subject` matches the thread's subject and `in_reply_to` (or `references`) names a message in the thread. Watch events carry this value as `threadId`",
+          "message": "要將郵件加入的 Gmail 對話群組 ID；設定此值即可在現有的對話中回覆。只有當 `subject` 與對話群組的主旨相符，且 `in_reply_to`（或 `references`）指向該對話群組中的郵件時，Gmail 才會採用此值。監視事件會將此值作為 `threadId` 傳遞"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.display_name": {
+          "source": "In Reply To",
+          "message": "回覆對象"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.short_desc": {
+          "source": "The Message-ID header value of the message being answered",
+          "message": "所回覆郵件的 Message-ID 標頭值"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.aW5fcmVwbHlfdG8.desc": {
+          "source": "The `Message-ID` header value of the message being answered, including the angle brackets; sent as the `In-Reply-To` header and, unless `references` is set, also as the `References` header, so that mail clients and Gmail thread the reply under the original message. Watch events carry this value as `Message-ID`",
+          "message": "所回覆郵件的 `Message-ID` 標頭值，包含角括號；會作為 `In-Reply-To` 標頭傳送，且在未設定 `references` 時也會作為 `References` 標頭傳送，讓郵件用戶端和 Gmail 將回覆歸入原始郵件之下。監視事件會將此值作為 `Message-ID` 傳遞"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.display_name": {
+          "source": "References",
+          "message": "參照"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.short_desc": {
+          "source": "The Message-ID header values of the conversation being answered",
+          "message": "所回覆對話的 Message-ID 標頭值"
+        },
+        "app.R21haWw.action.Y3JlYXRlLWRyYWZ0.option.cmVmZXJlbmNlcw.desc": {
+          "source": "The `References` header value: the `Message-ID` values of the messages in the conversation being answered, oldest first, separated by spaces and including the angle brackets. If not set, `in_reply_to` is used. Watch events carry the original message's `References` header",
+          "message": "`References` 標頭值：所回覆對話中各郵件的 `Message-ID` 值，由最舊到最新排列，以空格分隔並包含角括號。若未設定，則使用 `in_reply_to`。監視事件會傳遞原始郵件的 `References` 標頭"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.display_name": {
+          "source": "Search for Drafts",
+          "message": "搜尋草稿"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.short_desc": {
+          "source": "Search for drafts",
+          "message": "搜尋草稿"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.desc": {
+          "source": "Search for drafts in the account; each draft is returned with its ID and the ID and thread ID of the message it holds. Use `get-draft` to retrieve a draft's content",
+          "message": "搜尋帳戶中的草稿；每份草稿會連同其 ID，以及其所含郵件的 ID 與對話群組 ID 一併傳回。使用 `get-draft` 擷取草稿的內容"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.display_name": {
+          "source": "Search Criteria",
+          "message": "搜尋條件"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.short_desc": {
+          "source": "The gmail search criteria for retrieving the drafts",
+          "message": "用於擷取草稿的 Gmail 搜尋準則"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cQ.desc": {
+          "source": "The gmail search criteria for retrieving the drafts; ex: `to:me@gmail.com subject:hello`; if not set, all drafts are returned",
+          "message": "用於擷取草稿的 Gmail 搜尋準則；例如 `to:me@gmail.com subject:hello`；若未設定，則傳回所有草稿"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Max Results",
+          "message": "最大結果數"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of results to return",
+          "message": "要傳回的結果數量上限"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of results to return",
+          "message": "要傳回的結果數量上限"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.display_name": {
+          "source": "Include Spam and Trash?",
+          "message": "包含垃圾郵件和垃圾桶？"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.short_desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "搜尋時是否包含垃圾郵件和垃圾桶資料夾？"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.aW5jbHVkZVNwYW1UcmFzaA.desc": {
+          "source": "Include the spam and trash folders in the search?",
+          "message": "搜尋時是否包含垃圾郵件和垃圾桶資料夾？"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "頁面 Token"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "用於擷取清單中特定結果頁面的頁面權杖"
+        },
+        "app.R21haWw.action.bGlzdC1kcmFmdHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Page token to retrieve a specific page of results in the list",
+          "message": "用於擷取清單中特定結果頁面的頁面權杖"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.display_name": {
+          "source": "Retrieve a Draft",
+          "message": "擷取草稿"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.short_desc": {
+          "source": "Retrieve a draft",
+          "message": "擷取草稿"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.desc": {
+          "source": "Retrieves a draft and the message it holds in the requested `format`",
+          "message": "以要求的 `format` 擷取草稿及其所含的郵件"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "草稿 ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to retrieve",
+          "message": "要擷取的草稿 ID"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to retrieve; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "要擷取的草稿 ID；`list-drafts` 與 `create-draft` 會將此值作為 `id` 傳回"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.display_name": {
+          "source": "Message Format",
+          "message": "郵件格式"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.short_desc": {
+          "source": "How much of the draft's message to retrieve",
+          "message": "草稿郵件要擷取的範圍"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.desc": {
+          "source": "How much of the draft's message to retrieve; if not set, the complete message is returned",
+          "message": "草稿郵件要擷取的範圍；若未設定，則傳回完整郵件"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.display_name": {
+          "source": "Full",
+          "message": "完整"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.short_desc": {
+          "source": "The complete message including all headers and the body",
+          "message": "包含所有標頭與內文的完整郵件"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOmZ1bGw.desc": {
+          "source": "The complete message including all headers and the MIME body parts; attachment data is not included and must be retrieved with `get-attachment`",
+          "message": "包含所有標頭與 MIME 內文部分的完整郵件；不含附件資料，附件資料必須以 `get-attachment` 擷取"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.display_name": {
+          "source": "Metadata",
+          "message": "中繼資料"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.short_desc": {
+          "source": "Message IDs, labels, snippet, and headers only",
+          "message": "僅包含郵件 ID、標籤、摘要與標頭"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1ldGFkYXRh.desc": {
+          "source": "Message IDs, labels, snippet, and headers only; no body",
+          "message": "僅包含郵件 ID、標籤、摘要與標頭；不含內文"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.display_name": {
+          "source": "Minimal",
+          "message": "最小"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.short_desc": {
+          "source": "Message IDs and labels only",
+          "message": "僅包含郵件 ID 與標籤"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOm1pbmltYWw.desc": {
+          "source": "Message IDs and labels only; no headers and no body",
+          "message": "僅包含郵件 ID 與標籤；不含標頭與內文"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.display_name": {
+          "source": "Raw",
+          "message": "原始"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.short_desc": {
+          "source": "The complete message as base64url-encoded MIME data",
+          "message": "以 base64url 編碼的 MIME 資料形式呈現的完整郵件"
+        },
+        "app.R21haWw.action.Z2V0LWRyYWZ0.option.Zm9ybWF0.allowed-value.c3RyaW5nOnJhdw.desc": {
+          "source": "The complete message as base64url-encoded MIME data in `raw`; the body is not parsed",
+          "message": "以 base64url 編碼的 MIME 資料形式置於 `raw` 中的完整郵件；不會解析內文"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.display_name": {
+          "source": "Send a Draft",
+          "message": "傳送草稿"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.short_desc": {
+          "source": "Send an existing draft as it is",
+          "message": "依原樣傳送現有的草稿"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.desc": {
+          "source": "Sends the draft identified by `id` as it is to the recipients it names; Gmail removes the draft and returns the sent message. Use `get-draft` first to review what will be sent",
+          "message": "將 `id` 所指定的草稿依原樣傳送給其中指定的收件者；Gmail 會移除該草稿並傳回已傳送的郵件。請先使用 `get-draft` 檢閱將要傳送的內容"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "草稿 ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.short_desc": {
+          "source": "The ID of the draft to send",
+          "message": "要傳送的草稿 ID"
+        },
+        "app.R21haWw.action.c2VuZC1kcmFmdA.option.aWQ.desc": {
+          "source": "The ID of the draft to send; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "要傳送的草稿 ID；`list-drafts` 與 `create-draft` 會將此值作為 `id` 傳回"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.display_name": {
+          "source": "Delete a Draft",
+          "message": "刪除草稿"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.short_desc": {
+          "source": "Permanently delete a draft; this cannot be undone",
+          "message": "永久刪除草稿；此操作無法復原"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.desc": {
+          "source": "Permanently deletes a draft. **This cannot be undone**: the draft does not go to the trash and no copy remains.\n\nThe Gmail API returns no content for this call",
+          "message": "永久刪除草稿。**此操作無法復原**：草稿不會移至垃圾桶，且不會保留任何複本。\n\nGmail API 對此呼叫不傳回任何內容"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.display_name": {
+          "source": "Draft ID",
+          "message": "草稿 ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.short_desc": {
+          "source": "The ID of the draft to delete permanently",
+          "message": "要永久刪除的草稿 ID"
+        },
+        "app.R21haWw.action.ZGVsZXRlLWRyYWZ0.option.aWQ.desc": {
+          "source": "The ID of the draft to delete permanently; `list-drafts` and `create-draft` return this value as `id`",
+          "message": "要永久刪除的草稿 ID；`list-drafts` 與 `create-draft` 會將此值作為 `id` 傳回"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/GoogleCalendarDataProvider.qm
+++ b/qlib/GoogleCalendarDataProvider/GoogleCalendarDataProvider.qm
@@ -35,7 +35,7 @@
 %requires(reexport) GoogleRestClient
 
 module GoogleCalendarDataProvider {
-    version = "2.0";
+    version = "2.1";
     desc = "user module providing a data provider API for Google calendar REST cloud services";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -185,6 +185,195 @@ module GoogleCalendarDataProvider {
                     "events/delete");
             },
         });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GoogleCalendarDataProvider::CalendarAppName,
+            "path": "/calendars/{calendar}/events/list",
+            "path_vars": {
+                "calendar": <DataProviderPathVarInfo>{
+                    "display_name": "Calendar",
+                    "short_desc": "The calendar to list events from",
+                    "desc": "The calendar to list events from",
+                    "example_value": "primary",
+                },
+            },
+            "action": "list-events",
+            "display_name": "List Events",
+            "short_desc": "List events in a calendar",
+            "desc": "List events in a calendar; the result can be restricted to a time window, filtered with "
+                "free-text search terms, and paged with `maxResults` and `pageToken`",
+            "action_code": DPAT_API,
+            "mutates_state": False,
+            "options": {
+                "timeMin": <ActionOptionInfo>{
+                    "display_name": "Start Time",
+                    "short_desc": "Only return events that end after this time",
+                    "desc": "Lower bound (exclusive) for an event's end time; only events that end after this time "
+                        "are returned. The default is not to filter by end time",
+                    "type": AbstractDataProviderTypeMap."*date",
+                    "example_value": 2026-09-01T00:00:00Z,
+                    "preselected": True,
+                },
+                "timeMax": <ActionOptionInfo>{
+                    "display_name": "End Time",
+                    "short_desc": "Only return events that start before this time",
+                    "desc": "Upper bound (exclusive) for an event's start time; only events that start before this "
+                        "time are returned. The default is not to filter by start time",
+                    "type": AbstractDataProviderTypeMap."*date",
+                    "example_value": 2026-09-08T00:00:00Z,
+                },
+                "maxResults": <ActionOptionInfo>{
+                    "display_name": "Maximum Results",
+                    "short_desc": "The maximum number of events to return on one result page",
+                    "desc": "The maximum number of events to return on one result page; the page may contain fewer "
+                        "events than this value, or none at all, even if more events match the query. Incomplete "
+                        "pages can be detected by a non-empty `nextPageToken` field in the response. The default "
+                        "is `250`; the page size can never be larger than `2500`",
+                    "type": AbstractDataProviderTypeMap."*int",
+                    "example_value": 20,
+                    "preselected": True,
+                },
+                "singleEvents": <ActionOptionInfo>{
+                    "display_name": "Expand Recurring Events",
+                    "short_desc": "Expand recurring events into their individual instances",
+                    "desc": "If `True`, recurring events are expanded into their individual instances, and only "
+                        "single one-off events and instances of recurring events are returned, but not the "
+                        "underlying recurring events themselves. If `False`, each recurring event is returned once "
+                        "with its recurrence rule instead of its instances. Must be `True` to order the result by "
+                        "start time",
+                    "type": AbstractDataProviderTypeMap."*bool",
+                    "default_value": True,
+                },
+                "orderBy": <ActionOptionInfo>{
+                    "display_name": "Order By",
+                    "short_desc": "The order of the events returned in the result",
+                    "desc": "The order of the events returned in the result; the default is an unspecified, stable "
+                        "order.\n"
+                        "Acceptable values are:\n"
+                        "- `startTime`: Order by the start date/time (ascending); this is only available when "
+                            "`singleEvents` is `True`\n"
+                        "- `updated`: Order by last modification time (ascending)",
+                    "type": AbstractDataProviderTypeMap."*string",
+                    "allowed_values": (
+                        <AllowedValueInfo>{
+                            "value": "startTime",
+                            "desc": "Order by the start date/time (ascending); this is only available when "
+                                "`singleEvents` is `True`",
+                        },
+                        <AllowedValueInfo>{
+                            "value": "updated",
+                            "desc": "Order by last modification time (ascending)",
+                        },
+                    ),
+                },
+                "q": <ActionOptionInfo>{
+                    "display_name": "Search Terms",
+                    "short_desc": "Free-text search terms to find matching events",
+                    "desc": "Free-text search terms to find events that match these terms in the `summary`, "
+                        "`description`, and `location` fields, in attendee and organizer display names and email "
+                        "addresses, and in working location properties",
+                    "type": AbstractDataProviderTypeMap."*string",
+                    "example_value": "Lunch",
+                },
+                "pageToken": <ActionOptionInfo>{
+                    "display_name": "Page Token",
+                    "short_desc": "Token specifying which result page to return",
+                    "desc": "Token specifying which result page to return; use the `nextPageToken` value from the "
+                        "previous response to retrieve the next page",
+                    "type": AbstractDataProviderTypeMap."*string",
+                },
+                "showDeleted": <ActionOptionInfo>{
+                    "display_name": "Show Deleted",
+                    "short_desc": "Include deleted events in the result",
+                    "desc": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the "
+                        "result. Cancelled instances of recurring events (but not the underlying recurring event) "
+                        "are still included if `showDeleted` and `singleEvents` are both `False`; if both are "
+                        "`True`, only single instances of deleted events are returned. The default is `False`",
+                    "type": AbstractDataProviderTypeMap."*bool",
+                },
+            },
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryCalendarApiName,
+                    "events/list");
+            },
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GoogleCalendarDataProvider::CalendarAppName,
+            "path": "/calendars/{calendar}/events/get",
+            "path_vars": {
+                "calendar": <DataProviderPathVarInfo>{
+                    "display_name": "Calendar",
+                    "short_desc": "The calendar containing the event",
+                    "desc": "The calendar containing the event",
+                    "example_value": "primary",
+                },
+            },
+            "action": "get-event",
+            "display_name": "Get Event",
+            "short_desc": "Retrieve an event from a calendar",
+            "desc": "Retrieve a single event from a calendar by its event ID",
+            "action_code": DPAT_API,
+            "mutates_state": False,
+            "options": {
+                "eventId": <ActionOptionInfo>{
+                    "display_name": "Event ID",
+                    "short_desc": "The ID of the event to retrieve",
+                    "desc": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events "
+                        "returned by the `list-events` action",
+                    "type": AbstractDataProviderTypeMap."string",
+                    "required": True,
+                    "preselected": True,
+                },
+            },
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryCalendarApiName,
+                    "events/get");
+            },
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": GoogleCalendarDataProvider::CalendarAppName,
+            "path": "/calendarList/list",
+            "action": "list-calendars",
+            "display_name": "List Calendars",
+            "short_desc": "List the calendars in the user's calendar list",
+            "desc": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be "
+                "used as the calendar for the event actions",
+            "action_code": DPAT_API,
+            "mutates_state": False,
+            "options": {
+                "maxResults": <ActionOptionInfo>{
+                    "display_name": "Maximum Results",
+                    "short_desc": "The maximum number of calendars to return on one result page",
+                    "desc": "The maximum number of calendar list entries to return on one result page; incomplete "
+                        "pages can be detected by a non-empty `nextPageToken` field in the response. The default "
+                        "is `100`; the page size can never be larger than `250`",
+                    "type": AbstractDataProviderTypeMap."*int",
+                    "example_value": 100,
+                    "preselected": True,
+                },
+                "pageToken": <ActionOptionInfo>{
+                    "display_name": "Page Token",
+                    "short_desc": "Token specifying which result page to return",
+                    "desc": "Token specifying which result page to return; use the `nextPageToken` value from the "
+                        "previous response to retrieve the next page",
+                    "type": AbstractDataProviderTypeMap."*string",
+                },
+                "showHidden": <ActionOptionInfo>{
+                    "display_name": "Show Hidden",
+                    "short_desc": "Include hidden calendar list entries in the result",
+                    "desc": "If `True`, hidden calendar list entries are included in the result. The default is "
+                        "`False`",
+                    "type": AbstractDataProviderTypeMap."*bool",
+                    "preselected": True,
+                },
+            },
+            "get_output_type": AbstractDataProviderType sub () {
+                return GoogleDataProviderBase::getResponseTypeForSchema(GoogleDiscoveryCalendarApiName,
+                    "calendarList/list");
+            },
+        });
     };
 }
 
@@ -264,6 +453,10 @@ module GoogleCalendarDataProvider {
     @verbatim qdp gcal-conn/calendars/primary/events/get dor id=event_id
     @endverbatim
 
+    @par API Example: List Calendar Events
+    @verbatim qdp gcal-conn/calendars/primary/events/list dor maxResults=20,singleEvents=true,orderBy=startTime
+    @endverbatim
+
     @par API Example: Quick Add a Calendar Event
     @verbatim qdp gcal-conn/calendars/primary/events/quickAdd dor text="Lunch at Burger Bar from 12:30-13:30 today"
     @endverbatim
@@ -277,6 +470,11 @@ module GoogleCalendarDataProvider {
     @endverbatim
 
     @section googlecalendardataprovider_relnotes Release Notes
+
+    @subsection googlecalendardataprovider_v2_1 GoogleCalendarDataProvider v2.1
+    - added the read-only \c list-events, \c get-event, and \c list-calendars actions to the action catalog, so
+      events and calendars can be read without a custom API call
+      (<a href="https://github.com/qoretechnologies/qorus/issues/514">qorus issue 514</a>)
 
     @subsection googlecalendardataprovider_v2_0 GoogleCalendarDataProvider v2.0
     - split to a separate module

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/cs.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/cs.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "Kalendář, do kterého se má událost přidat"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "Vypsat události"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "Vypsat události v kalendáři"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "Vypsat události v kalendáři; výsledek lze omezit na časové okno, filtrovat fulltextovými hledanými výrazy a stránkovat pomocí `maxResults` a `pageToken`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Kalendář"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "Kalendář, z něhož se mají vypsat události"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "Kalendář, z něhož se mají vypsat události"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "Čas začátku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "Vrátit pouze události, které končí po tomto čase"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "Dolní mez (exkluzivní) pro čas konce události; vráceny jsou pouze události, které končí po tomto čase. Ve výchozím nastavení se podle času konce nefiltruje"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "Čas konce"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "Vrátit pouze události, které začínají před tímto časem"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "Horní mez (exkluzivní) pro čas začátku události; vráceny jsou pouze události, které začínají před tímto časem. Ve výchozím nastavení se podle času začátku nefiltruje"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maximální počet výsledků"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "Maximální počet událostí vrácených na jedné stránce výsledků"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "Maximální počet událostí vrácených na jedné stránce výsledků; stránka může obsahovat méně událostí než tato hodnota nebo žádné, i když dotazu odpovídá více událostí. Neúplné stránky lze rozpoznat podle neprázdného pole `nextPageToken` v odpovědi. Výchozí hodnota je `250`; velikost stránky nikdy nemůže být větší než `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "Rozvinout opakující se události"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "Rozvinout opakující se události na jejich jednotlivé instance"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "Pokud je `True`, opakující se události se rozvinou na jednotlivé instance a vráceny jsou pouze jednorázové události a instance opakujících se událostí, nikoli samotné opakující se události. Pokud je `False`, každá opakující se událost je vrácena jednou s pravidlem opakování místo svých instancí. Musí být `True`, aby bylo možné výsledek seřadit podle času začátku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "Řadit podle"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "Pořadí událostí vrácených ve výsledku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "Pořadí událostí vrácených ve výsledku; výchozí je nespecifikované, stabilní pořadí.\nPřijatelné hodnoty jsou:\n- `startTime`: Řadit podle data/času začátku (vzestupně); k dispozici pouze tehdy, když je `singleEvents` `True`\n- `updated`: Řadit podle času poslední změny (vzestupně)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "Řadit podle data/času začátku (vzestupně); k dispozici pouze tehdy, když je `singleEvents` `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "Řadit podle času poslední změny (vzestupně)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "Hledané výrazy"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "Fulltextové hledané výrazy pro nalezení odpovídajících událostí"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "Fulltextové hledané výrazy pro nalezení událostí, které těmto výrazům odpovídají v polích `summary`, `description` a `location`, v zobrazovaných jménech a e-mailových adresách účastníků a organizátorů a ve vlastnostech pracovního místa"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token stránky"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token určující, která stránka výsledků se má vrátit"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token určující, která stránka výsledků se má vrátit; pro načtení další stránky použijte hodnotu `nextPageToken` z předchozí odpovědi"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "Zobrazit smazané"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "Zahrnout smazané události do výsledku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "Pokud je `True`, jsou do výsledku zahrnuty smazané události (se `status` rovným `cancelled`). Zrušené instance opakujících se událostí (nikoli však samotná opakující se událost) jsou zahrnuty i tehdy, když jsou `showDeleted` i `singleEvents` obě `False`; pokud jsou obě `True`, vráceny jsou pouze jednotlivé instance smazaných událostí. Výchozí hodnota je `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "Získat událost"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "Načíst událost z kalendáře"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "Načíst jednu událost z kalendáře podle jejího ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Kalendář"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "Kalendář obsahující událost"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "Kalendář obsahující událost"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "ID události"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "ID události, která se má načíst"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "ID události, která se má načíst; ID událostí jsou vracena v poli `id` událostí vrácených akcí `list-events`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "Vypsat kalendáře"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "Vypsat kalendáře v seznamu kalendářů uživatele"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "Vypsat kalendáře v seznamu kalendářů ověřeného uživatele; `id` každé položky lze použít jako kalendář pro akce s událostmi"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maximální počet výsledků"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "Maximální počet kalendářů vrácených na jedné stránce výsledků"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "Maximální počet položek seznamu kalendářů vrácených na jedné stránce výsledků; neúplné stránky lze rozpoznat podle neprázdného pole `nextPageToken` v odpovědi. Výchozí hodnota je `100`; velikost stránky nikdy nemůže být větší než `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token stránky"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token určující, která stránka výsledků se má vrátit"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token určující, která stránka výsledků se má vrátit; pro načtení další stránky použijte hodnotu `nextPageToken` z předchozí odpovědi"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "Zobrazit skryté"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "Zahrnout skryté položky seznamu kalendářů do výsledku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "Pokud je `True`, jsou do výsledku zahrnuty skryté položky seznamu kalendářů. Výchozí hodnota je `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/de.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/de.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "Der Kalender, zu dem der Termin hinzugefügt werden soll"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "Termine auflisten"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "Termine in einem Kalender auflisten"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "Termine in einem Kalender auflisten; das Ergebnis kann auf ein Zeitfenster eingeschränkt, mit Freitext-Suchbegriffen gefiltert und mit `maxResults` und `pageToken` seitenweise abgerufen werden"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Kalender"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "Der Kalender, dessen Termine aufgelistet werden sollen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "Der Kalender, dessen Termine aufgelistet werden sollen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "Startzeit"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "Nur Termine zurückgeben, die nach diesem Zeitpunkt enden"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "Untere Grenze (exklusiv) für die Endzeit eines Termins; es werden nur Termine zurückgegeben, die nach diesem Zeitpunkt enden. Standardmäßig wird nicht nach Endzeit gefiltert"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "Endzeit"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "Nur Termine zurückgeben, die vor diesem Zeitpunkt beginnen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "Obere Grenze (exklusiv) für die Startzeit eines Termins; es werden nur Termine zurückgegeben, die vor diesem Zeitpunkt beginnen. Standardmäßig wird nicht nach Startzeit gefiltert"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maximale Ergebnisse"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "Die maximale Anzahl von Terminen, die auf einer Ergebnisseite zurückgegeben werden"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "Die maximale Anzahl von Terminen, die auf einer Ergebnisseite zurückgegeben werden; die Seite kann weniger Termine als diesen Wert oder gar keine enthalten, auch wenn weitere Termine der Abfrage entsprechen. Unvollständige Seiten sind an einem nicht leeren Feld `nextPageToken` in der Antwort erkennbar. Der Standardwert ist `250`; die Seitengröße kann nie größer als `2500` sein"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "Wiederkehrende Termine auflösen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "Wiederkehrende Termine in ihre einzelnen Instanzen auflösen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "Wenn `True`, werden wiederkehrende Termine in ihre einzelnen Instanzen aufgelöst, und es werden nur einmalige Termine und Instanzen wiederkehrender Termine zurückgegeben, nicht aber die zugrunde liegenden wiederkehrenden Termine selbst. Wenn `False`, wird jeder wiederkehrende Termin einmal mit seiner Wiederholungsregel anstelle seiner Instanzen zurückgegeben. Muss `True` sein, um das Ergebnis nach Startzeit zu sortieren"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "Sortieren nach"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "Die Reihenfolge der im Ergebnis zurückgegebenen Termine"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "Die Reihenfolge der im Ergebnis zurückgegebenen Termine; standardmäßig ist die Reihenfolge unspezifiziert, aber stabil.\nZulässige Werte sind:\n- `startTime`: Nach Startdatum/-zeit sortieren (aufsteigend); nur verfügbar, wenn `singleEvents` `True` ist\n- `updated`: Nach dem Zeitpunkt der letzten Änderung sortieren (aufsteigend)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "Nach Startdatum/-zeit sortieren (aufsteigend); nur verfügbar, wenn `singleEvents` `True` ist"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "Nach dem Zeitpunkt der letzten Änderung sortieren (aufsteigend)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "Suchbegriffe"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "Freitext-Suchbegriffe zum Finden passender Termine"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "Freitext-Suchbegriffe zum Finden von Terminen, die diesen Begriffen in den Feldern `summary`, `description` und `location`, in den Anzeigenamen und E-Mail-Adressen von Teilnehmern und Organisatoren sowie in den Arbeitsort-Eigenschaften entsprechen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Seiten-Token"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token, das angibt, welche Ergebnisseite zurückgegeben werden soll"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token, das angibt, welche Ergebnisseite zurückgegeben werden soll; verwenden Sie den Wert `nextPageToken` aus der vorherigen Antwort, um die nächste Seite abzurufen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "Gelöschte anzeigen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "Gelöschte Termine in das Ergebnis einbeziehen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "Wenn `True`, werden gelöschte Termine (mit `status` gleich `cancelled`) in das Ergebnis einbezogen. Abgesagte Instanzen wiederkehrender Termine (nicht aber der zugrunde liegende wiederkehrende Termin) werden weiterhin einbezogen, wenn `showDeleted` und `singleEvents` beide `False` sind; wenn beide `True` sind, werden nur einzelne Instanzen gelöschter Termine zurückgegeben. Der Standardwert ist `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "Termin abrufen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "Einen Termin aus einem Kalender abrufen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "Einen einzelnen Termin anhand seiner Termin-ID aus einem Kalender abrufen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Kalender"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "Der Kalender, der den Termin enthält"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "Der Kalender, der den Termin enthält"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "Termin-ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "Die ID des abzurufenden Termins"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "Die ID des abzurufenden Termins; Termin-IDs werden im Feld `id` der von der Aktion `list-events` zurückgegebenen Termine zurückgegeben"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "Kalender auflisten"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "Die Kalender in der Kalenderliste des Benutzers auflisten"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "Die Kalender in der Kalenderliste des authentifizierten Benutzers auflisten; die `id` jedes Eintrags kann als Kalender für die Terminaktionen verwendet werden"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maximale Ergebnisse"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "Die maximale Anzahl von Kalendern, die auf einer Ergebnisseite zurückgegeben werden"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "Die maximale Anzahl von Kalenderlisteneinträgen, die auf einer Ergebnisseite zurückgegeben werden; unvollständige Seiten sind an einem nicht leeren Feld `nextPageToken` in der Antwort erkennbar. Der Standardwert ist `100`; die Seitengröße kann nie größer als `250` sein"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Seiten-Token"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token, das angibt, welche Ergebnisseite zurückgegeben werden soll"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token, das angibt, welche Ergebnisseite zurückgegeben werden soll; verwenden Sie den Wert `nextPageToken` aus der vorherigen Antwort, um die nächste Seite abzurufen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "Ausgeblendete anzeigen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "Ausgeblendete Kalenderlisteneinträge in das Ergebnis einbeziehen"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "Wenn `True`, werden ausgeblendete Kalenderlisteneinträge in das Ergebnis einbezogen. Der Standardwert ist `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/es.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/es.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "El calendario al que se añadirá el evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "Listar eventos"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "Listar los eventos de un calendario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "Listar los eventos de un calendario; el resultado se puede restringir a un intervalo de tiempo, filtrar con términos de búsqueda de texto libre y paginar con `maxResults` y `pageToken`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Calendario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "El calendario del que se listan los eventos"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "El calendario del que se listan los eventos"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "Hora de inicio"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "Devolver solo los eventos que terminan después de esta hora"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "Límite inferior (exclusivo) de la hora de finalización de un evento; solo se devuelven los eventos que terminan después de esta hora. De forma predeterminada no se filtra por hora de finalización"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "Hora de finalización"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "Devolver solo los eventos que empiezan antes de esta hora"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "Límite superior (exclusivo) de la hora de inicio de un evento; solo se devuelven los eventos que empiezan antes de esta hora. De forma predeterminada no se filtra por hora de inicio"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Resultados máximos"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "El número máximo de eventos que se devuelven en una página de resultados"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "El número máximo de eventos que se devuelven en una página de resultados; la página puede contener menos eventos que este valor, o ninguno, aunque haya más eventos que coincidan con la consulta. Las páginas incompletas se pueden detectar por un campo `nextPageToken` no vacío en la respuesta. El valor predeterminado es `250`; el tamaño de página nunca puede ser mayor que `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "Expandir eventos periódicos"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "Expandir los eventos periódicos en sus instancias individuales"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "Si es `True`, los eventos periódicos se expanden en sus instancias individuales y solo se devuelven los eventos únicos y las instancias de los eventos periódicos, pero no los propios eventos periódicos subyacentes. Si es `False`, cada evento periódico se devuelve una sola vez con su regla de periodicidad en lugar de sus instancias. Debe ser `True` para ordenar el resultado por hora de inicio"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "Ordenar por"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "El orden de los eventos devueltos en el resultado"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "El orden de los eventos devueltos en el resultado; el orden predeterminado es un orden estable no especificado.\nLos valores aceptables son:\n- `startTime`: Ordenar por fecha/hora de inicio (ascendente); solo está disponible cuando `singleEvents` es `True`\n- `updated`: Ordenar por hora de la última modificación (ascendente)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "Ordenar por fecha/hora de inicio (ascendente); solo está disponible cuando `singleEvents` es `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "Ordenar por hora de la última modificación (ascendente)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "Términos de búsqueda"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "Términos de búsqueda de texto libre para encontrar eventos coincidentes"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "Términos de búsqueda de texto libre para encontrar eventos que coincidan con estos términos en los campos `summary`, `description` y `location`, en los nombres visibles y direcciones de correo electrónico de los asistentes y organizadores, y en las propiedades de la ubicación de trabajo"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token de página"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token que especifica qué página de resultados se debe devolver"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token que especifica qué página de resultados se debe devolver; use el valor `nextPageToken` de la respuesta anterior para recuperar la página siguiente"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "Mostrar eliminados"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "Incluir los eventos eliminados en el resultado"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "Si es `True`, los eventos eliminados (con `status` igual a `cancelled`) se incluyen en el resultado. Las instancias canceladas de eventos periódicos (pero no el evento periódico subyacente) se siguen incluyendo si `showDeleted` y `singleEvents` son ambos `False`; si ambos son `True`, solo se devuelven las instancias individuales de los eventos eliminados. El valor predeterminado es `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "Obtener evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "Recuperar un evento de un calendario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "Recuperar un único evento de un calendario por su ID de evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Calendario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "El calendario que contiene el evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "El calendario que contiene el evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "ID del evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "El ID del evento que se va a recuperar"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "El ID del evento que se va a recuperar; los ID de los eventos se devuelven en el campo `id` de los eventos devueltos por la acción `list-events`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "Listar calendarios"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "Listar los calendarios de la lista de calendarios del usuario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "Listar los calendarios de la lista de calendarios del usuario autenticado; el `id` de cada entrada se puede usar como calendario para las acciones de eventos"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Resultados máximos"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "El número máximo de calendarios que se devuelven en una página de resultados"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "El número máximo de entradas de la lista de calendarios que se devuelven en una página de resultados; las páginas incompletas se pueden detectar por un campo `nextPageToken` no vacío en la respuesta. El valor predeterminado es `100`; el tamaño de página nunca puede ser mayor que `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token de página"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token que especifica qué página de resultados se debe devolver"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token que especifica qué página de resultados se debe devolver; use el valor `nextPageToken` de la respuesta anterior para recuperar la página siguiente"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "Mostrar ocultos"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "Incluir las entradas ocultas de la lista de calendarios en el resultado"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "Si es `True`, las entradas ocultas de la lista de calendarios se incluyen en el resultado. El valor predeterminado es `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/fr.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/fr.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "L'agenda auquel ajouter l'événement"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "Lister les événements"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "Lister les événements d'un agenda"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "Lister les événements d'un agenda ; le résultat peut être restreint à une fenêtre temporelle, filtré par des termes de recherche en texte libre et paginé avec `maxResults` et `pageToken`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Calendrier"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "L'agenda dont les événements doivent être listés"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "L'agenda dont les événements doivent être listés"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "Heure de début"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "Ne renvoyer que les événements qui se terminent après cette heure"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "Borne inférieure (exclusive) de l'heure de fin d'un événement ; seuls les événements qui se terminent après cette heure sont renvoyés. Par défaut, aucun filtre n'est appliqué sur l'heure de fin"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "Heure de fin"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "Ne renvoyer que les événements qui commencent avant cette heure"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "Borne supérieure (exclusive) de l'heure de début d'un événement ; seuls les événements qui commencent avant cette heure sont renvoyés. Par défaut, aucun filtre n'est appliqué sur l'heure de début"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Nombre maximal de résultats"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "Le nombre maximal d'événements à renvoyer sur une page de résultats"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "Le nombre maximal d'événements à renvoyer sur une page de résultats ; la page peut contenir moins d'événements que cette valeur, voire aucun, même si d'autres événements correspondent à la requête. Les pages incomplètes se reconnaissent à un champ `nextPageToken` non vide dans la réponse. La valeur par défaut est `250` ; la taille de page ne peut jamais dépasser `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "Développer les événements récurrents"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "Développer les événements récurrents en leurs occurrences individuelles"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "Si `True`, les événements récurrents sont développés en leurs occurrences individuelles, et seuls les événements ponctuels et les occurrences d'événements récurrents sont renvoyés, mais pas les événements récurrents sous-jacents eux-mêmes. Si `False`, chaque événement récurrent est renvoyé une seule fois avec sa règle de récurrence au lieu de ses occurrences. Doit être `True` pour trier le résultat par heure de début"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "Trier par"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "L'ordre des événements renvoyés dans le résultat"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "L'ordre des événements renvoyés dans le résultat ; par défaut, l'ordre est stable mais non spécifié.\nLes valeurs acceptables sont :\n- `startTime` : Trier par date/heure de début (croissant) ; disponible uniquement lorsque `singleEvents` est `True`\n- `updated` : Trier par heure de dernière modification (croissant)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "Trier par date/heure de début (croissant) ; disponible uniquement lorsque `singleEvents` est `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "Trier par heure de dernière modification (croissant)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "Termes de recherche"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "Termes de recherche en texte libre pour trouver les événements correspondants"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "Termes de recherche en texte libre pour trouver les événements correspondant à ces termes dans les champs `summary`, `description` et `location`, dans les noms affichés et adresses e-mail des participants et des organisateurs, ainsi que dans les propriétés de lieu de travail"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Jeton de page"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Jeton indiquant la page de résultats à renvoyer"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Jeton indiquant la page de résultats à renvoyer ; utilisez la valeur `nextPageToken` de la réponse précédente pour récupérer la page suivante"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "Afficher les supprimés"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "Inclure les événements supprimés dans le résultat"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "Si `True`, les événements supprimés (dont le `status` vaut `cancelled`) sont inclus dans le résultat. Les occurrences annulées d'événements récurrents (mais pas l'événement récurrent sous-jacent) restent incluses si `showDeleted` et `singleEvents` valent tous deux `False` ; si les deux valent `True`, seules les occurrences individuelles des événements supprimés sont renvoyées. La valeur par défaut est `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "Obtenir un événement"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "Récupérer un événement d'un agenda"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "Récupérer un seul événement d'un agenda à partir de son ID d'événement"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Calendrier"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "L'agenda contenant l'événement"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "L'agenda contenant l'événement"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "ID de l'événement"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "L'ID de l'événement à récupérer"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "L'ID de l'événement à récupérer ; les ID d'événements sont renvoyés dans le champ `id` des événements renvoyés par l'action `list-events`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "Lister les agendas"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "Lister les agendas de la liste d'agendas de l'utilisateur"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "Lister les agendas de la liste d'agendas de l'utilisateur authentifié ; l'`id` de chaque entrée peut être utilisé comme agenda pour les actions sur les événements"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Nombre maximal de résultats"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "Le nombre maximal d'agendas à renvoyer sur une page de résultats"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "Le nombre maximal d'entrées de la liste d'agendas à renvoyer sur une page de résultats ; les pages incomplètes se reconnaissent à un champ `nextPageToken` non vide dans la réponse. La valeur par défaut est `100` ; la taille de page ne peut jamais dépasser `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Jeton de page"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Jeton indiquant la page de résultats à renvoyer"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Jeton indiquant la page de résultats à renvoyer ; utilisez la valeur `nextPageToken` de la réponse précédente pour récupérer la page suivante"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "Afficher les masqués"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "Inclure les entrées masquées de la liste d'agendas dans le résultat"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "Si `True`, les entrées masquées de la liste d'agendas sont incluses dans le résultat. La valeur par défaut est `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/it.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/it.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "Il calendario a cui aggiungere l'evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "Elenca eventi"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "Elenca gli eventi di un calendario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "Elenca gli eventi di un calendario; il risultato può essere limitato a un intervallo di tempo, filtrato con termini di ricerca a testo libero e suddiviso in pagine con `maxResults` e `pageToken`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Calendario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "Il calendario di cui elencare gli eventi"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "Il calendario di cui elencare gli eventi"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "Ora di inizio"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "Restituisce solo gli eventi che terminano dopo questo orario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "Limite inferiore (esclusivo) per l'ora di fine di un evento; vengono restituiti solo gli eventi che terminano dopo questo orario. Per impostazione predefinita non viene applicato alcun filtro sull'ora di fine"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "Ora di fine"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "Restituisce solo gli eventi che iniziano prima di questo orario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "Limite superiore (esclusivo) per l'ora di inizio di un evento; vengono restituiti solo gli eventi che iniziano prima di questo orario. Per impostazione predefinita non viene applicato alcun filtro sull'ora di inizio"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Numero massimo di risultati"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "Il numero massimo di eventi da restituire in una pagina di risultati"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "Il numero massimo di eventi da restituire in una pagina di risultati; la pagina può contenere meno eventi di questo valore, o nessuno, anche se altri eventi corrispondono alla query. Le pagine incomplete si riconoscono da un campo `nextPageToken` non vuoto nella risposta. Il valore predefinito è `250`; la dimensione della pagina non può mai essere superiore a `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "Espandi eventi ricorrenti"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "Espande gli eventi ricorrenti nelle singole istanze"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "Se `True`, gli eventi ricorrenti vengono espansi nelle singole istanze e vengono restituiti solo gli eventi singoli e le istanze degli eventi ricorrenti, ma non gli eventi ricorrenti sottostanti. Se `False`, ogni evento ricorrente viene restituito una sola volta con la sua regola di ricorrenza anziché con le sue istanze. Deve essere `True` per ordinare il risultato per ora di inizio"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "Ordina per"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "L'ordine degli eventi restituiti nel risultato"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "L'ordine degli eventi restituiti nel risultato; per impostazione predefinita l'ordine è stabile ma non specificato.\nI valori accettabili sono:\n- `startTime`: Ordina per data/ora di inizio (crescente); disponibile solo quando `singleEvents` è `True`\n- `updated`: Ordina per ora dell'ultima modifica (crescente)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "Ordina per data/ora di inizio (crescente); disponibile solo quando `singleEvents` è `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "Ordina per ora dell'ultima modifica (crescente)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "Termini di ricerca"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "Termini di ricerca a testo libero per trovare gli eventi corrispondenti"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "Termini di ricerca a testo libero per trovare gli eventi che corrispondono a questi termini nei campi `summary`, `description` e `location`, nei nomi visualizzati e negli indirizzi e-mail di partecipanti e organizzatori e nelle proprietà della sede di lavoro"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token di pagina"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token che specifica quale pagina di risultati restituire"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token che specifica quale pagina di risultati restituire; usare il valore `nextPageToken` della risposta precedente per recuperare la pagina successiva"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "Mostra eliminati"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "Include gli eventi eliminati nel risultato"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "Se `True`, gli eventi eliminati (con `status` uguale a `cancelled`) vengono inclusi nel risultato. Le istanze annullate degli eventi ricorrenti (ma non l'evento ricorrente sottostante) vengono comunque incluse se `showDeleted` e `singleEvents` sono entrambi `False`; se sono entrambi `True`, vengono restituite solo le singole istanze degli eventi eliminati. Il valore predefinito è `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "Ottieni evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "Recupera un evento da un calendario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "Recupera un singolo evento da un calendario tramite il suo ID evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Calendario"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "Il calendario che contiene l'evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "Il calendario che contiene l'evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "ID evento"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "L'ID dell'evento da recuperare"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "L'ID dell'evento da recuperare; gli ID degli eventi vengono restituiti nel campo `id` degli eventi restituiti dall'azione `list-events`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "Elenca calendari"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "Elenca i calendari nell'elenco dei calendari dell'utente"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "Elenca i calendari nell'elenco dei calendari dell'utente autenticato; l'`id` di ogni voce può essere usato come calendario per le azioni sugli eventi"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Numero massimo di risultati"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "Il numero massimo di calendari da restituire in una pagina di risultati"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "Il numero massimo di voci dell'elenco dei calendari da restituire in una pagina di risultati; le pagine incomplete si riconoscono da un campo `nextPageToken` non vuoto nella risposta. Il valore predefinito è `100`; la dimensione della pagina non può mai essere superiore a `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token di pagina"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token che specifica quale pagina di risultati restituire"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token che specifica quale pagina di risultati restituire; usare il valore `nextPageToken` della risposta precedente per recuperare la pagina successiva"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "Mostra nascosti"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "Include le voci nascoste dell'elenco dei calendari nel risultato"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "Se `True`, le voci nascoste dell'elenco dei calendari vengono incluse nel risultato. Il valore predefinito è `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/ja.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/ja.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "予定を追加するカレンダー"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "イベントを一覧表示"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "カレンダーの予定を一覧表示します"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "カレンダーの予定を一覧表示します。結果は時間範囲で絞り込んだり、フリーテキストの検索語でフィルタしたり、`maxResults` と `pageToken` でページ分割したりできます"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "カレンダー"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "予定を一覧表示するカレンダー"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "予定を一覧表示するカレンダー"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "開始時刻"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "この時刻より後に終了する予定のみを返します"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "予定の終了時刻の下限（この値を含まない）。この時刻より後に終了する予定のみが返されます。デフォルトでは終了時刻によるフィルタは行われません"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "終了時刻"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "この時刻より前に開始する予定のみを返します"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "予定の開始時刻の上限（この値を含まない）。この時刻より前に開始する予定のみが返されます。デフォルトでは開始時刻によるフィルタは行われません"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "最大結果数"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "1 ページの結果として返す予定の最大数"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "1 ページの結果として返す予定の最大数。クエリに一致する予定がさらにあっても、ページに含まれる予定はこの値より少ないか、まったく含まれない場合があります。不完全なページは、レスポンスの `nextPageToken` フィールドが空でないことで検出できます。デフォルトは `250` で、ページサイズが `2500` を超えることはありません"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "繰り返しの予定を展開"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "繰り返しの予定を個々のインスタンスに展開します"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "`True` の場合、繰り返しの予定は個々のインスタンスに展開され、単発の予定と繰り返しの予定のインスタンスのみが返され、元になる繰り返しの予定自体は返されません。`False` の場合、各繰り返しの予定はインスタンスの代わりに繰り返しルールとともに 1 回だけ返されます。結果を開始時刻で並べ替えるには `True` である必要があります"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "並べ替え順"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "結果として返される予定の順序"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "結果として返される予定の順序。デフォルトは未指定の安定した順序です。\n指定可能な値:\n- `startTime`: 開始日時で並べ替え（昇順）。`singleEvents` が `True` の場合にのみ使用できます\n- `updated`: 最終更新時刻で並べ替え（昇順）"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "開始日時で並べ替え（昇順）。`singleEvents` が `True` の場合にのみ使用できます"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "最終更新時刻で並べ替え（昇順）"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "検索語"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "一致する予定を検索するためのフリーテキストの検索語"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "`summary`、`description`、`location` の各フィールド、参加者と主催者の表示名およびメールアドレス、勤務場所のプロパティでこれらの語に一致する予定を検索するためのフリーテキストの検索語"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "ページトークン"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "返す結果ページを指定するトークン"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "返す結果ページを指定するトークン。次のページを取得するには、前のレスポンスの `nextPageToken` の値を使用します"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "削除済みを表示"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "削除された予定を結果に含めます"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "`True` の場合、削除された予定（`status` が `cancelled` のもの）が結果に含まれます。繰り返しの予定のキャンセルされたインスタンス（元になる繰り返しの予定は除く）は、`showDeleted` と `singleEvents` がどちらも `False` の場合でも含まれます。どちらも `True` の場合は、削除された予定の個々のインスタンスのみが返されます。デフォルトは `False` です"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "イベントを取得"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "カレンダーから予定を取得します"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "予定 ID を指定してカレンダーから 1 件の予定を取得します"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "カレンダー"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "予定を含むカレンダー"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "予定を含むカレンダー"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "予定 ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "取得する予定の ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "取得する予定の ID。予定 ID は、`list-events` アクションが返す予定の `id` フィールドで返されます"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "カレンダーを一覧表示"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "ユーザーのカレンダーリストにあるカレンダーを一覧表示します"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "認証済みユーザーのカレンダーリストにあるカレンダーを一覧表示します。各エントリの `id` は、予定に関するアクションのカレンダーとして使用できます"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "最大結果数"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "1 ページの結果として返すカレンダーの最大数"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "1 ページの結果として返すカレンダーリストのエントリの最大数。不完全なページは、レスポンスの `nextPageToken` フィールドが空でないことで検出できます。デフォルトは `100` で、ページサイズが `250` を超えることはありません"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "ページトークン"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "返す結果ページを指定するトークン"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "返す結果ページを指定するトークン。次のページを取得するには、前のレスポンスの `nextPageToken` の値を使用します"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "非表示を表示"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "非表示のカレンダーリストのエントリを結果に含めます"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "`True` の場合、非表示のカレンダーリストのエントリが結果に含まれます。デフォルトは `False` です"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/ko.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/ko.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "일정을 추가할 캘린더"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "이벤트 나열"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "캘린더의 일정을 나열합니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "캘린더의 일정을 나열합니다. 결과는 시간 범위로 제한하거나, 자유 텍스트 검색어로 필터링하거나, `maxResults`와 `pageToken`으로 페이지를 나눌 수 있습니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "캘린더"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "일정을 나열할 캘린더"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "일정을 나열할 캘린더"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "시작 시간"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "이 시간 이후에 끝나는 일정만 반환합니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "일정 종료 시간의 하한(해당 값 제외)입니다. 이 시간 이후에 끝나는 일정만 반환됩니다. 기본적으로 종료 시간으로 필터링하지 않습니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "종료 시간"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "이 시간 이전에 시작하는 일정만 반환합니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "일정 시작 시간의 상한(해당 값 제외)입니다. 이 시간 이전에 시작하는 일정만 반환됩니다. 기본적으로 시작 시간으로 필터링하지 않습니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "최대 결과 수"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "한 결과 페이지에 반환할 최대 일정 수"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "한 결과 페이지에 반환할 최대 일정 수입니다. 쿼리와 일치하는 일정이 더 있더라도 페이지에는 이 값보다 적은 일정이 포함되거나 아예 포함되지 않을 수 있습니다. 불완전한 페이지는 응답의 `nextPageToken` 필드가 비어 있지 않은 것으로 감지할 수 있습니다. 기본값은 `250`이며 페이지 크기는 `2500`을 초과할 수 없습니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "반복 일정 펼치기"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "반복 일정을 개별 인스턴스로 펼칩니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "`True`이면 반복 일정이 개별 인스턴스로 펼쳐지고, 단일 일정과 반복 일정의 인스턴스만 반환되며 기본 반복 일정 자체는 반환되지 않습니다. `False`이면 각 반복 일정이 인스턴스 대신 반복 규칙과 함께 한 번만 반환됩니다. 결과를 시작 시간으로 정렬하려면 `True`여야 합니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "정렬 기준"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "결과에 반환되는 일정의 순서"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "결과에 반환되는 일정의 순서입니다. 기본값은 지정되지 않은 안정적인 순서입니다.\n허용되는 값:\n- `startTime`: 시작 날짜/시간 기준 정렬(오름차순). `singleEvents`가 `True`인 경우에만 사용할 수 있습니다\n- `updated`: 마지막 수정 시간 기준 정렬(오름차순)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "시작 날짜/시간 기준 정렬(오름차순). `singleEvents`가 `True`인 경우에만 사용할 수 있습니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "마지막 수정 시간 기준 정렬(오름차순)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "검색어"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "일치하는 일정을 찾기 위한 자유 텍스트 검색어"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "`summary`, `description`, `location` 필드, 참석자와 주최자의 표시 이름 및 이메일 주소, 근무 위치 속성에서 이 검색어와 일치하는 일정을 찾기 위한 자유 텍스트 검색어"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "페이지 토큰"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "반환할 결과 페이지를 지정하는 토큰"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "반환할 결과 페이지를 지정하는 토큰입니다. 다음 페이지를 가져오려면 이전 응답의 `nextPageToken` 값을 사용하세요"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "삭제된 항목 표시"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "삭제된 일정을 결과에 포함합니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "`True`이면 삭제된 일정(`status`가 `cancelled`인 일정)이 결과에 포함됩니다. 반복 일정의 취소된 인스턴스(기본 반복 일정은 제외)는 `showDeleted`와 `singleEvents`가 모두 `False`인 경우에도 계속 포함됩니다. 둘 다 `True`이면 삭제된 일정의 개별 인스턴스만 반환됩니다. 기본값은 `False`입니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "이벤트 가져오기"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "캘린더에서 일정을 가져옵니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "일정 ID로 캘린더에서 단일 일정을 가져옵니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "캘린더"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "일정이 포함된 캘린더"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "일정이 포함된 캘린더"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "일정 ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "가져올 일정의 ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "가져올 일정의 ID입니다. 일정 ID는 `list-events` 액션이 반환하는 일정의 `id` 필드에 반환됩니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "캘린더 나열"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "사용자의 캘린더 목록에 있는 캘린더를 나열합니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "인증된 사용자의 캘린더 목록에 있는 캘린더를 나열합니다. 각 항목의 `id`는 일정 액션의 캘린더로 사용할 수 있습니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "최대 결과 수"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "한 결과 페이지에 반환할 최대 캘린더 수"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "한 결과 페이지에 반환할 캘린더 목록 항목의 최대 수입니다. 불완전한 페이지는 응답의 `nextPageToken` 필드가 비어 있지 않은 것으로 감지할 수 있습니다. 기본값은 `100`이며 페이지 크기는 `250`을 초과할 수 없습니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "페이지 토큰"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "반환할 결과 페이지를 지정하는 토큰"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "반환할 결과 페이지를 지정하는 토큰입니다. 다음 페이지를 가져오려면 이전 응답의 `nextPageToken` 값을 사용하세요"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "숨겨진 항목 표시"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "숨겨진 캘린더 목록 항목을 결과에 포함합니다"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "`True`이면 숨겨진 캘린더 목록 항목이 결과에 포함됩니다. 기본값은 `False`입니다"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/pl.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/pl.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "Kalendarz, do którego ma zostać dodane wydarzenie"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "Wyświetl wydarzenia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "Wyświetl wydarzenia w kalendarzu"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "Wyświetl wydarzenia w kalendarzu; wynik można ograniczyć do przedziału czasu, filtrować dowolnym tekstem wyszukiwania i stronicować za pomocą `maxResults` i `pageToken`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Kalendarz"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "Kalendarz, z którego mają zostać wyświetlone wydarzenia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "Kalendarz, z którego mają zostać wyświetlone wydarzenia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "Czas rozpoczęcia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "Zwracaj tylko wydarzenia kończące się po tym czasie"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "Dolna granica (wyłączna) czasu zakończenia wydarzenia; zwracane są tylko wydarzenia kończące się po tym czasie. Domyślnie nie filtruje się według czasu zakończenia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "Czas zakończenia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "Zwracaj tylko wydarzenia rozpoczynające się przed tym czasem"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "Górna granica (wyłączna) czasu rozpoczęcia wydarzenia; zwracane są tylko wydarzenia rozpoczynające się przed tym czasem. Domyślnie nie filtruje się według czasu rozpoczęcia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maksymalna liczba wyników"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "Maksymalna liczba wydarzeń zwracanych na jednej stronie wyników"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "Maksymalna liczba wydarzeń zwracanych na jednej stronie wyników; strona może zawierać mniej wydarzeń niż ta wartość lub żadnego, nawet jeśli więcej wydarzeń pasuje do zapytania. Niepełne strony można rozpoznać po niepustym polu `nextPageToken` w odpowiedzi. Wartość domyślna to `250`; rozmiar strony nigdy nie może przekroczyć `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "Rozwiń wydarzenia cykliczne"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "Rozwiń wydarzenia cykliczne na ich poszczególne wystąpienia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "Jeśli `True`, wydarzenia cykliczne są rozwijane na poszczególne wystąpienia i zwracane są tylko wydarzenia jednorazowe oraz wystąpienia wydarzeń cyklicznych, ale nie same bazowe wydarzenia cykliczne. Jeśli `False`, każde wydarzenie cykliczne jest zwracane raz z regułą cykliczności zamiast wystąpień. Musi mieć wartość `True`, aby posortować wynik według czasu rozpoczęcia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "Sortuj według"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "Kolejność wydarzeń zwracanych w wyniku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "Kolejność wydarzeń zwracanych w wyniku; domyślnie jest to nieokreślona, stabilna kolejność.\nDopuszczalne wartości:\n- `startTime`: Sortuj według daty/czasu rozpoczęcia (rosnąco); dostępne tylko wtedy, gdy `singleEvents` ma wartość `True`\n- `updated`: Sortuj według czasu ostatniej modyfikacji (rosnąco)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "Sortuj według daty/czasu rozpoczęcia (rosnąco); dostępne tylko wtedy, gdy `singleEvents` ma wartość `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "Sortuj według czasu ostatniej modyfikacji (rosnąco)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "Wyszukiwane hasła"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "Dowolny tekst wyszukiwania do znalezienia pasujących wydarzeń"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "Dowolny tekst wyszukiwania do znalezienia wydarzeń pasujących do tych haseł w polach `summary`, `description` i `location`, w wyświetlanych nazwach i adresach e-mail uczestników i organizatorów oraz we właściwościach miejsca pracy"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token strony"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token określający, którą stronę wyników zwrócić"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token określający, którą stronę wyników zwrócić; aby pobrać następną stronę, użyj wartości `nextPageToken` z poprzedniej odpowiedzi"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "Pokaż usunięte"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "Uwzględnij usunięte wydarzenia w wyniku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "Jeśli `True`, usunięte wydarzenia (ze `status` równym `cancelled`) są uwzględniane w wyniku. Odwołane wystąpienia wydarzeń cyklicznych (ale nie bazowe wydarzenie cykliczne) są nadal uwzględniane, jeśli `showDeleted` i `singleEvents` mają obie wartość `False`; jeśli obie mają wartość `True`, zwracane są tylko pojedyncze wystąpienia usuniętych wydarzeń. Wartość domyślna to `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "Pobierz wydarzenie"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "Pobierz wydarzenie z kalendarza"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "Pobierz pojedyncze wydarzenie z kalendarza na podstawie jego identyfikatora"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Kalendarz"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "Kalendarz zawierający wydarzenie"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "Kalendarz zawierający wydarzenie"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "Identyfikator wydarzenia"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "Identyfikator wydarzenia do pobrania"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "Identyfikator wydarzenia do pobrania; identyfikatory wydarzeń są zwracane w polu `id` wydarzeń zwracanych przez akcję `list-events`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "Wyświetl kalendarze"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "Wyświetl kalendarze z listy kalendarzy użytkownika"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "Wyświetl kalendarze z listy kalendarzy uwierzytelnionego użytkownika; `id` każdego wpisu można użyć jako kalendarza w akcjach dotyczących wydarzeń"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maksymalna liczba wyników"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "Maksymalna liczba kalendarzy zwracanych na jednej stronie wyników"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "Maksymalna liczba wpisów listy kalendarzy zwracanych na jednej stronie wyników; niepełne strony można rozpoznać po niepustym polu `nextPageToken` w odpowiedzi. Wartość domyślna to `100`; rozmiar strony nigdy nie może przekroczyć `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token strony"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token określający, którą stronę wyników zwrócić"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token określający, którą stronę wyników zwrócić; aby pobrać następną stronę, użyj wartości `nextPageToken` z poprzedniej odpowiedzi"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "Pokaż ukryte"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "Uwzględnij ukryte wpisy listy kalendarzy w wyniku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "Jeśli `True`, ukryte wpisy listy kalendarzy są uwzględniane w wyniku. Wartość domyślna to `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/root.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/root.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "The calendar to add the event to"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "List Events"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "List events in a calendar"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Calendar"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "The calendar to list events from"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "The calendar to list events from"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "Start Time"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "Only return events that end after this time"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "End Time"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "Only return events that start before this time"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maximum Results"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "The maximum number of events to return on one result page"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "Expand Recurring Events"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "Expand recurring events into their individual instances"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "Order By"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "The order of the events returned in the result"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "Order by last modification time (ascending)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "Search Terms"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "Free-text search terms to find matching events"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Page Token"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token specifying which result page to return"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "Show Deleted"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "Include deleted events in the result"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "Get Event"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "Retrieve an event from a calendar"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "Retrieve a single event from a calendar by its event ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Calendar"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "The calendar containing the event"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "The calendar containing the event"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "Event ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "The ID of the event to retrieve"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "List Calendars"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "List the calendars in the user's calendar list"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maximum Results"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "The maximum number of calendars to return on one result page"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Page Token"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token specifying which result page to return"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "Show Hidden"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "Include hidden calendar list entries in the result"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "If `True`, hidden calendar list entries are included in the result. The default is `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/sk.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/sk.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "Kalendár, do ktorého sa má udalosť pridať"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "Zobraziť udalosti"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "Zobraziť udalosti v kalendári"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "Zobraziť udalosti v kalendári; výsledok možno obmedziť na časové okno, filtrovať fulltextovými hľadanými výrazmi a stránkovať pomocou `maxResults` a `pageToken`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Kalendár"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "Kalendár, z ktorého sa majú zobraziť udalosti"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "Kalendár, z ktorého sa majú zobraziť udalosti"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "Čas začiatku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "Vrátiť iba udalosti, ktoré sa končia po tomto čase"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "Dolná hranica (exkluzívna) času konca udalosti; vrátené sú iba udalosti, ktoré sa končia po tomto čase. Predvolene sa podľa času konca nefiltruje"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "Čas konca"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "Vrátiť iba udalosti, ktoré sa začínajú pred týmto časom"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "Horná hranica (exkluzívna) času začiatku udalosti; vrátené sú iba udalosti, ktoré sa začínajú pred týmto časom. Predvolene sa podľa času začiatku nefiltruje"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maximálny počet výsledkov"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "Maximálny počet udalostí vrátených na jednej stránke výsledkov"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "Maximálny počet udalostí vrátených na jednej stránke výsledkov; stránka môže obsahovať menej udalostí ako táto hodnota alebo žiadne, aj keď dopytu zodpovedá viac udalostí. Neúplné stránky možno rozpoznať podľa neprázdneho poľa `nextPageToken` v odpovedi. Predvolená hodnota je `250`; veľkosť stránky nikdy nemôže byť väčšia ako `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "Rozvinúť opakujúce sa udalosti"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "Rozvinúť opakujúce sa udalosti na ich jednotlivé inštancie"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "Ak je `True`, opakujúce sa udalosti sa rozvinú na jednotlivé inštancie a vrátené sú iba jednorazové udalosti a inštancie opakujúcich sa udalostí, nie samotné opakujúce sa udalosti. Ak je `False`, každá opakujúca sa udalosť je vrátená raz s pravidlom opakovania namiesto svojich inštancií. Musí byť `True`, aby bolo možné výsledok zoradiť podľa času začiatku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "Zoradiť podľa"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "Poradie udalostí vrátených vo výsledku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "Poradie udalostí vrátených vo výsledku; predvolené je nešpecifikované, stabilné poradie.\nPrijateľné hodnoty sú:\n- `startTime`: Zoradiť podľa dátumu/času začiatku (vzostupne); k dispozícii iba vtedy, keď je `singleEvents` `True`\n- `updated`: Zoradiť podľa času poslednej zmeny (vzostupne)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "Zoradiť podľa dátumu/času začiatku (vzostupne); k dispozícii iba vtedy, keď je `singleEvents` `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "Zoradiť podľa času poslednej zmeny (vzostupne)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "Hľadané výrazy"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "Fulltextové hľadané výrazy na nájdenie zodpovedajúcich udalostí"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "Fulltextové hľadané výrazy na nájdenie udalostí, ktoré týmto výrazom zodpovedajú v poliach `summary`, `description` a `location`, v zobrazovaných menách a e-mailových adresách účastníkov a organizátorov a vo vlastnostiach pracovného miesta"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token stránky"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token určujúci, ktorá stránka výsledkov sa má vrátiť"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token určujúci, ktorá stránka výsledkov sa má vrátiť; na načítanie ďalšej stránky použite hodnotu `nextPageToken` z predchádzajúcej odpovede"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "Zobraziť odstránené"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "Zahrnúť odstránené udalosti do výsledku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "Ak je `True`, do výsledku sú zahrnuté odstránené udalosti (so `status` rovným `cancelled`). Zrušené inštancie opakujúcich sa udalostí (nie však samotná opakujúca sa udalosť) sú zahrnuté aj vtedy, keď sú `showDeleted` aj `singleEvents` obe `False`; ak sú obe `True`, vrátené sú iba jednotlivé inštancie odstránených udalostí. Predvolená hodnota je `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "Získať udalosť"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "Načítať udalosť z kalendára"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "Načítať jednu udalosť z kalendára podľa jej ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Kalendár"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "Kalendár obsahujúci udalosť"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "Kalendár obsahujúci udalosť"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "ID udalosti"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "ID udalosti, ktorá sa má načítať"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "ID udalosti, ktorá sa má načítať; ID udalostí sú vracané v poli `id` udalostí vrátených akciou `list-events`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "Zobraziť kalendáre"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "Zobraziť kalendáre v zozname kalendárov používateľa"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "Zobraziť kalendáre v zozname kalendárov overeného používateľa; `id` každej položky možno použiť ako kalendár pre akcie s udalosťami"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Maximálny počet výsledkov"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "Maximálny počet kalendárov vrátených na jednej stránke výsledkov"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "Maximálny počet položiek zoznamu kalendárov vrátených na jednej stránke výsledkov; neúplné stránky možno rozpoznať podľa neprázdneho poľa `nextPageToken` v odpovedi. Predvolená hodnota je `100`; veľkosť stránky nikdy nemôže byť väčšia ako `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Token stránky"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Token určujúci, ktorá stránka výsledkov sa má vrátiť"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Token určujúci, ktorá stránka výsledkov sa má vrátiť; na načítanie ďalšej stránky použite hodnotu `nextPageToken` z predchádzajúcej odpovede"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "Zobraziť skryté"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "Zahrnúť skryté položky zoznamu kalendárov do výsledku"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "Ak je `True`, do výsledku sú zahrnuté skryté položky zoznamu kalendárov. Predvolená hodnota je `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/uk.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/uk.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "Календар, до якого слід додати подію"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "Перелічити події"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "Перелічити події в календарі"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "Перелічити події в календарі; результат можна обмежити часовим проміжком, відфільтрувати за довільними пошуковими термінами та розбити на сторінки за допомогою `maxResults` і `pageToken`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Календар"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "Календар, з якого потрібно перелічити події"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "Календар, з якого потрібно перелічити події"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "Час початку"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "Повертати лише події, які закінчуються після цього часу"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "Нижня межа (не включно) часу закінчення події; повертаються лише події, які закінчуються після цього часу. Типово фільтрація за часом закінчення не виконується"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "Час закінчення"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "Повертати лише події, які починаються до цього часу"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "Верхня межа (не включно) часу початку події; повертаються лише події, які починаються до цього часу. Типово фільтрація за часом початку не виконується"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Максимальна кількість результатів"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "Максимальна кількість подій, що повертаються на одній сторінці результатів"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "Максимальна кількість подій, що повертаються на одній сторінці результатів; сторінка може містити менше подій, ніж це значення, або жодної, навіть якщо запиту відповідає більше подій. Неповні сторінки можна виявити за непорожнім полем `nextPageToken` у відповіді. Типове значення — `250`; розмір сторінки ніколи не може перевищувати `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "Розгортати повторювані події"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "Розгортати повторювані події на їхні окремі екземпляри"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "Якщо `True`, повторювані події розгортаються на окремі екземпляри, і повертаються лише одноразові події та екземпляри повторюваних подій, але не самі базові повторювані події. Якщо `False`, кожна повторювана подія повертається один раз із правилом повторення замість своїх екземплярів. Має бути `True`, щоб упорядкувати результат за часом початку"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "Упорядкувати за"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "Порядок подій, що повертаються в результаті"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "Порядок подій, що повертаються в результаті; типово порядок невизначений, але стабільний.\nДопустимі значення:\n- `startTime`: Упорядкувати за датою/часом початку (за зростанням); доступно лише тоді, коли `singleEvents` має значення `True`\n- `updated`: Упорядкувати за часом останньої зміни (за зростанням)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "Упорядкувати за датою/часом початку (за зростанням); доступно лише тоді, коли `singleEvents` має значення `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "Упорядкувати за часом останньої зміни (за зростанням)"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "Пошукові терміни"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "Довільні пошукові терміни для пошуку відповідних подій"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "Довільні пошукові терміни для пошуку подій, які відповідають цим термінам у полях `summary`, `description` і `location`, у відображуваних іменах та адресах електронної пошти учасників і організаторів, а також у властивостях робочого місця"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Токен сторінки"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Токен, який вказує, яку сторінку результатів повернути"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Токен, який вказує, яку сторінку результатів повернути; щоб отримати наступну сторінку, використовуйте значення `nextPageToken` з попередньої відповіді"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "Показувати видалені"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "Включати видалені події до результату"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "Якщо `True`, видалені події (зі `status`, що дорівнює `cancelled`) включаються до результату. Скасовані екземпляри повторюваних подій (але не базова повторювана подія) все одно включаються, якщо `showDeleted` і `singleEvents` обидва мають значення `False`; якщо обидва мають значення `True`, повертаються лише окремі екземпляри видалених подій. Типове значення — `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "Отримати подію"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "Отримати подію з календаря"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "Отримати одну подію з календаря за її ідентифікатором"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "Календар"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "Календар, що містить подію"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "Календар, що містить подію"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "Ідентифікатор події"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "Ідентифікатор події, яку потрібно отримати"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "Ідентифікатор події, яку потрібно отримати; ідентифікатори подій повертаються в полі `id` подій, які повертає дія `list-events`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "Перелічити календарі"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "Перелічити календарі зі списку календарів користувача"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "Перелічити календарі зі списку календарів автентифікованого користувача; `id` кожного запису можна використовувати як календар для дій з подіями"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "Максимальна кількість результатів"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "Максимальна кількість календарів, що повертаються на одній сторінці результатів"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "Максимальна кількість записів списку календарів, що повертаються на одній сторінці результатів; неповні сторінки можна виявити за непорожнім полем `nextPageToken` у відповіді. Типове значення — `100`; розмір сторінки ніколи не може перевищувати `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "Токен сторінки"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "Токен, який вказує, яку сторінку результатів повернути"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "Токен, який вказує, яку сторінку результатів повернути; щоб отримати наступну сторінку, використовуйте значення `nextPageToken` з попередньої відповіді"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "Показувати приховані"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "Включати приховані записи списку календарів до результату"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "Якщо `True`, приховані записи списку календарів включаються до результату. Типове значення — `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/zh-Hant.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/zh-Hant.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "要新增活動的行事曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "列出活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "列出行事曆中的活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "列出行事曆中的活動；結果可限制在某個時間範圍內、以自由文字搜尋字詞篩選，並透過 `maxResults` 和 `pageToken` 分頁"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "要列出活動的行事曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "要列出活動的行事曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "開始時間"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "只傳回在此時間之後結束的活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "活動結束時間的下限（不含此值）；只會傳回在此時間之後結束的活動。預設不依結束時間篩選"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "結束時間"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "只傳回在此時間之前開始的活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "活動開始時間的上限（不含此值）；只會傳回在此時間之前開始的活動。預設不依開始時間篩選"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "結果數上限"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "單一結果頁面傳回的活動數上限"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "單一結果頁面傳回的活動數上限；即使有更多活動符合查詢，頁面所包含的活動數也可能少於此值，甚至沒有任何活動。可透過回應中非空白的 `nextPageToken` 欄位偵測不完整的頁面。預設值為 `250`；頁面大小絕不能超過 `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "展開週期性活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "將週期性活動展開為個別的活動實例"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "若為 `True`，週期性活動會展開為個別的活動實例，且只會傳回單次活動與週期性活動的實例，而不會傳回週期性活動本身。若為 `False`，每個週期性活動只會連同其週期規則傳回一次，而非傳回其實例。若要依開始時間排序結果，必須為 `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "排序依據"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "結果中傳回的活動順序"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "結果中傳回的活動順序；預設為未指定但穩定的順序。\n可接受的值為：\n- `startTime`：依開始日期/時間排序（遞增）；僅在 `singleEvents` 為 `True` 時可用\n- `updated`：依最後修改時間排序（遞增）"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "依開始日期/時間排序（遞增）；僅在 `singleEvents` 為 `True` 時可用"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "依最後修改時間排序（遞增）"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "搜尋字詞"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "用於尋找相符活動的自由文字搜尋字詞"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "用於尋找活動的自由文字搜尋字詞，會比對 `summary`、`description` 和 `location` 欄位、邀請對象與主辦人的顯示名稱和電子郵件地址，以及工作地點屬性"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "頁面權杖"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "指定要傳回哪一頁結果的權杖"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "指定要傳回哪一頁結果的權杖；請使用上一個回應中的 `nextPageToken` 值來擷取下一頁"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "顯示已刪除的活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "在結果中包含已刪除的活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "若為 `True`，已刪除的活動（`status` 等於 `cancelled`）會包含在結果中。若 `showDeleted` 和 `singleEvents` 皆為 `False`，週期性活動中已取消的實例（但不含週期性活動本身）仍會包含在內；若兩者皆為 `True`，則只會傳回已刪除活動的個別實例。預設值為 `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "取得活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "從行事曆擷取活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "依活動 ID 從行事曆擷取單一活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "包含該活動的行事曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "包含該活動的行事曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "活動 ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "要擷取之活動的 ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "要擷取之活動的 ID；活動 ID 會在 `list-events` 動作所傳回活動的 `id` 欄位中傳回"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "列出行事曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "列出使用者行事曆清單中的行事曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "列出已驗證使用者行事曆清單中的行事曆；每個項目的 `id` 可作為活動動作的行事曆使用"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "結果數上限"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "單一結果頁面傳回的行事曆數上限"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "單一結果頁面傳回的行事曆清單項目數上限；可透過回應中非空白的 `nextPageToken` 欄位偵測不完整的頁面。預設值為 `100`；頁面大小絕不能超過 `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "頁面權杖"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "指定要傳回哪一頁結果的權杖"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "指定要傳回哪一頁結果的權杖；請使用上一個回應中的 `nextPageToken` 值來擷取下一頁"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "顯示隱藏的項目"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "在結果中包含隱藏的行事曆清單項目"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "若為 `True`，隱藏的行事曆清單項目會包含在結果中。預設值為 `False`"
         }
       }
     }

--- a/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/zh-TW.json
+++ b/qlib/GoogleCalendarDataProvider/i18n/data-provider.R29vZ2xlQ2FsZW5kYXI/zh-TW.json
@@ -470,6 +470,218 @@
         "app.R29vZ2xlQ2FsZW5kYXI.action.ZGVsZXRlLWV2ZW50.option.Y2FsZW5kYXI.desc": {
           "source": "The calendar to add the event to",
           "message": "要新增活動的日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.display_name": {
+          "source": "List Events",
+          "message": "列出活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.short_desc": {
+          "source": "List events in a calendar",
+          "message": "列出日曆中的活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.desc": {
+          "source": "List events in a calendar; the result can be restricted to a time window, filtered with free-text search terms, and paged with `maxResults` and `pageToken`",
+          "message": "列出日曆中的活動；結果可限制在特定時間範圍內、以自由文字搜尋字詞篩選，並使用 `maxResults` 與 `pageToken` 分頁"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar to list events from",
+          "message": "要列出活動的日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar to list events from",
+          "message": "要列出活動的日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.display_name": {
+          "source": "Start Time",
+          "message": "開始時間"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.short_desc": {
+          "source": "Only return events that end after this time",
+          "message": "僅傳回在此時間之後結束的活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1pbg.desc": {
+          "source": "Lower bound (exclusive) for an event's end time; only events that end after this time are returned. The default is not to filter by end time",
+          "message": "活動結束時間的下限（不含）；僅傳回在此時間之後結束的活動。預設不依結束時間篩選"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.display_name": {
+          "source": "End Time",
+          "message": "結束時間"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.short_desc": {
+          "source": "Only return events that start before this time",
+          "message": "僅傳回在此時間之前開始的活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.dGltZU1heA.desc": {
+          "source": "Upper bound (exclusive) for an event's start time; only events that start before this time are returned. The default is not to filter by start time",
+          "message": "活動開始時間的上限（不含）；僅傳回在此時間之前開始的活動。預設不依開始時間篩選"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "最大結果數"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of events to return on one result page",
+          "message": "單一結果頁面傳回的最大活動數"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of events to return on one result page; the page may contain fewer events than this value, or none at all, even if more events match the query. Incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `250`; the page size can never be larger than `2500`",
+          "message": "單一結果頁面傳回的最大活動數；即使有更多活動符合查詢，頁面中的活動數仍可能少於此值，甚至為零。可藉由回應中非空白的 `nextPageToken` 欄位偵測不完整的頁面。預設值為 `250`；頁面大小不得超過 `2500`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.display_name": {
+          "source": "Expand Recurring Events",
+          "message": "展開週期性活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.short_desc": {
+          "source": "Expand recurring events into their individual instances",
+          "message": "將週期性活動展開為各個實例"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2luZ2xlRXZlbnRz.desc": {
+          "source": "If `True`, recurring events are expanded into their individual instances, and only single one-off events and instances of recurring events are returned, but not the underlying recurring events themselves. If `False`, each recurring event is returned once with its recurrence rule instead of its instances. Must be `True` to order the result by start time",
+          "message": "若為 `True`，週期性活動會展開為各個實例，且僅傳回單次活動與週期性活動的實例，不會傳回週期性活動本身。若為 `False`，每個週期性活動僅會連同其週期規則傳回一次，而非其實例。若要依開始時間排序結果，必須設為 `True`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.display_name": {
+          "source": "Order By",
+          "message": "排序方式"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.short_desc": {
+          "source": "The order of the events returned in the result",
+          "message": "結果中傳回活動的順序"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.desc": {
+          "source": "The order of the events returned in the result; the default is an unspecified, stable order.\nAcceptable values are:\n- `startTime`: Order by the start date/time (ascending); this is only available when `singleEvents` is `True`\n- `updated`: Order by last modification time (ascending)",
+          "message": "結果中傳回活動的順序；預設為未指定但穩定的順序。\n可接受的值為：\n- `startTime`：依開始日期/時間排序（遞增）；僅在 `singleEvents` 為 `True` 時可用\n- `updated`：依最後修改時間排序（遞增）"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnN0YXJ0VGltZQ.desc": {
+          "source": "Order by the start date/time (ascending); this is only available when `singleEvents` is `True`",
+          "message": "依開始日期/時間排序（遞增）；僅在 `singleEvents` 為 `True` 時可用"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.b3JkZXJCeQ.allowed-value.c3RyaW5nOnVwZGF0ZWQ.desc": {
+          "source": "Order by last modification time (ascending)",
+          "message": "依最後修改時間排序（遞增）"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.display_name": {
+          "source": "Search Terms",
+          "message": "搜尋字詞"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.short_desc": {
+          "source": "Free-text search terms to find matching events",
+          "message": "用於尋找符合活動的自由文字搜尋字詞"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cQ.desc": {
+          "source": "Free-text search terms to find events that match these terms in the `summary`, `description`, and `location` fields, in attendee and organizer display names and email addresses, and in working location properties",
+          "message": "用於尋找活動的自由文字搜尋字詞，會在 `summary`、`description` 與 `location` 欄位、邀請對象與主辦人的顯示名稱及電子郵件地址，以及工作地點屬性中進行比對"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "頁面權杖"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "指定要傳回哪一頁結果的權杖"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "指定要傳回哪一頁結果的權杖；請使用前一個回應中的 `nextPageToken` 值以擷取下一頁"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.display_name": {
+          "source": "Show Deleted",
+          "message": "顯示已刪除"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.short_desc": {
+          "source": "Include deleted events in the result",
+          "message": "在結果中納入已刪除的活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1ldmVudHM.option.c2hvd0RlbGV0ZWQ.desc": {
+          "source": "If `True`, deleted events (with `status` equal to `cancelled`) are included in the result. Cancelled instances of recurring events (but not the underlying recurring event) are still included if `showDeleted` and `singleEvents` are both `False`; if both are `True`, only single instances of deleted events are returned. The default is `False`",
+          "message": "若為 `True`，已刪除的活動（`status` 為 `cancelled`）會納入結果。當 `showDeleted` 與 `singleEvents` 皆為 `False` 時，週期性活動中已取消的實例（但不含週期性活動本身）仍會納入；當兩者皆為 `True` 時，僅傳回已刪除活動的個別實例。預設值為 `False`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.display_name": {
+          "source": "Get Event",
+          "message": "取得活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.short_desc": {
+          "source": "Retrieve an event from a calendar",
+          "message": "從日曆擷取活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.desc": {
+          "source": "Retrieve a single event from a calendar by its event ID",
+          "message": "依活動 ID 從日曆擷取單一活動"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.display_name": {
+          "source": "Calendar",
+          "message": "日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.short_desc": {
+          "source": "The calendar containing the event",
+          "message": "包含該活動的日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.Y2FsZW5kYXI.desc": {
+          "source": "The calendar containing the event",
+          "message": "包含該活動的日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.display_name": {
+          "source": "Event ID",
+          "message": "活動 ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.short_desc": {
+          "source": "The ID of the event to retrieve",
+          "message": "要擷取的活動 ID"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.Z2V0LWV2ZW50.option.ZXZlbnRJZA.desc": {
+          "source": "The ID of the event to retrieve; event IDs are returned in the `id` field of the events returned by the `list-events` action",
+          "message": "要擷取的活動 ID；活動 ID 會在 `list-events` 動作所傳回活動的 `id` 欄位中傳回"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.display_name": {
+          "source": "List Calendars",
+          "message": "列出日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.short_desc": {
+          "source": "List the calendars in the user's calendar list",
+          "message": "列出使用者日曆清單中的日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.desc": {
+          "source": "List the calendars in the authenticated user's calendar list; the `id` of each entry can be used as the calendar for the event actions",
+          "message": "列出已驗證使用者日曆清單中的日曆；每個項目的 `id` 可作為活動動作所使用的日曆"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.display_name": {
+          "source": "Maximum Results",
+          "message": "最大結果數"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.short_desc": {
+          "source": "The maximum number of calendars to return on one result page",
+          "message": "單一結果頁面傳回的最大日曆數"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.bWF4UmVzdWx0cw.desc": {
+          "source": "The maximum number of calendar list entries to return on one result page; incomplete pages can be detected by a non-empty `nextPageToken` field in the response. The default is `100`; the page size can never be larger than `250`",
+          "message": "單一結果頁面傳回的最大日曆清單項目數；可藉由回應中非空白的 `nextPageToken` 欄位偵測不完整的頁面。預設值為 `100`；頁面大小不得超過 `250`"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.display_name": {
+          "source": "Page Token",
+          "message": "頁面權杖"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.short_desc": {
+          "source": "Token specifying which result page to return",
+          "message": "指定要傳回哪一頁結果的權杖"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.cGFnZVRva2Vu.desc": {
+          "source": "Token specifying which result page to return; use the `nextPageToken` value from the previous response to retrieve the next page",
+          "message": "指定要傳回哪一頁結果的權杖；請使用前一個回應中的 `nextPageToken` 值以擷取下一頁"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.display_name": {
+          "source": "Show Hidden",
+          "message": "顯示隱藏項目"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.short_desc": {
+          "source": "Include hidden calendar list entries in the result",
+          "message": "在結果中納入隱藏的日曆清單項目"
+        },
+        "app.R29vZ2xlQ2FsZW5kYXI.action.bGlzdC1jYWxlbmRhcnM.option.c2hvd0hpZGRlbg.desc": {
+          "source": "If `True`, hidden calendar list entries are included in the result. The default is `False`",
+          "message": "若為 `True`，隱藏的日曆清單項目會納入結果。預設值為 `False`"
         }
       }
     }

--- a/qlib/GoogleDataProvider/GoogleDataProvider.qm
+++ b/qlib/GoogleDataProvider/GoogleDataProvider.qm
@@ -34,7 +34,7 @@
 %requires(reexport) GoogleRestClient
 
 module GoogleDataProvider {
-    version = "2.0";
+    version = "2.1";
     desc = "user module providing a base data provider API for Google REST cloud services";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -55,6 +55,10 @@ module GoogleDataProvider {
     - <a href="../../modules/GoogleCalendarDataProvider/html/index.html">GoogleCalendarDataProvider</a>: Google Calendars
 
     @section googledataprovider_relnotes Release Notes
+
+    @subsection googledataprovider_v2_1 GoogleDataProvider v2.1
+    - date values in query arguments are serialized as RFC 3339 timestamps (ex: `2026-09-02T10:00:00+02:00`),
+      as Google APIs require for arguments such as `timeMin` / `timeMax`, instead of an unparseable digit string
 
     @subsection googledataprovider_v2_0 GoogleDataProvider v2.0
     - split off calendar API to a separate module

--- a/qlib/GoogleDataProvider/GoogleDataProviderBase.qc
+++ b/qlib/GoogleDataProvider/GoogleDataProviderBase.qc
@@ -192,6 +192,12 @@ public class GoogleDataProviderBase inherits DataProvider::AbstractDataProvider 
         @endcode
     */
     string getQueryValue(string key, AbstractDataProviderType type, auto val) {
+        if (val.typeCode() == NT_DATE) {
+            # Google APIs take timestamps in query arguments as RFC 3339 strings (ex: timeMin / timeMax /
+            # updatedMin in Calendar events.list); the default date-to-string conversion would send an
+            # unparseable digit string instead
+            return encode_url(val.format("YYYY-MM-DDTHH:mm:SSZ"), True);
+        }
         switch (type.getBaseTypeCode()) {
             case NT_BOOLEAN:
                 return val ? "true" : "false";

--- a/qlib/OpenAiDataProvider/OpenAiDataProvider.qc
+++ b/qlib/OpenAiDataProvider/OpenAiDataProvider.qc
@@ -53,6 +53,7 @@ public class OpenAiDataProvider inherits OpenAiDataProviderCommon {
             "responses": Class::forName("OpenAiDataProvider::OpenAiResponsesDataProvider"),
             "simple-chat": Class::forName("OpenAiDataProvider::OpenAiSimpleChatCompletionDataProvider"),
             "threads": Class::forName("OpenAiDataProvider::OpenAiThreadsDataProvider"),
+            "transcribe-audio": Class::forName("OpenAiDataProvider::OpenAiTranscribeAudioDataProvider"),
             "upload-file": Class::forName("OpenAiDataProvider::OpenAiFileUploadDataProvider"),
             "upload-file-from-location":
                 Class::forName("OpenAiDataProvider::OpenAiFileUploadFromLocationDataProvider"),

--- a/qlib/OpenAiDataProvider/OpenAiDataProvider.qm
+++ b/qlib/OpenAiDataProvider/OpenAiDataProvider.qm
@@ -42,7 +42,7 @@
 %endtry
 
 module OpenAiDataProvider {
-    version = "1.6";
+    version = "1.7";
     desc = "user module providing a data provider API for OpenAI services";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -527,6 +527,30 @@ module OpenAiDataProvider {
             ),
             "output_type": OpenAiCreateImageResponseType,
         });
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": OpenAiDataProvider::AppName,
+            "path": "/transcribe-audio",
+            "action": "transcribe-audio",
+            "display_name": "Transcribe Audio",
+            "short_desc": "Transcribe an audio file into text",
+            "desc": "Transcribe an audio file into text using an OpenAI speech-to-text model such as "
+                "`gpt-4o-transcribe` or `whisper-1`",
+            "action_code": DPAT_API,
+            "mutates_state": False,
+            "options": DataProviderActionCatalog::getActionOptionFromFields(
+                OpenAiTranscribeAudioRequestType::Fields{"file", "model"}, {
+                    "preselected": True,
+                    "required": True,
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                OpenAiTranscribeAudioRequestType::Fields{"language", "response_format"}, {
+                    "preselected": True,
+                }
+            ) + DataProviderActionCatalog::getActionOptionFromFields(
+                OpenAiTranscribeAudioRequestType::Fields - ("file", "model", "language", "response_format")
+            ),
+            "output_type": OpenAiTranscribeAudioDataProvider::ResponseType,
+        });
     };
 }
 
@@ -780,6 +804,12 @@ hash<auto> items = conversations.getChildProvider("items").getChildProvider("lis
     items on a follow-up request that sets \c previous_response_id or reuses the same \c conversation.
 
     @section openaidataprovider_relnotes Release Notes
+
+    @subsection openaidataprovider_v1_7 OpenAiDataProvider v1.7
+    - added the \c transcribe-audio data provider and the <b>Transcribe Audio</b> action implementing the OpenAI
+      audio transcription (speech-to-text) API; the audio file is uploaded as \c multipart/form-data and the
+      \c gpt-4o-transcribe, \c gpt-4o-mini-transcribe, and \c whisper-1 models are supported with the \c json,
+      \c text, \c srt, \c verbose_json, and \c vtt response formats
 
     @subsection openaidataprovider_v1_6 OpenAiDataProvider v1.6
     - added the \c conversations data provider tree implementing the OpenAI Conversations API

--- a/qlib/OpenAiDataProvider/OpenAiDataProviderCommon.qc
+++ b/qlib/OpenAiDataProvider/OpenAiDataProviderCommon.qc
@@ -463,6 +463,39 @@ public class OpenAiDataProviderCommon inherits DataProvider::AbstractDataProvide
         }
     }
 
+    #! Makes a REST call with a pre-serialized body and returns the response; handles I/O retries
+    /** The body is sent verbatim with the given \c Content-Type; no serialization and no client-side schema
+        validation is performed on the request, which is required for \c multipart/form-data uploads of binary
+        data such as audio files
+
+        @param method the HTTP method
+        @param path the URI path
+        @param body the request body, sent verbatim
+        @param content_type the content type of \a body
+        @param hdr any additional headers
+
+        @return the REST response
+
+        @since OpenAiDataProvider 1.7
+    */
+    private hash<auto> doRestRawCommand(string method, string path, data body, string content_type,
+            *hash<auto> hdr) {
+        hdr = (hdr ?? {}) + {"Content-Type": content_type};
+        int retries = 0;
+        while (True) {
+            try {
+                debug("REST (raw) %y %y (%y) %d byte(s) %y", method, rest.getUrl(), path, body.size(),
+                    content_type);
+                return rest.restDoRawRequest(method, path, body, hdr);
+            } catch (hash<ExceptionInfo> ex) {
+                if (retry(ex, \retries)) {
+                    continue;
+                }
+                rethrow ex.err, sprintf("%s (HTTP response code: %y)", ex.desc, ex.arg.status_code);
+            }
+        }
+    }
+
     #! Returns True if the error indicates that the operation should be retried
     private bool retry(hash<ExceptionInfo> ex, reference<int> retries) {
         if (RetrySet{ex.err}) {

--- a/qlib/OpenAiDataProvider/OpenAiDataProviderCommon.qc
+++ b/qlib/OpenAiDataProvider/OpenAiDataProviderCommon.qc
@@ -491,7 +491,12 @@ public class OpenAiDataProviderCommon inherits DataProvider::AbstractDataProvide
                 if (retry(ex, \retries)) {
                     continue;
                 }
-                rethrow ex.err, sprintf("%s (HTTP response code: %y)", ex.desc, ex.arg.status_code);
+                # socket-level errors carry no HTTP status; keep the original argument so that any response
+                # metadata (status, headers, body) stays available to the caller
+                string desc = ex.arg.status_code.val()
+                    ? sprintf("%s (HTTP response code: %d)", ex.desc, ex.arg.status_code)
+                    : ex.desc;
+                rethrow ex.err, desc, ex.arg;
             }
         }
     }

--- a/qlib/OpenAiDataProvider/OpenAiDataProviderCommon.qc
+++ b/qlib/OpenAiDataProvider/OpenAiDataProviderCommon.qc
@@ -452,7 +452,7 @@ public class OpenAiDataProviderCommon inherits DataProvider::AbstractDataProvide
         int retries = 0;
         while (True) {
             try {
-                debug("REST %y %y (%y) body: %y", method, rest.getUrl(), path, body);
+                debug("REST %y %y (%y) body: %y", method, rest.getSafeUrl(), path, body);
                 return rest.restDoRequest(method, path, body, hdr);
             } catch (hash<ExceptionInfo> ex) {
                 if (retry(ex, \retries)) {
@@ -484,7 +484,7 @@ public class OpenAiDataProviderCommon inherits DataProvider::AbstractDataProvide
         int retries = 0;
         while (True) {
             try {
-                debug("REST (raw) %y %y (%y) %d byte(s) %y", method, rest.getUrl(), path, body.size(),
+                debug("REST (raw) %y %y (%y) %d byte(s) %y", method, rest.getSafeUrl(), path, body.size(),
                     content_type);
                 return rest.restDoRawRequest(method, path, body, hdr);
             } catch (hash<ExceptionInfo> ex) {

--- a/qlib/OpenAiDataProvider/OpenAiTranscribeAudioDataProvider.qc
+++ b/qlib/OpenAiDataProvider/OpenAiTranscribeAudioDataProvider.qc
@@ -1,0 +1,481 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore OpenAiDataProvider module definition
+
+/** OpenAiTranscribeAudioDataProvider.qc Copyright 2024 - 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+#! contains all public definitions in the OpenAiDataProvider module
+public namespace OpenAiDataProvider {
+#! Transcribes audio into text with the OpenAI audio transcription API
+/** The audio file is sent as a \c multipart/form-data upload; the response depends on the \c response_format
+    request field: JSON formats are returned as parsed hashes, while the \c text, \c srt, and \c vtt formats are
+    returned in the \c text key of the response.
+
+    @since OpenAiDataProvider 1.7
+*/
+public class OpenAiTranscribeAudioDataProvider inherits OpenAiDataProviderCommon {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "transcribe-audio",
+            "desc": "Transcribes an audio file into text",
+            "type": "OpenAiTranscribeAudioDataProvider",
+            "constructor_options": ConstructorOptions,
+            "supports_request": True,
+        };
+
+        #! Provider summary info
+        const ProviderSummaryInfo = cast<hash<DataProviderSummaryInfo>>(ProviderInfo{
+            AbstractDataProvider::DataProviderSummaryInfoKeys
+        });
+
+        #! Request type
+        const RequestType = OpenAiTranscribeAudioRequestType;
+
+        #! Response type
+        const ResponseType = OpenAiTranscriptionDataType;
+
+        #! The REST path for audio transcriptions
+        const TranscriptionsPath = "audio/transcriptions";
+
+        #! Audio file name extensions accepted by the transcription API
+        const SupportedAudioExtensions = {
+            "flac": True,
+            "m4a": True,
+            "mp3": True,
+            "mp4": True,
+            "mpeg": True,
+            "mpga": True,
+            "oga": True,
+            "ogg": True,
+            "wav": True,
+            "webm": True,
+        };
+
+        #! The maximum audio file size accepted by the transcription API in bytes (25 MB)
+        const MaxAudioFileSize = 25 * 1024 * 1024;
+
+        #! Response formats returned by the API as raw text instead of JSON
+        const TextResponseFormats = {
+            "text": True,
+            "srt": True,
+            "vtt": True,
+        };
+    }
+
+    #! Creates the object from the arguments
+    constructor(*RestClientIo::RestClientIo rest) : OpenAiDataProviderCommon(rest) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return ProviderInfo.name;
+    }
+
+    #! Makes a request and returns the response
+    /** The file is decoded from its base64 representation and sent as the \c file part of a
+        \c multipart/form-data request together with one part for each other request field with a value.
+
+        @param req the request to serialize and make according to the request type
+        @param request_options the request options; will be processed by validateRequestOptions()
+
+        @return the response to the request
+
+        @throw TRANSCRIBE-AUDIO-ERROR the audio file has an unsupported name extension or exceeds the maximum size
+    */
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        hash<auto> file = remove req.file;
+        binary content = parse_base64_string(file.content);
+        checkAudioFile(file.name, content);
+
+        Mime::MultiPartFormDataMessage msg();
+        msg.addPart(content, "file", file.name, file.mime_type ?? MimeTypeOctetStream);
+        foreach hash<auto> i in (req.pairIterator()) {
+            if (exists i.value) {
+                msg.addPart(string(i.value), i.key, {"Content-Type": MimeTypeText});
+            }
+        }
+        hash<MessageInfo> mh = msg.getMsgAndHeaders();
+
+        auto body = doRestRawCommand("POST", TranscriptionsPath, mh.body, mh.hdr."Content-Type").body;
+        # the text, srt, and vtt formats are returned by the API as a raw text body
+        if (TextResponseFormats{req.response_format} || body.typeCode() != NT_HASH) {
+            return {
+                "text": body.typeCode() == NT_BINARY ? body.toString() : string(body),
+            };
+        }
+        return body;
+    }
+
+    #! Validates the audio file name extension and size before uploading
+    /** @param name the file name
+        @param content the decoded file content
+
+        @throw TRANSCRIBE-AUDIO-ERROR the audio file has an unsupported name extension or exceeds the maximum size
+    */
+    private checkAudioFile(string name, binary content) {
+        *string ext = (name =~ x/\.([^.\/]+)$/)[0];
+        if (!ext.val() || !SupportedAudioExtensions{ext.lwr()}) {
+            throw "TRANSCRIBE-AUDIO-ERROR", sprintf("audio file %y has an unsupported format; the file name must "
+                "have one of the following extensions: %y", name, keys SupportedAudioExtensions);
+        }
+        if (content.size() > MaxAudioFileSize) {
+            throw "TRANSCRIBE-AUDIO-ERROR", sprintf("audio file %y has %d bytes; the maximum size accepted by the "
+                "transcription API is %d bytes", name, content.size(), MaxAudioFileSize);
+        }
+    }
+
+    #! Returns the description of a successful request message, if any
+    /** @return the request type for this provider
+    */
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return RequestType;
+    }
+
+    #! Returns the description of a response message, if this object represents a response message
+    /** @return the response type for this response message
+    */
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return ResponseType;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! The audio transcription request type
+/** @since OpenAiDataProvider 1.7
+*/
+public class OpenAiTranscribeAudioRequestType inherits HashDataType {
+    public {
+        #! The default transcription model
+        const DefaultModel = "gpt-4o-transcribe";
+
+        #! The default response format
+        const DefaultResponseFormat = "json";
+
+        #! fields
+        const Fields = {
+            "file": {
+                "display_name": "Audio File",
+                "short_desc": "The audio file to transcribe",
+                "desc": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, "
+                    "`mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching "
+                    "extension. The maximum file size is 25 MB",
+                "type": FileDataType,
+            },
+            "model": {
+                "display_name": "Model",
+                "short_desc": "The speech-to-text model to use",
+                "desc": "The speech-to-text model to use for the transcription",
+                "type": AbstractDataProviderTypeMap."string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "display_name": "GPT-4o Transcribe",
+                        "value": "gpt-4o-transcribe",
+                        "desc": "The most accurate speech-to-text model; supports the `json` response format only",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "GPT-4o Mini Transcribe",
+                        "value": "gpt-4o-mini-transcribe",
+                        "desc": "A faster and cheaper speech-to-text model; supports the `json` response format "
+                            "only",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Whisper",
+                        "value": "whisper-1",
+                        "desc": "The open source Whisper V2 model; supports all response formats",
+                    },
+                ),
+                "default_value": DefaultModel,
+            },
+            "language": {
+                "display_name": "Language",
+                "short_desc": "The language of the input audio as an ISO-639-1 code",
+                "desc": "The language of the input audio in "
+                    "[ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example "
+                    "`en`); supplying the input language improves accuracy and latency",
+                "type": AbstractDataProviderTypeMap."*string",
+                "example_value": "en",
+            },
+            "prompt": {
+                "display_name": "Prompt",
+                "short_desc": "Optional text to guide the model's style or continue a previous audio segment",
+                "desc": "Optional text to guide the model's style or to continue a previous audio segment; the "
+                    "prompt should match the audio language",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "response_format": {
+                "display_name": "Response Format",
+                "short_desc": "The format of the transcription output",
+                "desc": "The format of the transcription output.\n\n"
+                    "**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, "
+                    "`srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in "
+                    "the `text` field of the response",
+                "type": AbstractDataProviderTypeMap."*string",
+                "allowed_values": (
+                    <AllowedValueInfo>{
+                        "display_name": "JSON",
+                        "value": "json",
+                        "desc": "A JSON object with the transcribed text",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Plain Text",
+                        "value": "text",
+                        "desc": "The transcribed text only (`whisper-1` only)",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "SRT Subtitles",
+                        "value": "srt",
+                        "desc": "SubRip subtitles with timestamps (`whisper-1` only)",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "Verbose JSON",
+                        "value": "verbose_json",
+                        "desc": "A JSON object with the transcribed text, language, duration, and timestamped "
+                            "segments (`whisper-1` only)",
+                    },
+                    <AllowedValueInfo>{
+                        "display_name": "WebVTT Subtitles",
+                        "value": "vtt",
+                        "desc": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+                    },
+                ),
+                "default_value": DefaultResponseFormat,
+            },
+            "temperature": {
+                "display_name": "Temperature",
+                "short_desc": "The sampling temperature between 0 and 1",
+                "desc": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output "
+                    "more random, while lower values like `0.2` make it more focused and deterministic. If set to "
+                    "`0`, the model uses log probability to automatically increase the temperature until certain "
+                    "thresholds are hit",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("OpenAiTranscribeAudioRequest") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Audio transcription request type constant
+/** @since OpenAiDataProvider 1.7
+*/
+public const OpenAiTranscribeAudioRequestType = new OpenAiTranscribeAudioRequestType();
+
+#! A timestamped word in a verbose transcription
+/** @since OpenAiDataProvider 1.7
+*/
+public class OpenAiTranscriptionWordDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "word": {
+                "display_name": "Word",
+                "short_desc": "The text content of the word",
+                "desc": "The text content of the word",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "start": {
+                "display_name": "Start Time",
+                "short_desc": "Start time of the word in seconds",
+                "desc": "Start time of the word in seconds",
+                "type": AbstractDataProviderTypeMap."float",
+            },
+            "end": {
+                "display_name": "End Time",
+                "short_desc": "End time of the word in seconds",
+                "desc": "End time of the word in seconds",
+                "type": AbstractDataProviderTypeMap."float",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("OpenAiTranscriptionWord") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Transcription word type constant
+/** @since OpenAiDataProvider 1.7
+*/
+public const OpenAiTranscriptionWordDataType = new OpenAiTranscriptionWordDataType();
+
+#! A timestamped segment in a verbose transcription
+/** @since OpenAiDataProvider 1.7
+*/
+public class OpenAiTranscriptionSegmentDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "id": {
+                "display_name": "Segment ID",
+                "short_desc": "Unique identifier of the segment",
+                "desc": "Unique identifier of the segment",
+                "type": AbstractDataProviderTypeMap."int",
+            },
+            "seek": {
+                "display_name": "Seek Offset",
+                "short_desc": "Seek offset of the segment",
+                "desc": "Seek offset of the segment",
+                "type": AbstractDataProviderTypeMap."int",
+            },
+            "start": {
+                "display_name": "Start Time",
+                "short_desc": "Start time of the segment in seconds",
+                "desc": "Start time of the segment in seconds",
+                "type": AbstractDataProviderTypeMap."float",
+            },
+            "end": {
+                "display_name": "End Time",
+                "short_desc": "End time of the segment in seconds",
+                "desc": "End time of the segment in seconds",
+                "type": AbstractDataProviderTypeMap."float",
+            },
+            "text": {
+                "display_name": "Text",
+                "short_desc": "Text content of the segment",
+                "desc": "Text content of the segment",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "tokens": {
+                "display_name": "Tokens",
+                "short_desc": "Array of token IDs for the text content",
+                "desc": "Array of token IDs for the text content",
+                "type": new ListDataType("TranscriptionSegmentTokenList", AbstractDataProviderTypeMap."int"),
+            },
+            "temperature": {
+                "display_name": "Temperature",
+                "short_desc": "Temperature parameter used for generating the segment",
+                "desc": "Temperature parameter used for generating the segment",
+                "type": AbstractDataProviderTypeMap."float",
+            },
+            "avg_logprob": {
+                "display_name": "Average Log Probability",
+                "short_desc": "Average logprob of the segment",
+                "desc": "Average logprob of the segment; if the value is lower than `-1`, consider the logprobs "
+                    "failed",
+                "type": AbstractDataProviderTypeMap."float",
+            },
+            "compression_ratio": {
+                "display_name": "Compression Ratio",
+                "short_desc": "Compression ratio of the segment",
+                "desc": "Compression ratio of the segment; if the value is greater than `2.4`, consider the "
+                    "compression failed",
+                "type": AbstractDataProviderTypeMap."float",
+            },
+            "no_speech_prob": {
+                "display_name": "No Speech Probability",
+                "short_desc": "Probability of no speech in the segment",
+                "desc": "Probability of no speech in the segment; if the value is higher than `1.0` and the "
+                    "`avg_logprob` is below `-1`, consider this segment silent",
+                "type": AbstractDataProviderTypeMap."float",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("OpenAiTranscriptionSegment") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Transcription segment type constant
+/** @since OpenAiDataProvider 1.7
+*/
+public const OpenAiTranscriptionSegmentDataType = new OpenAiTranscriptionSegmentDataType();
+
+#! The audio transcription response type
+/** Only \c text is always present; the other fields depend on the model and the \c response_format used
+
+    @since OpenAiDataProvider 1.7
+*/
+public class OpenAiTranscriptionDataType inherits HashDataType {
+    public {
+        #! fields
+        const Fields = {
+            "text": {
+                "display_name": "Text",
+                "short_desc": "The transcribed text",
+                "desc": "The transcribed text; for the `text`, `srt`, and `vtt` response formats, the raw output in "
+                    "the requested format",
+                "type": AbstractDataProviderTypeMap."string",
+            },
+            "task": {
+                "display_name": "Task",
+                "short_desc": "The task performed (verbose JSON only)",
+                "desc": "The task performed; always `transcribe` (`verbose_json` response format only)",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "language": {
+                "display_name": "Language",
+                "short_desc": "The language of the input audio (verbose JSON only)",
+                "desc": "The language of the input audio (`verbose_json` response format only)",
+                "type": AbstractDataProviderTypeMap."*string",
+            },
+            "duration": {
+                "display_name": "Duration",
+                "short_desc": "The duration of the input audio in seconds (verbose JSON only)",
+                "desc": "The duration of the input audio in seconds (`verbose_json` response format only)",
+                "type": AbstractDataProviderTypeMap."*float",
+            },
+            "segments": {
+                "display_name": "Segments",
+                "short_desc": "Timestamped segments of the transcribed text (verbose JSON only)",
+                "desc": "Timestamped segments of the transcribed text and their corresponding details "
+                    "(`verbose_json` response format only)",
+                "type": new ListDataType("*TranscriptionSegmentList", OpenAiTranscriptionSegmentDataType, True),
+            },
+            "words": {
+                "display_name": "Words",
+                "short_desc": "Timestamped words of the transcribed text (verbose JSON only)",
+                "desc": "Timestamped words of the transcribed text and their corresponding details "
+                    "(`verbose_json` response format only)",
+                "type": new ListDataType("*TranscriptionWordList", OpenAiTranscriptionWordDataType, True),
+            },
+            "usage": {
+                "display_name": "Usage",
+                "short_desc": "Token or duration usage statistics for the request (JSON only)",
+                "desc": "Usage statistics for the request; token counts (`type` = `tokens`) for `gpt-4o-transcribe` "
+                    "and `gpt-4o-mini-transcribe`, or the audio duration in seconds (`type` = `duration`) for "
+                    "`whisper-1` (`json` response format only)",
+                "type": AbstractDataProviderTypeMap."*hash",
+            },
+        };
+    }
+
+    #! Creates the type
+    constructor() : HashDataType("OpenAiTranscription") {
+        addQoreFields(Fields);
+    }
+}
+
+#! Audio transcription response type constant
+/** @since OpenAiDataProvider 1.7
+*/
+public const OpenAiTranscriptionDataType = new OpenAiTranscriptionDataType();
+}

--- a/qlib/OpenAiDataProvider/OpenAiTranscribeAudioDataProvider.qc
+++ b/qlib/OpenAiDataProvider/OpenAiTranscribeAudioDataProvider.qc
@@ -107,7 +107,7 @@ public class OpenAiTranscribeAudioDataProvider inherits OpenAiDataProviderCommon
         checkAudioFile(file.name, content);
 
         Mime::MultiPartFormDataMessage msg();
-        msg.addPart(content, "file", file.name, file.mime_type ?? MimeTypeOctetStream);
+        msg.addPart(content, "file", file.name, getAudioMimeType(file));
         foreach hash<auto> i in (req.pairIterator()) {
             if (exists i.value) {
                 msg.addPart(string(i.value), i.key, {"Content-Type": MimeTypeText});
@@ -123,6 +123,22 @@ public class OpenAiTranscribeAudioDataProvider inherits OpenAiDataProviderCommon
             };
         }
         return body;
+    }
+
+    #! Returns the MIME type to send for the audio file part
+    /** @param file the file value
+
+        @return the MIME type carried by the file; the @ref DataProvider::FileDataType "FileDataType" placeholder
+        \c "auto" (or a missing value) is resolved from the file name, falling back to
+        \c application/octet-stream, so that the part never carries an invalid \c Content-Type
+
+        @since OpenAiDataProvider 1.7
+    */
+    private static string getAudioMimeType(hash<auto> file) {
+        if (file.mime_type.val() && file.mime_type != "auto") {
+            return file.mime_type;
+        }
+        return file.name.val() ? get_mime_type_from_ext(file.name) : MimeTypeOctetStream;
     }
 
     #! Validates the audio file name extension and size before uploading

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/cs.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/cs.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "Jedinečný identifikátor představující vašeho koncového uživatele, který může pomoci OpenAI sledovat a zjišťovat zneužití"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "Přepsat zvuk"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "Přepsat zvukový soubor na text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "Přepsat zvukový soubor na text pomocí modelu OpenAI pro převod řeči na text, například `gpt-4o-transcribe` nebo `whisper-1`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "Zvukový soubor"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "Zvukový soubor k přepisu"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "Zvukový soubor k přepisu v jednom z následujících formátů: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav` nebo `webm`; název souboru musí mít odpovídající příponu. Maximální velikost souboru je 25 MB"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Data souboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 kódovaná data souboru nebo surová data k zakódování pomocí base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 kódovaná data souboru nebo surová data k zakódování pomocí base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME typ"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Řetězec MIME typu pro soubor"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Řetězec MIME typu pro soubor"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Automatické rozpoznání"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické rozpoznání z názvu souboru; platné jen pro vstup"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické rozpoznání z názvu souboru; platné jen pro vstup"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Prostý text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Prostý text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Soubor PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Soubor PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Soubor MS Word docx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Soubor MS Word `docx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Soubor MS PowerPoint pptx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Soubor MS PowerPoint `pptx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Soubor MS Excel xlsx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Soubor MS Excel `xlsx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Název souboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Název souboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Název souboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "Model"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "Model pro převod řeči na text, který se má použít"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "Model pro převod řeči na text, který se má použít pro přepis"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "Nejpřesnější model pro převod řeči na text; podporuje pouze formát odpovědi `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "Rychlejší a levnější model pro převod řeči na text; podporuje pouze formát odpovědi `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "Open source model Whisper V2; podporuje všechny formáty odpovědi"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "Jazyk"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "Jazyk vstupního zvuku jako kód ISO-639-1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "Jazyk vstupního zvuku ve formátu [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (například `en`); zadání vstupního jazyka zlepšuje přesnost a latenci"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "Formát odpovědi"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "Formát výstupu přepisu"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "Formát výstupu přepisu.\n\n**Poznámka**: `gpt-4o-transcribe` a `gpt-4o-mini-transcribe` podporují pouze `json`; formáty `text`, `srt`, `verbose_json` a `vtt` vyžadují `whisper-1`. Výstup, který není ve formátu JSON, je vrácen v poli `text` odpovědi"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "Objekt JSON s přepsaným textem"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "Prostý text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "Pouze přepsaný text (pouze `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "Titulky SRT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "Titulky SubRip s časovými značkami (pouze `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "Podrobný JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "Objekt JSON s přepsaným textem, jazykem, délkou a segmenty s časovými značkami (pouze `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "Titulky WebVTT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "Titulky Web Video Text Tracks s časovými značkami (pouze `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "Prompt"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "Volitelný text pro usměrnění stylu modelu nebo navázání na předchozí zvukový segment"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "Volitelný text pro usměrnění stylu modelu nebo pro navázání na předchozí zvukový segment; prompt by měl odpovídat jazyku zvuku"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "Teplota vzorkování"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "Teplota vzorkování mezi 0 a 1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "Teplota vzorkování mezi `0` a `1`; vyšší hodnoty jako `0.8` činí výstup náhodnějším, zatímco nižší hodnoty jako `0.2` jej činí soustředěnějším a deterministickým. Při nastavení na `0` model použije logaritmickou pravděpodobnost k automatickému zvyšování teploty, dokud nejsou dosaženy určité prahové hodnoty"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/de.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/de.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "Eine eindeutige Kennung für Ihren Endbenutzer, die OpenAI dabei helfen kann, Missbrauch zu überwachen und zu erkennen"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "Audio transkribieren"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "Eine Audiodatei in Text transkribieren"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "Eine Audiodatei mit einem OpenAI-Sprache-zu-Text-Modell wie `gpt-4o-transcribe` oder `whisper-1` in Text transkribieren"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "Audiodatei"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "Die zu transkribierende Audiodatei"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "Die zu transkribierende Audiodatei in einem der folgenden Formate: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav` oder `webm`; der Dateiname muss eine passende Erweiterung haben. Die maximale Dateigröße beträgt 25 MB"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dateidaten"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-codierte Dateidaten oder Rohdaten, die mit Base64 kodiert werden sollen"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-codierte Dateidaten oder Rohdaten, die mit Base64 kodiert werden sollen"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME-Typ"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Die MIME-Typ-Zeichenkette für die Datei"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Die MIME-Typ-Zeichenkette für die Datei"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Automatische Erkennung"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatische Erkennung aus dem Dateinamen; nur für Eingaben gültig"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatische Erkennung aus dem Dateinamen; nur für Eingaben gültig"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Klartext"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Klartext"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML-Text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML-Text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF-Datei"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF-Datei"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx-Dokument"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx`-Dokument"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx-Dokument"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx`-Dokument"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx-Dokument"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx`-Dokument"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Dateiname"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Der Dateiname"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Der Dateiname"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "Modell"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "Das zu verwendende Sprache-zu-Text-Modell"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "Das für die Transkription zu verwendende Sprache-zu-Text-Modell"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "Das genaueste Sprache-zu-Text-Modell; unterstützt nur das Antwortformat `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "Ein schnelleres und günstigeres Sprache-zu-Text-Modell; unterstützt nur das Antwortformat `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "Das Open-Source-Modell Whisper V2; unterstützt alle Antwortformate"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "Sprache"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "Die Sprache des Eingabe-Audios als ISO-639-1-Code"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "Die Sprache des Eingabe-Audios im [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)-Format (zum Beispiel `en`); die Angabe der Eingabesprache verbessert Genauigkeit und Latenz"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "Antwortformat"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "Das Format der Transkriptionsausgabe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "Das Format der Transkriptionsausgabe.\n\n**Hinweis**: `gpt-4o-transcribe` und `gpt-4o-mini-transcribe` unterstützen nur `json`; die Formate `text`, `srt`, `verbose_json` und `vtt` erfordern `whisper-1`. Nicht-JSON-Ausgaben werden im Feld `text` der Antwort zurückgegeben"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "Ein JSON-Objekt mit dem transkribierten Text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "Nur Text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "Nur der transkribierte Text (nur `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "SRT-Untertitel"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "SubRip-Untertitel mit Zeitstempeln (nur `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "Ausführliches JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "Ein JSON-Objekt mit dem transkribierten Text, der Sprache, der Dauer und Segmenten mit Zeitstempeln (nur `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "WebVTT-Untertitel"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "Web-Video-Text-Tracks-Untertitel mit Zeitstempeln (nur `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "Prompt"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "Optionaler Text zur Steuerung des Modellstils oder zur Fortsetzung eines vorherigen Audiosegments"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "Optionaler Text zur Steuerung des Modellstils oder zur Fortsetzung eines vorherigen Audiosegments; der Prompt sollte der Sprache des Audios entsprechen"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "Sampling-Temperatur"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "Die Sampling-Temperatur zwischen 0 und 1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "Die Sampling-Temperatur zwischen `0` und `1`; höhere Werte wie `0.8` machen die Ausgabe zufälliger, während niedrigere Werte wie `0.2` sie fokussierter und deterministischer machen. Bei `0` verwendet das Modell die Log-Wahrscheinlichkeit, um die Temperatur automatisch zu erhöhen, bis bestimmte Schwellenwerte erreicht sind"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/es.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/es.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "Un identificador único que representa a su usuario final, el cual puede ayudar a OpenAI a monitorear y detectar abusos"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "Transcribir audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "Transcribir un archivo de audio a texto"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "Transcribir un archivo de audio a texto utilizando un modelo de voz a texto de OpenAI como `gpt-4o-transcribe` o `whisper-1`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "Archivo de audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "El archivo de audio que se va a transcribir"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "El archivo de audio que se va a transcribir, en uno de los siguientes formatos: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav` o `webm`; el nombre del archivo debe tener la extensión correspondiente. El tamaño máximo del archivo es de 25 MB"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Datos del archivo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Datos de archivo codificados en Base64 o datos brutos para codificar con codificación Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Datos de archivo codificados en Base64 o datos brutos para codificar con codificación Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Tipo MIME"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "La cadena MIME para el archivo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "La cadena MIME para el archivo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Detección automática"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Detectar automáticamente del nombre de archivo; válido solo en entrada"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Detectar automáticamente del nombre de archivo; válido solo en entrada"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Texto sin formato"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Texto sin formato"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Texto HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Texto HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Archivo PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Archivo PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Documento MS Word docx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Documento de MS Word `docx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Documento MS PowerPoint pptx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Documento de MS PowerPoint `pptx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Documento MS Excel xlsx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Documento de MS Excel `xlsx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nombre de archivo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "El nombre del archivo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "El nombre del archivo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "Modelo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "El modelo de voz a texto que se utilizará"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "El modelo de voz a texto que se utilizará para la transcripción"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "El modelo de voz a texto más preciso; solo admite el formato de respuesta `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "Un modelo de voz a texto más rápido y económico; solo admite el formato de respuesta `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "El modelo de código abierto Whisper V2; admite todos los formatos de respuesta"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "Idioma"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "El idioma del audio de entrada como código ISO-639-1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "El idioma del audio de entrada en formato [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (por ejemplo, `en`); indicar el idioma de entrada mejora la precisión y la latencia"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "Formato de respuesta"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "El formato de la salida de la transcripción"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "El formato de la salida de la transcripción.\n\n**Nota**: `gpt-4o-transcribe` y `gpt-4o-mini-transcribe` solo admiten `json`; los formatos `text`, `srt`, `verbose_json` y `vtt` requieren `whisper-1`. La salida que no es JSON se devuelve en el campo `text` de la respuesta"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "Un objeto JSON con el texto transcrito"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "Texto sin formato"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "Solo el texto transcrito (solo `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "Subtítulos SRT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "Subtítulos SubRip con marcas de tiempo (solo `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "JSON detallado"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "Un objeto JSON con el texto transcrito, el idioma, la duración y los segmentos con marcas de tiempo (solo `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "Subtítulos WebVTT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "Subtítulos Web Video Text Tracks con marcas de tiempo (solo `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "Prompt"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "Texto opcional para guiar el estilo del modelo o continuar un segmento de audio anterior"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "Texto opcional para guiar el estilo del modelo o para continuar un segmento de audio anterior; el prompt debe coincidir con el idioma del audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "Temperatura de muestreo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "La temperatura de muestreo entre 0 y 1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "La temperatura de muestreo, entre `0` y `1`; los valores más altos como `0.8` hacen que la salida sea más aleatoria, mientras que los valores más bajos como `0.2` la hacen más centrada y determinista. Si se establece en `0`, el modelo utiliza la probabilidad logarítmica para aumentar automáticamente la temperatura hasta alcanzar ciertos umbrales"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/fr.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/fr.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "Un identifiant unique représentant votre utilisateur final, pouvant aider OpenAI à surveiller et détecter les abus"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "Transcrire l'audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "Transcrire un fichier audio en texte"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "Transcrire un fichier audio en texte à l'aide d'un modèle de reconnaissance vocale OpenAI tel que `gpt-4o-transcribe` ou `whisper-1`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "Fichier audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "Le fichier audio à transcrire"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "Le fichier audio à transcrire, dans l'un des formats suivants : `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav` ou `webm` ; le nom du fichier doit avoir une extension correspondante. La taille maximale du fichier est de 25 Mo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Données du fichier"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Données de fichier encodées en Base64 ou données brutes à encoder en Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Données de fichier encodées en Base64 ou données brutes à encoder en Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Type MIME"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "La chaîne de type MIME pour le fichier"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "La chaîne de type MIME pour le fichier"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Détection automatique"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Détection automatique à partir du nom de fichier ; valable uniquement en entrée"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Détection automatique à partir du nom de fichier ; valable uniquement en entrée"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Texte brut"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Texte brut"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Texte HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Texte HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Fichier PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Fichier PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Document Word docx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Document Word `docx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Document PowerPoint pptx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Document PowerPoint `pptx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Document Excel xlsx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Document Excel `xlsx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nom de fichier"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Le nom du fichier"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Le nom du fichier"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "Modèle"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "Le modèle de reconnaissance vocale à utiliser"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "Le modèle de reconnaissance vocale à utiliser pour la transcription"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "Le modèle de reconnaissance vocale le plus précis ; prend en charge uniquement le format de réponse `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "Un modèle de reconnaissance vocale plus rapide et moins coûteux ; prend en charge uniquement le format de réponse `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "Le modèle open source Whisper V2 ; prend en charge tous les formats de réponse"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "Langue"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "La langue de l'audio d'entrée sous forme de code ISO-639-1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "La langue de l'audio d'entrée au format [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (par exemple `en`) ; indiquer la langue d'entrée améliore la précision et la latence"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "Format de réponse"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "Le format de la sortie de transcription"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "Le format de la sortie de transcription.\n\n**Remarque** : `gpt-4o-transcribe` et `gpt-4o-mini-transcribe` ne prennent en charge que `json` ; les formats `text`, `srt`, `verbose_json` et `vtt` nécessitent `whisper-1`. La sortie non JSON est renvoyée dans le champ `text` de la réponse"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "Un objet JSON contenant le texte transcrit"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "Texte brut"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "Le texte transcrit uniquement (`whisper-1` uniquement)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "Sous-titres SRT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "Sous-titres SubRip avec horodatages (`whisper-1` uniquement)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "JSON détaillé"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "Un objet JSON contenant le texte transcrit, la langue, la durée et les segments horodatés (`whisper-1` uniquement)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "Sous-titres WebVTT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "Sous-titres Web Video Text Tracks avec horodatages (`whisper-1` uniquement)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "Prompt"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "Texte facultatif pour guider le style du modèle ou poursuivre un segment audio précédent"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "Texte facultatif pour guider le style du modèle ou pour poursuivre un segment audio précédent ; le prompt doit correspondre à la langue de l'audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "Température d'échantillonnage"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "La température d'échantillonnage entre 0 et 1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "La température d'échantillonnage, entre `0` et `1` ; des valeurs plus élevées comme `0.8` rendent la sortie plus aléatoire, tandis que des valeurs plus basses comme `0.2` la rendent plus ciblée et déterministe. Si elle est définie sur `0`, le modèle utilise la probabilité logarithmique pour augmenter automatiquement la température jusqu'à atteindre certains seuils"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/it.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/it.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "Un identificatore univoco che rappresenta l'utente finale, utile a OpenAI per monitorare e rilevare abusi"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "Trascrivi audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "Trascrivere un file audio in testo"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "Trascrivere un file audio in testo utilizzando un modello OpenAI di riconoscimento vocale come `gpt-4o-transcribe` o `whisper-1`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "File audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "Il file audio da trascrivere"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "Il file audio da trascrivere, in uno dei seguenti formati: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav` o `webm`; il nome del file deve avere un'estensione corrispondente. La dimensione massima del file è 25 MB"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dati File"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dati file codificati in Base64 o dati grezzi da codificare con l'encoding Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dati file codificati in Base64 o dati grezzi da codificare con l'encoding Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Tipo MIME"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Stringa tipo MIME del file"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Stringa tipo MIME del file"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Rilevamento automatico"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Rilevamento automatico dal nome del file; valido solo in input"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Rilevamento automatico dal nome del file; valido solo in input"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Testo normale"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Testo normale"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Testo HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Testo HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "File PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "File PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Documento MS Word docx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Documento MS Word `docx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Documento MS PowerPoint pptx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Documento MS PowerPoint `pptx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Documento MS Excel xlsx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Documento MS Excel `xlsx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nome file"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Il nome del file"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Il nome del file"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "Modello"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "Il modello di riconoscimento vocale da utilizzare"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "Il modello di riconoscimento vocale da utilizzare per la trascrizione"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "Il modello di riconoscimento vocale più accurato; supporta solo il formato di risposta `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "Un modello di riconoscimento vocale più veloce ed economico; supporta solo il formato di risposta `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "Il modello open source Whisper V2; supporta tutti i formati di risposta"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "Lingua"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "La lingua dell'audio di input come codice ISO-639-1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "La lingua dell'audio di input nel formato [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (ad esempio `en`); specificare la lingua di input migliora l'accuratezza e la latenza"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "Formato della risposta"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "Il formato dell'output della trascrizione"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "Il formato dell'output della trascrizione.\n\n**Nota**: `gpt-4o-transcribe` e `gpt-4o-mini-transcribe` supportano solo `json`; i formati `text`, `srt`, `verbose_json` e `vtt` richiedono `whisper-1`. L'output non JSON viene restituito nel campo `text` della risposta"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "Un oggetto JSON con il testo trascritto"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "Testo semplice"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "Solo il testo trascritto (solo `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "Sottotitoli SRT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "Sottotitoli SubRip con marcature temporali (solo `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "JSON dettagliato"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "Un oggetto JSON con il testo trascritto, la lingua, la durata e i segmenti con marcature temporali (solo `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "Sottotitoli WebVTT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "Sottotitoli Web Video Text Tracks con marcature temporali (solo `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "Prompt"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "Testo facoltativo per guidare lo stile del modello o continuare un segmento audio precedente"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "Testo facoltativo per guidare lo stile del modello o per continuare un segmento audio precedente; il prompt deve corrispondere alla lingua dell'audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "Temperatura di campionamento"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "La temperatura di campionamento compresa tra 0 e 1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "La temperatura di campionamento, compresa tra `0` e `1`; valori più alti come `0.8` rendono l'output più casuale, mentre valori più bassi come `0.2` lo rendono più mirato e deterministico. Se impostata su `0`, il modello utilizza la probabilità logaritmica per aumentare automaticamente la temperatura fino al raggiungimento di determinate soglie"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/ja.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/ja.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "OpenAI が不正利用を監視および検出するのに役立つ、エンドユーザーを表す一意の識別子"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "音声を文字起こし"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "音声ファイルをテキストに文字起こしします"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "`gpt-4o-transcribe` や `whisper-1` などの OpenAI の音声認識モデルを使用して、音声ファイルをテキストに文字起こしします"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "音声ファイル"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "文字起こしする音声ファイル"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "文字起こしする音声ファイル。`flac`、`mp3`、`mp4`、`mpeg`、`mpga`、`m4a`、`ogg`、`wav`、`webm` のいずれかの形式で、ファイル名には対応する拡張子が必要です。ファイルサイズの上限は 25 MB です"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "ファイルデータ"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64でエンコードされたファイルデータまたは、Base64エンコードでエンコードされるべき生データ"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64でエンコードされたファイルデータまたは、Base64エンコードでエンコードされるべき生データ"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME タイプ"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "ファイルのMIMEタイプ文字列"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "ファイルのMIMEタイプ文字列"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "自動検出"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "ファイル名から自動検出；入力時のみ有効"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "ファイル名から自動検出；入力時のみ有効"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "プレーンテキスト"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "プレーンテキスト"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTMLテキスト"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTMLテキスト"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF ファイル"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF ファイル"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx ドキュメント"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` ドキュメント"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx ドキュメント"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` ドキュメント"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx ドキュメント"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` ドキュメント"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "ファイル名"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "ファイル名"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "ファイル名"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "モデル"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "使用する音声認識モデル"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "文字起こしに使用する音声認識モデル"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "最も高精度な音声認識モデル。応答形式は `json` のみをサポートします"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "より高速で低コストな音声認識モデル。応答形式は `json` のみをサポートします"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "オープンソースの Whisper V2 モデル。すべての応答形式をサポートします"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "言語"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "入力音声の言語（ISO-639-1 コード）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "[ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) 形式の入力音声の言語（例: `en`）。入力言語を指定すると精度とレイテンシが向上します"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "応答形式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "文字起こし出力の形式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "文字起こし出力の形式。\n\n**注意**: `gpt-4o-transcribe` と `gpt-4o-mini-transcribe` は `json` のみをサポートします。`text`、`srt`、`verbose_json`、`vtt` の各形式には `whisper-1` が必要です。JSON 以外の出力は応答の `text` フィールドに返されます"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "文字起こしされたテキストを含む JSON オブジェクト"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "プレーンテキスト"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "文字起こしされたテキストのみ（`whisper-1` のみ）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "SRT 字幕"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "タイムスタンプ付きの SubRip 字幕（`whisper-1` のみ）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "詳細 JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "文字起こしされたテキスト、言語、長さ、タイムスタンプ付きセグメントを含む JSON オブジェクト（`whisper-1` のみ）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "WebVTT 字幕"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "タイムスタンプ付きの Web Video Text Tracks 字幕（`whisper-1` のみ）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "プロンプト"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "モデルのスタイルを誘導するか、前の音声セグメントを続けるための任意のテキスト"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "モデルのスタイルを誘導するか、前の音声セグメントを続けるための任意のテキスト。プロンプトは音声の言語と一致させる必要があります"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "サンプリング温度"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "0 から 1 の間のサンプリング温度"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "`0` から `1` の間のサンプリング温度。`0.8` のような高い値では出力がよりランダムになり、`0.2` のような低い値ではより焦点が絞られ決定論的になります。`0` に設定すると、モデルは対数確率を使用して特定のしきい値に達するまで自動的に温度を上げます"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/ko.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/ko.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "최종 사용자를 나타내는 고유 식별자로, OpenAI가 오남용을 모니터링하고 감지하는 데 도움이 될 수 있습니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "오디오 전사"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "오디오 파일을 텍스트로 전사합니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "`gpt-4o-transcribe` 또는 `whisper-1`과 같은 OpenAI 음성-텍스트 변환 모델을 사용하여 오디오 파일을 텍스트로 전사합니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "오디오 파일"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "전사할 오디오 파일"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "전사할 오디오 파일로, `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, `webm` 형식 중 하나여야 하며 파일 이름에 해당 확장자가 있어야 합니다. 최대 파일 크기는 25 MB입니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "파일 데이터"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 인코딩된 파일 데이터 또는 Base64로 인코딩할 원시 데이터"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 인코딩된 파일 데이터 또는 Base64로 인코딩할 원시 데이터"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME 유형"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "파일에 대한 MIME 유형 문자열"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "파일에 대한 MIME 유형 문자열"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "자동 감지"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "파일 이름에서 자동 감지; 입력 시에만 유효"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "파일 이름에서 자동 감지; 입력 시에만 유효"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "일반 텍스트"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "일반 텍스트"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 텍스트"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 텍스트"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF 파일"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF 파일"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx 문서"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` 문서"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx 문서"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` 문서"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx 문서"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` 문서"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "파일 이름"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "파일 이름"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "파일 이름"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "모델"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "사용할 음성-텍스트 변환 모델"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "전사에 사용할 음성-텍스트 변환 모델"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "가장 정확한 음성-텍스트 변환 모델로, `json` 응답 형식만 지원합니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "더 빠르고 저렴한 음성-텍스트 변환 모델로, `json` 응답 형식만 지원합니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "오픈 소스 Whisper V2 모델로, 모든 응답 형식을 지원합니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "언어"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "ISO-639-1 코드로 된 입력 오디오의 언어"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "[ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) 형식의 입력 오디오 언어(예: `en`)로, 입력 언어를 지정하면 정확도와 지연 시간이 개선됩니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "응답 형식"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "전사 출력의 형식"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "전사 출력의 형식입니다.\n\n**참고**: `gpt-4o-transcribe`와 `gpt-4o-mini-transcribe`는 `json`만 지원하며, `text`, `srt`, `verbose_json`, `vtt` 형식에는 `whisper-1`이 필요합니다. JSON이 아닌 출력은 응답의 `text` 필드에 반환됩니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "전사된 텍스트가 포함된 JSON 객체"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "일반 텍스트"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "전사된 텍스트만(`whisper-1` 전용)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "SRT 자막"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "타임스탬프가 포함된 SubRip 자막(`whisper-1` 전용)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "상세 JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "전사된 텍스트, 언어, 길이 및 타임스탬프가 포함된 세그먼트를 담은 JSON 객체(`whisper-1` 전용)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "WebVTT 자막"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "타임스탬프가 포함된 Web Video Text Tracks 자막(`whisper-1` 전용)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "프롬프트"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "모델의 스타일을 안내하거나 이전 오디오 세그먼트를 이어가기 위한 선택적 텍스트"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "모델의 스타일을 안내하거나 이전 오디오 세그먼트를 이어가기 위한 선택적 텍스트로, 프롬프트는 오디오의 언어와 일치해야 합니다"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "샘플링 온도"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "0과 1 사이의 샘플링 온도"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "`0`과 `1` 사이의 샘플링 온도로, `0.8`과 같은 높은 값은 출력을 더 무작위로 만들고 `0.2`와 같은 낮은 값은 더 집중적이고 결정론적으로 만듭니다. `0`으로 설정하면 모델은 로그 확률을 사용하여 특정 임계값에 도달할 때까지 온도를 자동으로 높입니다"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/pl.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/pl.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "Unikatowy identyfikator reprezentujący użytkownika końcowego, który może pomóc OpenAI w monitorowaniu i wykrywaniu nadużyć"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "Transkrybuj audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "Transkrybuj plik audio na tekst"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "Transkrybuj plik audio na tekst przy użyciu modelu zamiany mowy na tekst OpenAI, takiego jak `gpt-4o-transcribe` lub `whisper-1`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "Plik audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "Plik audio do transkrypcji"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "Plik audio do transkrypcji w jednym z następujących formatów: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav` lub `webm`; nazwa pliku musi mieć odpowiednie rozszerzenie. Maksymalny rozmiar pliku to 25 MB"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dane pliku"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dane pliku zakodowane w formacie Base64 lub dane surowe do zakodowania w formacie Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dane pliku zakodowane w formacie Base64 lub dane surowe do zakodowania w formacie Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Typ MIME"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Ciąg typu MIME pliku"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Ciąg typu MIME pliku"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Wykrywanie automatyczne"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Wykrywanie automatyczne na podstawie nazwy pliku; ważne tylko dla danych wejściowych"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Wykrywanie automatyczne na podstawie nazwy pliku; ważne tylko dla danych wejściowych"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Zwykły tekst"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Zwykły tekst"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Tekst HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Tekst HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Plik PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Plik PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Dokument MS Word docx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Dokument MS Word `docx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Dokument MS PowerPoint pptx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Dokument MS PowerPoint `pptx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Dokument MS Excel xlsx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Dokument MS Excel `xlsx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Nazwa pliku"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Nazwa pliku"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Nazwa pliku"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "Model"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "Model zamiany mowy na tekst, który ma zostać użyty"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "Model zamiany mowy na tekst, który ma zostać użyty do transkrypcji"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "Najdokładniejszy model zamiany mowy na tekst; obsługuje wyłącznie format odpowiedzi `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "Szybszy i tańszy model zamiany mowy na tekst; obsługuje wyłącznie format odpowiedzi `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "Model open source Whisper V2; obsługuje wszystkie formaty odpowiedzi"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "Język"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "Język wejściowego audio jako kod ISO-639-1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "Język wejściowego audio w formacie [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (na przykład `en`); podanie języka wejściowego poprawia dokładność i opóźnienie"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "Format odpowiedzi"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "Format wyniku transkrypcji"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "Format wyniku transkrypcji.\n\n**Uwaga**: `gpt-4o-transcribe` i `gpt-4o-mini-transcribe` obsługują wyłącznie `json`; formaty `text`, `srt`, `verbose_json` i `vtt` wymagają `whisper-1`. Wynik w formacie innym niż JSON jest zwracany w polu `text` odpowiedzi"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "Obiekt JSON z transkrybowanym tekstem"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "Zwykły tekst"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "Tylko transkrybowany tekst (tylko `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "Napisy SRT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "Napisy SubRip ze znacznikami czasu (tylko `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "Szczegółowy JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "Obiekt JSON z transkrybowanym tekstem, językiem, czasem trwania i segmentami ze znacznikami czasu (tylko `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "Napisy WebVTT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "Napisy Web Video Text Tracks ze znacznikami czasu (tylko `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "Prompt"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "Opcjonalny tekst kierujący stylem modelu lub kontynuujący poprzedni segment audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "Opcjonalny tekst kierujący stylem modelu lub kontynuujący poprzedni segment audio; prompt powinien odpowiadać językowi audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "Temperatura próbkowania"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "Temperatura próbkowania od 0 do 1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "Temperatura próbkowania od `0` do `1`; wyższe wartości, takie jak `0.8`, sprawiają, że wynik jest bardziej losowy, a niższe wartości, takie jak `0.2`, czynią go bardziej skupionym i deterministycznym. Przy ustawieniu `0` model używa logarytmu prawdopodobieństwa, aby automatycznie zwiększać temperaturę do osiągnięcia określonych progów"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/root.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/root.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "Transcribe Audio"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "Transcribe an audio file into text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "Audio File"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "The audio file to transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "File Data"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-encoded file data or raw data to be encoded with base64 encoding"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64-encoded file data or raw data to be encoded with base64 encoding"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME Type"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "The MIME type string for the file"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "The MIME type string for the file"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Autodetect"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Autodetect from the file name; valid only on input"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Autodetect from the file name; valid only on input"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Plain text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Plain text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF file"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF file"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Filename"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "The filename"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "The filename"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "Model"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "The speech-to-text model to use"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "The speech-to-text model to use for the transcription"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "The most accurate speech-to-text model; supports the `json` response format only"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "A faster and cheaper speech-to-text model; supports the `json` response format only"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "The open source Whisper V2 model; supports all response formats"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "Language"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "The language of the input audio as an ISO-639-1 code"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "Response Format"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "The format of the transcription output"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "A JSON object with the transcribed text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "Plain Text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "The transcribed text only (`whisper-1` only)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "SRT Subtitles"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "SubRip subtitles with timestamps (`whisper-1` only)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "Verbose JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "WebVTT Subtitles"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "Prompt"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "Optional text to guide the model's style or continue a previous audio segment"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "Temperature"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "The sampling temperature between 0 and 1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/sk.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/sk.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "Jedinečný identifikátor reprezentujúci vášho koncového používateľa, ktorý môže pomôcť OpenAI monitorovať a zisťovať zneužitie"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "Prepísať zvuk"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "Prepísať zvukový súbor na text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "Prepísať zvukový súbor na text pomocou modelu OpenAI na prevod reči na text, napríklad `gpt-4o-transcribe` alebo `whisper-1`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "Zvukový súbor"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "Zvukový súbor na prepis"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "Zvukový súbor na prepis v jednom z nasledujúcich formátov: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav` alebo `webm`; názov súboru musí mať zodpovedajúcu príponu. Maximálna veľkosť súboru je 25 MB"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Dáta súboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dáta súboru zakódované v Base64 alebo nezakódované dáta, ktoré sa majú zakódovať pomocou Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Dáta súboru zakódované v Base64 alebo nezakódované dáta, ktoré sa majú zakódovať pomocou Base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "Typ MIME"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Reťazec MIME typu súboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Reťazec MIME typu súboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Automatické detekovanie"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické detekovanie z názvu súboru; platné iba pri vstupe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Automatické detekovanie z názvu súboru; platné iba pri vstupe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Obyčajný text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Obyčajný text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF súbor"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF súbor"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Dokument MS Word docx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Dokument MS Word `docx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Dokument MS PowerPoint pptx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Dokument MS PowerPoint `pptx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Dokument MS Excel xlsx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Dokument MS Excel `xlsx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Názov súboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Názov súboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Názov súboru"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "Model"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "Model na prevod reči na text, ktorý sa má použiť"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "Model na prevod reči na text, ktorý sa má použiť na prepis"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "Najpresnejší model na prevod reči na text; podporuje iba formát odpovede `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "Rýchlejší a lacnejší model na prevod reči na text; podporuje iba formát odpovede `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "Open source model Whisper V2; podporuje všetky formáty odpovede"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "Jazyk"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "Jazyk vstupného zvuku ako kód ISO-639-1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "Jazyk vstupného zvuku vo formáte [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (napríklad `en`); zadanie vstupného jazyka zlepšuje presnosť a latenciu"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "Formát odpovede"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "Formát výstupu prepisu"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "Formát výstupu prepisu.\n\n**Poznámka**: `gpt-4o-transcribe` a `gpt-4o-mini-transcribe` podporujú iba `json`; formáty `text`, `srt`, `verbose_json` a `vtt` vyžadujú `whisper-1`. Výstup, ktorý nie je vo formáte JSON, sa vracia v poli `text` odpovede"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "Objekt JSON s prepísaným textom"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "Obyčajný text"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "Iba prepísaný text (iba `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "Titulky SRT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "Titulky SubRip s časovými značkami (iba `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "Podrobný JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "Objekt JSON s prepísaným textom, jazykom, trvaním a segmentmi s časovými značkami (iba `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "Titulky WebVTT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "Titulky Web Video Text Tracks s časovými značkami (iba `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "Prompt"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "Voliteľný text na usmernenie štýlu modelu alebo na nadviazanie na predchádzajúci zvukový segment"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "Voliteľný text na usmernenie štýlu modelu alebo na nadviazanie na predchádzajúci zvukový segment; prompt by mal zodpovedať jazyku zvuku"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "Teplota vzorkovania"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "Teplota vzorkovania v rozsahu od 0 do 1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "Teplota vzorkovania v rozsahu od `0` do `1`; vyššie hodnoty ako `0.8` robia výstup náhodnejším, zatiaľ čo nižšie hodnoty ako `0.2` ho robia sústredenejším a deterministickejším. Pri nastavení na `0` model použije logaritmickú pravdepodobnosť na automatické zvyšovanie teploty, kým sa nedosiahnu určité prahové hodnoty"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/uk.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/uk.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "Унікальний ідентифікатор кінцевого користувача, який може допомогти OpenAI відстежувати та виявляти зловживання"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "Транскрибувати аудіо"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "Транскрибувати аудіофайл у текст"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "Транскрибувати аудіофайл у текст за допомогою моделі OpenAI для перетворення мовлення на текст, наприклад `gpt-4o-transcribe` або `whisper-1`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "Аудіофайл"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "Аудіофайл для транскрибування"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "Аудіофайл для транскрибування в одному з таких форматів: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav` або `webm`; ім'я файлу повинно мати відповідне розширення. Максимальний розмір файлу — 25 МБ"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "Дані файлу"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Дані файлу у форматі base64 або сирові дані, що кодуються за допомогою base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Дані файлу у форматі base64 або сирові дані, що кодуються за допомогою base64"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME-тип"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "Строка MIME-типу файлу"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "Строка MIME-типу файлу"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "Автоматичне визначення"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Автоматичне визначення за назвою файлу; дійсно лише для вхідних даних"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "Автоматичне визначення за назвою файлу; дійсно лише для вхідних даних"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "Звичайний текст"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "Звичайний текст"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "Текст HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "Текст HTML"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "Файл PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "Файл PDF"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "Документ MS Word docx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "Документ MS Word `docx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "Документ MS PowerPoint pptx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "Документ MS PowerPoint `pptx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "Документ MS Excel xlsx"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "Документ MS Excel `xlsx`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "Назва файлу"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "Ім’я файлу"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "Ім’я файлу"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "Модель"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "Модель перетворення мовлення на текст, яку слід використовувати"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "Модель перетворення мовлення на текст, яку слід використовувати для транскрибування"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "Найточніша модель перетворення мовлення на текст; підтримує лише формат відповіді `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "Швидша та дешевша модель перетворення мовлення на текст; підтримує лише формат відповіді `json`"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "Модель Whisper V2 з відкритим кодом; підтримує всі формати відповіді"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "Мова"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "Мова вхідного аудіо у вигляді коду ISO-639-1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "Мова вхідного аудіо у форматі [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (наприклад, `en`); зазначення мови вхідних даних покращує точність і затримку"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "Формат відповіді"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "Формат результату транскрибування"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "Формат результату транскрибування.\n\n**Примітка**: `gpt-4o-transcribe` та `gpt-4o-mini-transcribe` підтримують лише `json`; формати `text`, `srt`, `verbose_json` і `vtt` потребують `whisper-1`. Результат не у форматі JSON повертається в полі `text` відповіді"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "Об'єкт JSON із транскрибованим текстом"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "Звичайний текст"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "Лише транскрибований текст (лише `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "Субтитри SRT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "Субтитри SubRip із часовими мітками (лише `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "Детальний JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "Об'єкт JSON із транскрибованим текстом, мовою, тривалістю та сегментами з часовими мітками (лише `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "Субтитри WebVTT"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "Субтитри Web Video Text Tracks із часовими мітками (лише `whisper-1`)"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "Промпт"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "Необов'язковий текст для спрямування стилю моделі або продовження попереднього аудіосегмента"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "Необов'язковий текст для спрямування стилю моделі або для продовження попереднього аудіосегмента; промпт повинен відповідати мові аудіо"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "Температура вибірки"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "Температура вибірки від 0 до 1"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "Температура вибірки від `0` до `1`; вищі значення, як-от `0.8`, роблять результат більш випадковим, тоді як нижчі значення, як-от `0.2`, роблять його більш сфокусованим і детермінованим. Якщо встановлено `0`, модель використовує логарифмічну ймовірність для автоматичного підвищення температури до досягнення певних порогових значень"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/zh-Hant.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/zh-Hant.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "代表您終端使用者的唯一識別碼，可協助 OpenAI 監控並偵測濫用行為"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "轉錄音訊"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "將音訊檔案轉錄為文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "使用 OpenAI 的語音轉文字模型（例如 `gpt-4o-transcribe` 或 `whisper-1`）將音訊檔案轉錄為文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "音訊檔案"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "要轉錄的音訊檔案"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "要轉錄的音訊檔案，格式須為以下其中之一：`flac`、`mp3`、`mp4`、`mpeg`、`mpga`、`m4a`、`ogg`、`wav` 或 `webm`；檔案名稱必須具有相符的副檔名。檔案大小上限為 25 MB"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "檔案資料"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料，將以 Base64 編碼"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料，將以 Base64 編碼"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME 類型"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "自動偵測"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "根據檔案名稱自動偵測；僅在輸入時有效"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "根據檔案名稱自動偵測；僅在輸入時有效"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF檔案"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF檔案"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "檔案名稱"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "檔案名稱"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "檔案名稱"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "模型"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "要使用的語音轉文字模型"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "用於轉錄的語音轉文字模型"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "最準確的語音轉文字模型；僅支援 `json` 回應格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "更快速且更經濟的語音轉文字模型；僅支援 `json` 回應格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "開放原始碼的 Whisper V2 模型；支援所有回應格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "語言"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "輸入音訊的語言（ISO-639-1 代碼）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "以 [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) 格式表示的輸入音訊語言（例如 `en`）；提供輸入語言可提高準確度並降低延遲"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "回應格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "轉錄輸出的格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "轉錄輸出的格式。\n\n**注意**：`gpt-4o-transcribe` 和 `gpt-4o-mini-transcribe` 僅支援 `json`；`text`、`srt`、`verbose_json` 和 `vtt` 格式需要 `whisper-1`。非 JSON 輸出會在回應的 `text` 欄位中傳回"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "包含轉錄文字的 JSON 物件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "純文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "僅包含轉錄文字（僅限 `whisper-1`）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "SRT 字幕"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "含時間戳記的 SubRip 字幕（僅限 `whisper-1`）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "詳細 JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "包含轉錄文字、語言、時長及含時間戳記片段的 JSON 物件（僅限 `whisper-1`）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "WebVTT 字幕"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "含時間戳記的 Web Video Text Tracks 字幕（僅限 `whisper-1`）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "提示"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "用於引導模型風格或延續先前音訊片段的選用文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "用於引導模型風格或延續先前音訊片段的選用文字；提示應與音訊的語言相符"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "取樣溫度"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "介於 0 到 1 之間的取樣溫度"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "介於 `0` 到 `1` 之間的取樣溫度；較高的值（例如 `0.8`）會使輸出更隨機，而較低的值（例如 `0.2`）會使輸出更集中且更具確定性。若設為 `0`，模型會使用對數機率自動提高溫度，直到達到特定閾值為止"
         }
       }
     }

--- a/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/zh-TW.json
+++ b/qlib/OpenAiDataProvider/i18n/data-provider.T3BlbkFJ/zh-TW.json
@@ -8690,6 +8690,274 @@
         "app.T3BlbkFJ.action.Y3JlYXRlLWltYWdl.option.dXNlcg.desc": {
           "source": "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse",
           "message": "代表您終端使用者的唯一識別碼，可協助 OpenAI 監控並偵測濫用行為"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.display_name": {
+          "source": "Transcribe Audio",
+          "message": "轉錄音訊"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.short_desc": {
+          "source": "Transcribe an audio file into text",
+          "message": "將音訊檔案轉錄為文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.desc": {
+          "source": "Transcribe an audio file into text using an OpenAI speech-to-text model such as `gpt-4o-transcribe` or `whisper-1`",
+          "message": "使用 OpenAI 的語音轉文字模型（例如 `gpt-4o-transcribe` 或 `whisper-1`）將音訊檔案轉錄為文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.display_name": {
+          "source": "Audio File",
+          "message": "音訊檔案"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.short_desc": {
+          "source": "The audio file to transcribe",
+          "message": "要轉錄的音訊檔案"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.desc": {
+          "source": "The audio file to transcribe, in one of the following formats: `flac`, `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `ogg`, `wav`, or `webm`; the file name must have a matching extension. The maximum file size is 25 MB",
+          "message": "要轉錄的音訊檔案，格式須為以下其中之一：`flac`、`mp3`、`mp4`、`mpeg`、`mpga`、`m4a`、`ogg`、`wav` 或 `webm`；檔案名稱必須具有相符的副檔名。檔案大小上限為 25 MB"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.display_name": {
+          "source": "File Data",
+          "message": "檔案資料"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.short_desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.Y29udGVudA.desc": {
+          "source": "Base64-encoded file data or raw data to be encoded with base64 encoding",
+          "message": "Base64 編碼的檔案資料或原始資料"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.display_name": {
+          "source": "MIME Type",
+          "message": "MIME 類型"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.short_desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.desc": {
+          "source": "The MIME type string for the file",
+          "message": "檔案的 MIME 類型字串"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.display_name": {
+          "source": "Autodetect",
+          "message": "自動偵測"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.short_desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "從檔名自動偵測；僅適用於輸入"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmF1dG8.desc": {
+          "source": "Autodetect from the file name; valid only on input",
+          "message": "從檔名自動偵測；僅適用於輸入"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.display_name": {
+          "source": "text/plain",
+          "message": "text/plain"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.short_desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvcGxhaW4.desc": {
+          "source": "Plain text",
+          "message": "純文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.display_name": {
+          "source": "text/html",
+          "message": "text/html"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.short_desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOnRleHQvaHRtbA.desc": {
+          "source": "HTML text",
+          "message": "HTML 文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.display_name": {
+          "source": "application/pdf",
+          "message": "application/pdf"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.short_desc": {
+          "source": "PDF file",
+          "message": "PDF 檔案"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3BkZg.desc": {
+          "source": "PDF file",
+          "message": "PDF 檔案"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "message": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.short_desc": {
+          "source": "MS Word docx document",
+          "message": "MS Word docx 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC53b3JkcHJvY2Vzc2luZ21sLmRvY3VtZW50.desc": {
+          "source": "MS Word `docx` document",
+          "message": "MS Word `docx` 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+          "message": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.short_desc": {
+          "source": "MS PowerPoint pptx document",
+          "message": "MS PowerPoint pptx 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5wcmVzZW50YXRpb25tbC5wcmVzZW50YXRpb24.desc": {
+          "source": "MS PowerPoint `pptx` document",
+          "message": "MS PowerPoint `pptx` 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.display_name": {
+          "source": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "message": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.short_desc": {
+          "source": "MS Excel xlsx document",
+          "message": "MS Excel xlsx 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bWltZV90eXBl.allowed-value.c3RyaW5nOmFwcGxpY2F0aW9uL3ZuZC5vcGVueG1sZm9ybWF0cy1vZmZpY2Vkb2N1bWVudC5zcHJlYWRzaGVldG1sLnNoZWV0.desc": {
+          "source": "MS Excel `xlsx` document",
+          "message": "MS Excel `xlsx` 文件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.display_name": {
+          "source": "Filename",
+          "message": "檔案名稱"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.short_desc": {
+          "source": "The filename",
+          "message": "檔案名"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.ZmlsZQ.field.bmFtZQ.desc": {
+          "source": "The filename",
+          "message": "檔案名"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.display_name": {
+          "source": "Model",
+          "message": "模型"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.short_desc": {
+          "source": "The speech-to-text model to use",
+          "message": "要使用的語音轉文字模型"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.desc": {
+          "source": "The speech-to-text model to use for the transcription",
+          "message": "用於轉錄的語音轉文字模型"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.display_name": {
+          "source": "GPT-4o Transcribe",
+          "message": "GPT-4o Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by10cmFuc2NyaWJl.desc": {
+          "source": "The most accurate speech-to-text model; supports the `json` response format only",
+          "message": "最準確的語音轉文字模型；僅支援 `json` 回應格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.display_name": {
+          "source": "GPT-4o Mini Transcribe",
+          "message": "GPT-4o Mini Transcribe"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOmdwdC00by1taW5pLXRyYW5zY3JpYmU.desc": {
+          "source": "A faster and cheaper speech-to-text model; supports the `json` response format only",
+          "message": "更快速且更經濟的語音轉文字模型；僅支援 `json` 回應格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.display_name": {
+          "source": "Whisper",
+          "message": "Whisper"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bW9kZWw.allowed-value.c3RyaW5nOndoaXNwZXItMQ.desc": {
+          "source": "The open source Whisper V2 model; supports all response formats",
+          "message": "開放原始碼的 Whisper V2 模型；支援所有回應格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.display_name": {
+          "source": "Language",
+          "message": "語言"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.short_desc": {
+          "source": "The language of the input audio as an ISO-639-1 code",
+          "message": "輸入音訊的語言（ISO-639-1 代碼）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.bGFuZ3VhZ2U.desc": {
+          "source": "The language of the input audio in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format (for example `en`); supplying the input language improves accuracy and latency",
+          "message": "以 [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) 格式表示的輸入音訊語言（例如 `en`）；提供輸入語言可提高準確度並降低延遲"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.display_name": {
+          "source": "Response Format",
+          "message": "回應格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.short_desc": {
+          "source": "The format of the transcription output",
+          "message": "轉錄輸出的格式"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.desc": {
+          "source": "The format of the transcription output.\n\n**Note**: `gpt-4o-transcribe` and `gpt-4o-mini-transcribe` support only `json`; the `text`, `srt`, `verbose_json`, and `vtt` formats require `whisper-1`. Non-JSON output is returned in the `text` field of the response",
+          "message": "轉錄輸出的格式。\n\n**注意**：`gpt-4o-transcribe` 和 `gpt-4o-mini-transcribe` 僅支援 `json`；`text`、`srt`、`verbose_json` 和 `vtt` 格式需要 `whisper-1`。非 JSON 輸出會在回應的 `text` 欄位中傳回"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.display_name": {
+          "source": "JSON",
+          "message": "JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOmpzb24.desc": {
+          "source": "A JSON object with the transcribed text",
+          "message": "包含轉錄文字的 JSON 物件"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.display_name": {
+          "source": "Plain Text",
+          "message": "純文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnRleHQ.desc": {
+          "source": "The transcribed text only (`whisper-1` only)",
+          "message": "僅包含轉錄文字（僅限 `whisper-1`）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.display_name": {
+          "source": "SRT Subtitles",
+          "message": "SRT 字幕"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnNydA.desc": {
+          "source": "SubRip subtitles with timestamps (`whisper-1` only)",
+          "message": "含時間戳記的 SubRip 字幕（僅限 `whisper-1`）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.display_name": {
+          "source": "Verbose JSON",
+          "message": "詳細 JSON"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZlcmJvc2VfanNvbg.desc": {
+          "source": "A JSON object with the transcribed text, language, duration, and timestamped segments (`whisper-1` only)",
+          "message": "包含轉錄文字、語言、時長及含時間戳記片段的 JSON 物件（僅限 `whisper-1`）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.display_name": {
+          "source": "WebVTT Subtitles",
+          "message": "WebVTT 字幕"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cmVzcG9uc2VfZm9ybWF0.allowed-value.c3RyaW5nOnZ0dA.desc": {
+          "source": "Web Video Text Tracks subtitles with timestamps (`whisper-1` only)",
+          "message": "含時間戳記的 Web Video Text Tracks 字幕（僅限 `whisper-1`）"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.display_name": {
+          "source": "Prompt",
+          "message": "提示"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.short_desc": {
+          "source": "Optional text to guide the model's style or continue a previous audio segment",
+          "message": "用於引導模型風格或延續先前音訊片段的選用文字"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.cHJvbXB0.desc": {
+          "source": "Optional text to guide the model's style or to continue a previous audio segment; the prompt should match the audio language",
+          "message": "用於引導模型風格或延續先前音訊片段的選用文字；提示應與音訊的語言相符"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.display_name": {
+          "source": "Temperature",
+          "message": "取樣溫度"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.short_desc": {
+          "source": "The sampling temperature between 0 and 1",
+          "message": "介於 0 和 1 之間的取樣溫度"
+        },
+        "app.T3BlbkFJ.action.dHJhbnNjcmliZS1hdWRpbw.option.dGVtcGVyYXR1cmU.desc": {
+          "source": "The sampling temperature, between `0` and `1`; higher values like `0.8` make the output more random, while lower values like `0.2` make it more focused and deterministic. If set to `0`, the model uses log probability to automatically increase the temperature until certain thresholds are hit",
+          "message": "介於 `0` 和 `1` 之間的取樣溫度；較高的值（例如 `0.8`）會使輸出更隨機，而較低的值（例如 `0.2`）會使輸出更集中且更具確定性。若設為 `0`，模型會使用對數機率自動提高溫度，直到達到特定閾值為止"
         }
       }
     }


### PR DESCRIPTION
Implements gaps 2, 3, 5, 6, 7 and 8 of qoretechnologies/qorus#514 (gap 1, foreach accumulation, is handled separately in the qorus repo; gap 4 is the module-v8 PR). Also fixes qoretechnologies/qorus#524 (Google date serialization), which surfaced during this work; the Deepgram authentication bug (qoretechnologies/qorus#523) that surfaced too was fixed on `develop` in c732d148a, and this branch adds the wire test and release notes for it.

## GmailDataProvider 1.1 → 1.2 (gaps 2, 6, 7, 8)

New actions:

| Action | Backed by |
|---|---|
| `create-draft` | new `GmailCreateDraftDataProvider`, sharing the MIME builder with `send-message` |
| `list-drafts`, `get-draft`, `send-draft`, `delete-draft` | Discovery `users/drafts/*`; `get`/`send`/`delete` get a `drafts` dropdown |
| `modify-message-labels` | Discovery `users/messages/modify` with a `labels` dropdown on `addLabelIds` / `removeLabelIds` (add or remove `UNREAD`, `INBOX`, `STARRED`, or user labels) |
| `list-labels`, `create-label`, `untrash-message` | Discovery `users/labels/list`, `users/labels/create`, `users/messages/untrash` |
| `list-with-metadata` | new `GmailListWithMetadataDataProvider`: `messages.list` plus one `messages.get` per match in the requested `format` with `metadata_headers`, returning headers, snippet, labels and thread ID instead of bare IDs |

Updated:
- `send-message` (and `create-draft`) accept `thread_id`, `in_reply_to` and `references`, so replies stay in the conversation they answer. The MIME headers follow RFC 5322 and `references` defaults to `in_reply_to`.
- `watch` events carry the `In-Reply-To` header; `watch-attachment` events carry the source `thread_id`.
- `list`, `get` and `get-attachment` are now classified read-only (`mutates_state: False`); an unannotated `DPAT_API` action counts as mutating.

Tests: catalogue cases for every new action, offline request-shape tests with a mock REST client (`GmailActionRequests.qtest`, new), and live cases gated on a Gmail connection (drafts create → list → get → delete; labels list → create → apply → remove → delete; metadata search). The live cases were run against a real account; nothing is ever sent.

## GoogleCalendarDataProvider 2.0 → 2.1 (gap 3)

New read actions `list-events`, `get-event` and `list-calendars`, registered like `create-event` against the Discovery paths that already resolve, with explicit options (`timeMin`, `timeMax`, `maxResults`, `singleEvents`, `orderBy`, `q`, `pageToken`, `showDeleted` and friends) and `mutates_state: False`. The three `watch-event-*` triggers registered by qorus are unchanged.

## GoogleDataProvider 2.0 → 2.1 (qorus#524)

`GoogleDataProviderBase::getQueryValue()` now serializes `date` values as RFC 3339 (`2026-09-02T10:00:00+02:00`). Previously a date became `20260902100000`, which Google rejects, and an RFC 3339 string did not help because the Discovery request types coerce those parameters to dates first. Without this, `list-events` with `timeMin` / `timeMax` cannot work. Regression test in the Calendar test's query-encoding case.

## DeepgramRestClient 1.0 → 1.1 (qorus#523)

The `apikey` option used to be mapped into a `default_headers` option that no REST client reads, so both the sync and the async client, and with them the connection ping and every action, went out unauthenticated (verified live: 401 with `apikey`, 200 with an explicit header). The rename to `headers` landed on `develop` in c732d148a; this branch adds what that fix did not: a wire test asserting both clients send `Authorization: Token <key>` against a local HttpServer, folding of a caller-supplied `default_headers` into `headers` for compatibility, and the version bump with release notes. Verified live after the fix: ping OK, transcription OK.

## DeepgramDataProvider 1.0 → 1.1 (gap 5)

`transcribe-file` accepts the audio directly through a new `audio` option (a file value or raw binary, sent as the raw request body with the file's MIME type); `url` is now optional and exactly one of the two must be given. Verified live with the Deepgram sample: URL, file value, and raw binary all transcribe.

## OpenAiDataProvider 1.6 → 1.7 (gap 5)

New `transcribe-audio` action for `/v1/audio/transcriptions` (multipart upload; models `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `whisper-1`; `json`, `text`, `srt`, `verbose_json`, `vtt` response formats). Offline tests parse the multipart body back and check every part; no live key was available.

## Bookkeeping

- i18n catalogs regenerated for the five modules and completed in all 12 standard locales; the `qore-data-provider-i18n --check-source-tree --require-standard-locales --require-complete-locales` gate passes.
- Release notes in each module mainpage and in `doxygen/lang/900_release_notes.dox.tmpl`.

## Test commands

```
QORE_MODULE_DIR=build/qlib-qmod:qlib qore examples/test/qlib/GmailDataProvider/GmailDataProvider.qtest -v          # 15/15
QORE_MODULE_DIR=build/qlib-qmod:qlib qore examples/test/qlib/GmailDataProvider/GmailActionRequests.qtest -v        # 7/7
QORE_MODULE_DIR=build/qlib-qmod:qlib qore examples/test/qlib/GmailDataProvider/GmailWatchOrdering.qtest -v         # 12/12
QORE_MODULE_DIR=build/qlib-qmod:qlib qore examples/test/qlib/GoogleCalendarDataProvider/GoogleCalendarDataProvider.qtest -v  # 4/4
QORE_MODULE_DIR=build/qlib-qmod:qlib qore examples/test/qlib/DeepgramDataProvider/DeepgramDataProvider.qtest -v    # 9/9
QORE_MODULE_DIR=build/qlib-qmod:qlib qore examples/test/qlib/DeepgramRestClient/DeepgramRestClient.qtest -v        # 5/5
QORE_MODULE_DIR=build/qlib-qmod:qlib qore examples/test/qlib/OpenAiDataProvider/OpenAiDataProvider.qtest -v        # 26/26
QORE_MODULE_DIR=build/qlib-qmod:qlib qore examples/test/qlib/OpenAiRestClient/OpenAiRestClient.qtest -v            # 3/3
```

Live runs: Gmail (`-c gmail`, 15/15 including the three live cases) and Deepgram (ping, URL and upload transcription with a real key). Calendar and OpenAI live cases skip without a connection.

