### PR TITLE
feat: shared column and index definitions in a data schema

### DIFF
--- a/design/data-schema-format.md
+++ b/design/data-schema-format.md
@@ -29,7 +29,43 @@ reference_data:   # Optional: reference/seed data
 migrations:       # Optional: version-based migration steps
 index_options:    # Optional: index creation options
 column_options:   # Optional: column creation options
+columns:          # Optional: shared column definitions, drawn from with `$use`
+indexes:          # Optional: shared index definitions, drawn from with `$use`
 ```
+
+## Shared Definitions
+
+A column used in nine tables should be described once. Declare it under the
+top-level `columns` (or `indexes`) and draw from it in a table with `$use`;
+any key set alongside overrides the shared value.
+
+```yaml
+columns:
+  audit_ts:
+    type: timestamp
+    notnull: true
+    comment: when the row was written
+
+tables:
+  orders:
+    columns:
+      id: {type: int, notnull: true}
+      created:
+        $use: audit_ts             # timestamp, NOT NULL, with the comment
+      updated:
+        $use: audit_ts
+        notnull: false             # ...but this one may be null
+```
+
+References are resolved when the schema is loaded, before anything else looks
+at it: the normalized schema carries fully-expanded tables, so alignment, the
+diff and migrations neither see nor need to know about sharing. The shared
+sections are an authoring convenience and do not appear in the normalized
+output.
+
+A reference that names a definition which does not exist raises
+`DATA-SCHEMA-ERROR` at load, naming the table, the entry and what it asked
+for.
 
 ## Schema Metadata
 

--- a/examples/test/qlib/Schema/DataSchema.qtest
+++ b/examples/test/qlib/Schema/DataSchema.qtest
@@ -19,6 +19,7 @@ class DataSchemaTest inherits QUnit::Test {
             \tableReconciliationContractTests());
         addTestCase("column normalization", \columnNormalizationTests());
         addTestCase("table normalization", \tableNormalizationTests());
+        addTestCase("shared definitions", \sharedDefinitionTests());
         addTestCase("partition normalization", \partitionNormalizationTests());
         addTestCase("reference data normalization", \referenceDataTests());
         addTestCase("auto-trigger expansion", \autoTriggerExpansionTests());
@@ -329,6 +330,81 @@ class DataSchemaTest inherits QUnit::Test {
                 "primary_key": {"name": "pk_bad", "columns": ("missing",)},
             });
         });
+    }
+
+    sharedDefinitionTests() {
+        # a column drawing from a shared definition inherits it
+        hash<auto> raw = {
+            "schema": {"name": "S", "version": "1.0"},
+            "columns": {
+                "audit_ts": {"type": "timestamp", "notnull": True, "comment": "when it happened"},
+            },
+            "tables": {
+                "t": {
+                    "columns": {
+                        "id": {"type": "int", "notnull": True},
+                        "created": {"$use": "audit_ts"},
+                    },
+                },
+            },
+        };
+        hash<auto> out = Schema::DataSchemaLoader::normalize(raw);
+        assertEq(Type::Date, out.tables.t.columns.created.qore_type);
+        assertTrue(out.tables.t.columns.created.notnull);
+        assertEq("when it happened", out.tables.t.columns.created.comment);
+
+        # `$use` is an authoring key: it must not reach SqlUtil
+        assertFalse(out.tables.t.columns.created.hasKey("$use"));
+
+        # the shared sections have done their job and do not survive: the
+        # normalized hash is what SqlUtil consumes, and it has no such keys
+        assertFalse(out.hasKey("columns"));
+
+        # local keys override the shared ones
+        raw.tables.t.columns.updated = {"$use": "audit_ts", "notnull": False, "comment": "or not"};
+        out = Schema::DataSchemaLoader::normalize(raw);
+        assertEq(Type::Date, out.tables.t.columns.updated.qore_type);
+        # nullable is the ABSENCE of notnull, not notnull: False — the
+        # normalizer has always emitted it that way, so an override that
+        # turns it off removes the key
+        assertFalse(out.tables.t.columns.updated.hasKey("notnull"));
+        assertEq("or not", out.tables.t.columns.updated.comment);
+        # ...and the definition it drew from is untouched by that override
+        assertTrue(out.tables.t.columns.created.notnull);
+
+        # a shared definition may itself be overridden into a different type
+        raw.tables.t.columns.note = {"$use": "audit_ts", "type": "varchar", "size": 40};
+        out = Schema::DataSchemaLoader::normalize(raw);
+        assertEq(SqlUtil::VARCHAR, out.tables.t.columns.note.qore_type);
+        assertEq(40, out.tables.t.columns.note.size);
+
+        # a dangling reference names the table, the column and the target
+        raw.tables.t.columns.bad = {"$use": "nope"};
+        assertThrows("DATA-SCHEMA-ERROR", "unknown shared column", sub () {
+            Schema::DataSchemaLoader::normalize(raw);
+        });
+        remove raw.tables.t.columns.bad;
+
+        # indexes work the same way
+        raw.indexes = {"by_created": {"columns": ("created",)}};
+        raw.tables.t.indexes = {"t_created": {"$use": "by_created"}};
+        out = Schema::DataSchemaLoader::normalize(raw);
+        assertEq(("created",), out.tables.t.indexes.t_created.columns);
+        assertFalse(out.tables.t.indexes.t_created.hasKey("$use"));
+        assertFalse(out.hasKey("indexes"));
+
+        raw.tables.t.indexes.bad = {"$use": "nope"};
+        assertThrows("DATA-SCHEMA-ERROR", "unknown shared index", sub () {
+            Schema::DataSchemaLoader::normalize(raw);
+        });
+        remove raw.tables.t.indexes.bad;
+
+        # a schema that uses no shared definitions is unaffected
+        hash<auto> plain = getSampleSchema();
+        assertEq(Schema::DataSchemaLoader::normalize(plain), Schema::DataSchemaLoader::normalize(plain));
+
+        # the meta-schema accepts the two new top-level sections
+        Schema::DataSchemaLoader::validate(raw);
     }
 
     partitionNormalizationTests() {

--- a/examples/test/qlib/Schema/DataSchema.qtest
+++ b/examples/test/qlib/Schema/DataSchema.qtest
@@ -403,6 +403,31 @@ class DataSchemaTest inherits QUnit::Test {
         hash<auto> plain = getSampleSchema();
         assertEq(Schema::DataSchemaLoader::normalize(plain), Schema::DataSchemaLoader::normalize(plain));
 
+        # a reference in a schema with NO shared section at all reaches the
+        # same error, rather than failing on the missing section
+        hash<auto> orphan = {
+            "schema": {"name": "S", "version": "1.0"},
+            "tables": {"t": {"columns": {"created": {"$use": "audit_ts"}}}},
+        };
+        assertThrows("DATA-SCHEMA-ERROR", "unknown shared column", sub () {
+            Schema::DataSchemaLoader::normalize(orphan);
+        });
+
+        # resolution is one level deep, and says so rather than merging an
+        # unresolved key through — an index carries unknown keys verbatim
+        # into SqlUtil, so this would otherwise leave `$use` in the output
+        hash<auto> chained = {
+            "schema": {"name": "S", "version": "1.0"},
+            "columns": {
+                "base_ts": {"type": "timestamp"},
+                "audit_ts": {"$use": "base_ts", "notnull": True},
+            },
+            "tables": {"t": {"columns": {"created": {"$use": "audit_ts"}}}},
+        };
+        assertThrows("DATA-SCHEMA-ERROR", "not resolved recursively", sub () {
+            Schema::DataSchemaLoader::normalize(chained);
+        });
+
         # the meta-schema accepts the two new top-level sections
         Schema::DataSchemaLoader::validate(raw);
     }

--- a/qlib/Schema/DataSchemaLoader.qc
+++ b/qlib/Schema/DataSchemaLoader.qc
@@ -262,11 +262,21 @@ public class DataSchemaLoader {
             return def;
         }
         string ref = def{DataSchemaLoader::SharedDefinitionKey};
+        # indexing NOTHING yields NOTHING, so a schema with no shared section at all reaches the
+        # same error as one that simply does not declare this name
         *hash<auto> base = shared{ref};
         if (!exists base) {
             throw "DATA-SCHEMA-ERROR", sprintf("table %y %s %y draws from unknown shared %s %y; "
                 "the schema declares %y", table_name, what, name, what, ref,
                 shared ? shared.keys() : ());
+        }
+        # Resolution is deliberately one level deep, and that is enforced rather than documented:
+        # a shared definition that itself draws from another would otherwise merge the unresolved
+        # key straight through, and an index carries unknown keys verbatim into SqlUtil.
+        if (exists base{DataSchemaLoader::SharedDefinitionKey}) {
+            throw "DATA-SCHEMA-ERROR", sprintf("table %y %s %y draws from shared %s %y, which "
+                "itself draws from %y; shared definitions are not resolved recursively",
+                table_name, what, name, what, ref, base{DataSchemaLoader::SharedDefinitionKey});
         }
         # the shared definition first, then the entry's own keys, so a local key wins
         return base + (def - DataSchemaLoader::SharedDefinitionKey);

--- a/qlib/Schema/DataSchemaLoader.qc
+++ b/qlib/Schema/DataSchemaLoader.qc
@@ -157,11 +157,13 @@ public class DataSchemaLoader {
             "schema": raw.schema,
         };
 
-        # Normalize tables
+        # Normalize tables, resolving shared column and index definitions first
         if (raw.tables) {
             hash<auto!> tables();
             foreach hash<auto> pair in (raw.tables.pairIterator()) {
-                tables{pair.key} = DataSchemaLoader::normalizeTable(pair.key, pair.value);
+                hash<auto> table_def = DataSchemaLoader::resolveSharedDefinitions(pair.key, pair.value,
+                    raw.columns, raw.indexes);
+                tables{pair.key} = DataSchemaLoader::normalizeTable(pair.key, table_def);
             }
             result.tables = tables;
         }
@@ -185,6 +187,89 @@ public class DataSchemaLoader {
         }
 
         return result;
+    }
+
+    #! The key by which a table entry draws from a shared definition
+    public const SharedDefinitionKey = "$use";
+
+    #! Resolves a table's shared column and index references
+    /** A schema may declare `columns` and `indexes` at the top level: definitions named once and
+        drawn from by any table, so that a column used in nine tables is described in one place. A
+        table's entry draws from one with @ref SharedDefinitionKey, and any key it sets alongside
+        overrides the shared value:
+
+        @code{.yaml}
+    columns:
+      audit_ts:
+        type: timestamp
+        notnull: true
+
+    tables:
+      orders:
+        columns:
+          created:
+            $use: audit_ts
+          updated:
+            $use: audit_ts
+            notnull: false      # this one may be null
+        @endcode
+
+        Resolution happens here, before normalization, so everything downstream — the normalized
+        hash, @ref Schema::DataSchema "DataSchema", the diff and the alignment — sees fully-expanded
+        tables and needs to know nothing about sharing. The shared sections are an authoring
+        convenience and do not appear in the normalized schema.
+
+        @param table_name the table being resolved (for error messages)
+        @param table_def the raw table definition
+        @param shared_columns the schema's shared column definitions, if any
+        @param shared_indexes the schema's shared index definitions, if any
+
+        @return the table definition with every reference expanded
+
+        @throw DATA-SCHEMA-ERROR if a reference names a definition that does not exist
+    */
+    static hash<auto> resolveSharedDefinitions(string table_name, hash<auto> table_def,
+            *hash<auto> shared_columns, *hash<auto> shared_indexes) {
+        if (exists table_def.columns) {
+            table_def.columns = DataSchemaLoader::resolveSharedSection(table_name, "column",
+                table_def.columns, shared_columns);
+        }
+        if (exists table_def.indexes) {
+            table_def.indexes = DataSchemaLoader::resolveSharedSection(table_name, "index",
+                table_def.indexes, shared_indexes);
+        }
+        return table_def;
+    }
+
+    #! Resolves every reference in one named-entry section of a table
+    private static auto resolveSharedSection(string table_name, string what, auto entries,
+            *hash<auto> shared) {
+        if (entries.typeCode() != NT_HASH) {
+            return entries;
+        }
+        hash<auto!> result();
+        foreach hash<auto> pair in (entries.pairIterator()) {
+            result{pair.key} = DataSchemaLoader::resolveSharedEntry(table_name, what, pair.key,
+                pair.value, shared);
+        }
+        return result;
+    }
+
+    #! Resolves one entry against the shared definitions, if it draws from them
+    private static auto resolveSharedEntry(string table_name, string what, string name, auto def,
+            *hash<auto> shared) {
+        if (def.typeCode() != NT_HASH || !exists def{DataSchemaLoader::SharedDefinitionKey}) {
+            return def;
+        }
+        string ref = def{DataSchemaLoader::SharedDefinitionKey};
+        *hash<auto> base = shared{ref};
+        if (!exists base) {
+            throw "DATA-SCHEMA-ERROR", sprintf("table %y %s %y draws from unknown shared %s %y; "
+                "the schema declares %y", table_name, what, name, what, ref,
+                shared ? shared.keys() : ());
+        }
+        # the shared definition first, then the entry's own keys, so a local key wins
+        return base + (def - DataSchemaLoader::SharedDefinitionKey);
     }
 
     #! Normalizes a single table definition

--- a/qlib/Schema/DataSchemaMetaSchema.qc
+++ b/qlib/Schema/DataSchemaMetaSchema.qc
@@ -83,6 +83,23 @@ public const DataSchemaJsonSchema = {
         "column_options": {
             "type": "object",
         },
+        "columns": {
+            "type": "object",
+            "description": "Shared column definitions keyed by name. A table's column draws from one "
+                "with {\"$use\": \"<name>\"}, and any key it sets alongside overrides the shared value. "
+                "Resolved at load; the normalized schema carries fully-expanded columns only.",
+            "additionalProperties": {
+                "$ref": "#/$defs/columnDefinition",
+            },
+        },
+        "indexes": {
+            "type": "object",
+            "description": "Shared index definitions keyed by name, drawn from the same way as shared "
+                "columns.",
+            "additionalProperties": {
+                "$ref": "#/$defs/indexDefinition",
+            },
+        },
     },
     "$defs": {
         "schemaMetadata": {
@@ -120,6 +137,11 @@ public const DataSchemaJsonSchema = {
         "columnDefinition": {
             "type": "object",
             "properties": {
+                "$use": {
+                    "type": "string",
+                    "description": "Draw from the shared column definition of this name; any key set "
+                        "here overrides the shared value.",
+                },
                 "type": {
                     "type": "string",
                     "enum": ("int", "varchar", "char", "timestamp", "date", "number",
@@ -166,8 +188,18 @@ public const DataSchemaJsonSchema = {
         },
         "indexDefinition": {
             "type": "object",
-            "required": ("columns",),
+            # either the index says what it indexes, or it draws from a
+            # shared definition that does
+            "anyOf": (
+                {"required": ("columns",)},
+                {"required": ("$use",)},
+            ),
             "properties": {
+                "$use": {
+                    "type": "string",
+                    "description": "Draw from the shared index definition of this name; any key set "
+                        "here overrides the shared value.",
+                },
                 "columns": {
                     "type": "array",
                     "items": {"type": "string"},

--- a/qlib/Schema/Schema.qm
+++ b/qlib/Schema/Schema.qm
@@ -44,7 +44,7 @@
 %requires json
 
 module Schema {
-    version = "1.7.0";
+    version = "1.8.0";
     desc = "user module for working with SQL schemas";
     author = "David Nichols <david@qore.org>";
     url = "http://qore.org";
@@ -363,6 +363,38 @@ module Schema {
       version_where:                 # WHERE clause to locate the version row
         name: MyApp
     @endcode
+
+    @section schema_shared_definitions Shared Column and Index Definitions
+
+    A column used in nine tables should be described once. Declare it under the top-level
+    \c columns (or \c indexes) and draw from it in a table with \c $use; any key set alongside
+    overrides the shared value.
+
+    @par Example: A column defined once and used twice
+    @code{.yaml}
+    columns:
+      audit_ts:
+        type: timestamp
+        notnull: true
+        comment: when the row was written
+
+    tables:
+      orders:
+        columns:
+          id: {type: int, notnull: true}
+          created:
+            $use: audit_ts          # timestamp, NOT NULL, with the comment
+          updated:
+            $use: audit_ts
+            notnull: false          # ...but this one may be null
+    @endcode
+
+    References are resolved when the schema is loaded, before anything else looks at it, so
+    alignment, the diff and migrations see fully-expanded tables and need to know nothing about
+    sharing. The shared sections do not appear in the normalized schema.
+
+    A reference naming a definition that does not exist raises \c DATA-SCHEMA-ERROR at load,
+    naming the table, the entry and what it asked for.
 
     See \c design/data-schema-format.md in the Qore source for the complete format specification.
 
@@ -852,8 +884,14 @@ module Schema {
     - Migration action types: all 18 supported actions with their field definitions
     - Reference data categories: \c strict, \c normal, \c create_only, \c insert_only
     - Auto-trigger configuration: \c created, \c modified, \c sequence_columns
+    - Shared definitions: top-level \c columns and \c indexes, drawn from with \c $use
 
     @section schema_relnotes Schema Module Release History
+
+    @subsection schema_v1_8_0 Schema Module v1.8.0
+    - added shared \c columns and \c indexes definitions at the top level of a data schema: a
+      definition named once and drawn from by any table with \c {$use: <name>}, with any key set
+      alongside overriding the shared value — see @ref schema_shared_definitions
 
     @subsection schema_v1_7_0 Schema Module v1.7.0
     - added the additive, data-preserving \c reconcile_table DataSchema

--- a/qlib/Schema/Schema.qm
+++ b/qlib/Schema/Schema.qm
@@ -890,7 +890,7 @@ module Schema {
 
     @subsection schema_v1_8_0 Schema Module v1.8.0
     - added shared \c columns and \c indexes definitions at the top level of a data schema: a
-      definition named once and drawn from by any table with \c {$use: <name>}, with any key set
+      definition named once and drawn from by any table with \c {$use:\ name}, with any key set
       alongside overriding the shared value — see @ref schema_shared_definitions
 
     @subsection schema_v1_7_0 Schema Module v1.7.0


### PR DESCRIPTION
## Why

A column used in nine tables has to be described nine times today. This adds
shared definitions to the DataSchema format, so it can be described once.

It also closes a gap on the Qorus side: the Qorus option catalogue already
offers top-level `columns` / `indexes` as authorable sections, described as
"the same shape used inside each table's `columns`" — but the format has no
such keys, so `normalize()` drops them and the IDE offers a dead end. A user
hit this by defining a reusable column in the schema builder's Advanced tab
and finding no way to use it. See
[qoretechnologies/qorus#571](https://github.com/qoretechnologies/qorus/issues/571).

## What

A schema may declare `columns` and `indexes` at the top level. A table draws
from one with `{$use: <name>}`; any key set alongside overrides the shared
value.

```yaml
columns:
  audit_ts:
    type: timestamp
    notnull: true
    comment: when the row was written

tables:
  orders:
    columns:
      id: {type: int, notnull: true}
      created:
        $use: audit_ts          # timestamp, NOT NULL, with the comment
      updated:
        $use: audit_ts
        notnull: false          # ...but this one may be null
```

Resolution happens in `DataSchemaLoader::normalize()`, **before** table
normalization, so everything downstream — the normalized hash, `DataSchema`,
the diff, alignment and migrations — sees fully-expanded tables and needs to
know nothing about sharing. The shared sections are an authoring convenience
and do not appear in the normalized output.

A dangling reference raises `DATA-SCHEMA-ERROR` at load naming the table, the
entry and what it asked for, rather than surfacing later as the confusing
"column definition must set either 'type' or 'driver'".

The meta-schema gains the two sections and allows `$use` on a column or an
index. An index drawing from a shared definition need not repeat `columns`,
so `indexDefinition`'s `required` becomes an `anyOf` over the two forms.

## Design notes, for review

- **`$use` rather than a bare string.** `columns: {created: audit_ts}` would
  be terser and is available (`normalizeColumn` takes a hash today, so there
  is no collision), but it cannot express a per-table override — and overrides
  are the point of reuse. The key name is a single constant
  (`DataSchemaLoader::SharedDefinitionKey`) if you want a different spelling.
- **Only `columns` and `indexes`.** Qorus also advertises top-level
  `constraints` and `auto_triggers`, but those are single option *groups*
  rather than name-keyed maps, so "a definition drawn from by name" has no
  meaning for them. They should come out of the Qorus catalogue instead; that
  is tracked in the linked issue.
- **Resolution is not recursive**: a shared definition drawing from another
  shared definition is not supported. Say the word if you want it.

## Testing

Built and run on a Linux box whose installed qore matches `develop`:

```
qcc -m qlib/Schema -o qlib/Schema/Schema.qmod
qore examples/test/qlib/Schema/DataSchema.qtest
→ Ran 16 test cases, 16 succeeded (214 assertions)
```

The new `shared definitions` case fails against the unmodified module (15/16,
erroring inside `normalizeColumn` on an entry with neither `type` nor
`driver`), so it covers the change rather than passing either way.

`MigrationExecutor.qtest` is unaffected (10/10). `QschemaCli.qtest` fails
identically before and after — it shells out to the `qschema` CLI, which was
absent from the test staging.

Module version bumped 1.7.0 → 1.8.0, with a release note and a
`@section schema_shared_definitions` in `Schema.qm`, plus the format spec in
`design/data-schema-format.md`.